### PR TITLE
No longer copy profile name when copying session

### DIFF
--- a/src/braket/aws/aws_qpu.py
+++ b/src/braket/aws/aws_qpu.py
@@ -129,7 +129,6 @@ class AwsQpu(Device):
                     aws_access_key_id=creds.access_key,
                     aws_secret_access_key=creds.secret_key,
                     aws_session_token=creds.token,
-                    profile_name=aws_session.boto_session.profile_name,
                     region_name=qpu_regions[0],
                 )
                 return AwsSession(boto_session=boto_session)

--- a/test/unit_tests/braket/aws/test_aws_qpu.py
+++ b/test/unit_tests/braket/aws/test_aws_qpu.py
@@ -93,12 +93,11 @@ def test_aws_session_in_another_qpu_region(
 
     AwsQpu(arn, different_region_aws_session)
 
-    # assert creds, profile, and region were correctly supplied
+    # assert creds, and region were correctly supplied
     boto_session_init.assert_called_with(
         aws_access_key_id=creds.access_key,
         aws_secret_access_key=creds.secret_key,
         aws_session_token=creds.token,
-        profile_name=different_region_aws_session.boto_session.profile_name,
         region_name=region,
     )
 


### PR DESCRIPTION
Create-quantum-job was throwing "botocore.exceptions.ProfileNotFound:
The config profile (default) could not be found" since the container
does not have a profile "default" configuration. There are some
potential workarounds but the easiest is to just remove setting
the profile name all together. Since we are already copying the
credentials and region there really is no value in copying the profile
hence this change.
