### PR TITLE
Update to use new state vector wire format

### DIFF
--- a/src/braket/aws/aws_quantum_task_result.py
+++ b/src/braket/aws/aws_quantum_task_result.py
@@ -40,11 +40,11 @@ class AwsQuantumTaskResult(QuantumTaskResult):
             `measurement_probabilities` were copied from device. If false,
             `measurement_probabilities` are calculated from device data.
         task_metadata (Dict[str, Any]): Dictionary of task metadata. TODO: Link boto3 docs.
-        state_vector (Dict[str, float]): Dictionary where key is state and value is probability.
+        state_vector (Dict[str, complex]): Dictionary where key is state and value is amplitude.
     """
 
     task_metadata: Dict[str, Any]
-    state_vector: Dict[str, float] = None
+    state_vector: Dict[str, complex] = None
 
     @staticmethod
     def from_string(result: str) -> "AwsQuantumTaskResult":
@@ -80,6 +80,10 @@ class AwsQuantumTaskResult(QuantumTaskResult):
             measurements_copied_from_device = False
             m_counts_copied_from_device = False
             m_probabilities_copied_from_device = True
+        if "StateVector" in json_obj:
+            state_vector = json_obj.get("StateVector", None)
+            for state in state_vector:
+                state_vector[state] = complex(*state_vector[state])
         return AwsQuantumTaskResult(
             state_vector=state_vector,
             task_metadata=task_metadata,

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import math
+
 import pytest
 from braket.aws import AwsQuantumSimulator, AwsQuantumSimulatorArns
 from braket.circuits import Circuit
@@ -31,7 +33,7 @@ def test_bell_pair(simulator_arn, aws_session, s3_destination_folder):
 @pytest.mark.parametrize(
     "simulator_arn",
     [  # TODO Uncomment out below once proper ordering fix has been applied to QS1
-        # AwsQuantumSimulatorArns.QS1,
+        AwsQuantumSimulatorArns.QS1,
         AwsQuantumSimulatorArns.QS3
     ],
 )
@@ -47,6 +49,16 @@ def test_qubit_ordering(simulator_arn, aws_session, s3_destination_folder):
     state_001 = Circuit().i(0).i(1).x(2)
     result = device.run(state_001, s3_destination_folder).result()
     assert result.measurement_counts.most_common(1)[0][0] == "001"
+
+
+def test_state_vector(aws_session, s3_destination_folder):
+    device = AwsQuantumSimulator(AwsQuantumSimulatorArns.QS3, aws_session)
+    bell = Circuit().h(0).cnot(0, 1)
+    state_vector = device.run(bell, s3_destination_folder, shots=1).result().state_vector
+    assert state_vector["00"] == complex(1 / math.sqrt(2), 0)
+    assert state_vector["01"] == 0
+    assert state_vector["10"] == 0
+    assert state_vector["11"] == complex(1 / math.sqrt(2), 0)
 
 
 def test_qs2_quantum_task(aws_session, s3_destination_folder):

--- a/test/unit_tests/braket/aws/common_test_utils.py
+++ b/test/unit_tests/braket/aws/common_test_utils.py
@@ -69,7 +69,7 @@ class MockS3:
 
     MOCK_S3_RESULT_1 = json.dumps(
         {
-            "StateVector": {"00": 0.19999, "01": 0.80000, "10": 0.00000, "11": 0.00001},
+            "StateVector": {"00": [0.2, 0.2], "01": [0.3, 0.1], "10": [0.1, 0.3], "11": [0.2, 0.2]},
             "Measurements": [[0, 0], [0, 1], [0, 1], [0, 1]],
             "TaskMetadata": {
                 "Id": "UUID_blah_1",
@@ -83,7 +83,7 @@ class MockS3:
 
     MOCK_S3_RESULT_2 = json.dumps(
         {
-            "StateVector": {"00": 0.80000, "01": 0.00000, "10": 0.00000, "11": 0.19999},
+            "StateVector": {"00": [0.2, 0.2], "01": [0.3, 0.1], "10": [0.1, 0.3], "11": [0.2, 0.2]},
             "Measurements": [[0, 0], [0, 0], [0, 0], [1, 1]],
             "TaskMetadata": {
                 "Id": "UUID_blah_2",

--- a/test/unit_tests/braket/aws/test_aws_quantum_task_result.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task_result.py
@@ -35,19 +35,28 @@ def result_str_3():
     return MockS3.MOCK_S3_RESULT_3
 
 
-def test_state_vector():
-    state_vector: Dict[str, float] = {"00": 0.00, "01": 0.50, "10": 0.50, "11": 0.00}
+@pytest.fixture
+def parsed_state_vector():
+    return {
+        "00": complex(0.2, 0.2),
+        "01": complex(0.3, 0.1),
+        "10": complex(0.1, 0.3),
+        "11": complex(0.2, 0.2),
+    }
+
+
+def test_state_vector(parsed_state_vector):
     result: AwsQuantumTaskResult = AwsQuantumTaskResult(
         measurements=None,
         task_metadata=None,
-        state_vector=state_vector,
+        state_vector=parsed_state_vector,
         measurement_counts=None,
         measurement_probabilities=None,
         measurements_copied_from_device=False,
         measurement_counts_copied_from_device=False,
         measurement_probabilities_copied_from_device=False,
     )
-    assert result.state_vector == state_vector
+    assert result.state_vector == parsed_state_vector
 
 
 def test_task_metadata():
@@ -72,12 +81,12 @@ def test_task_metadata():
     assert result.task_metadata == task_metadata
 
 
-def test_from_string_measurements(result_str_1):
+def test_from_string_measurements(result_str_1, parsed_state_vector):
     result_obj = json.loads(result_str_1)
     task_result = AwsQuantumTaskResult.from_string(result_str_1)
     expected_measurements = np.asarray(result_obj["Measurements"], dtype=int)
     assert task_result.task_metadata == result_obj["TaskMetadata"]
-    assert task_result.state_vector == result_obj["StateVector"]
+    assert task_result.state_vector == parsed_state_vector
     assert np.array2string(task_result.measurements) == np.array2string(expected_measurements)
     assert not task_result.measurement_counts_copied_from_device
     assert not task_result.measurement_probabilities_copied_from_device


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updating the framework to read the new state vector wire format, which returns an array of floats that represent complex numbers.

Example interaction with state vector:

```python
device = AwsQuantumSimulator("arn:aws:aqx:::quantum-simulator:aqx:qs3")
bell = Circuit().h(0).cnot(0, 1)
state_vector = device.run(bell, s3_folder, shots=1).result().state_vector
print(state_vector)
> {'00': (0.7071067811865475+0j),
   '01': 0j,
   '10': 0j,
   '11': (0.7071067811865475+0j)}

print(abs(state_vector["00"])**2)
> 0.4999999999999999
```

Also updated the integ tests to reflect the change in qubit ordering for QS1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[build_files.tar.gz](https://github.com/aws/braket-python-sdk/files/3988014/build_files.tar.gz)
