### PR TITLE
Changed Amazon Braket's AWS model name from 'aqx' to 'braket'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ pip install -e "braket-python-sdk[test]"
 5. Install latest Amazon Braket model in AWS CLI.
 
 ```bash
-aws s3 cp s3://braket-external-assets-prod-us-west-2/models/aqx-2019-09-01.normal.json aqx-model.json
-aws configure add-model --service-model "file://aqx-model.json" --service-name aqx
+aws s3 cp s3://braket-external-assets-prod-us-west-2/models/braket-2019-09-01.normal.json braket-model.json
+aws configure add-model --service-model "file://braket-model.json" --service-name braket
 ```
 
 6. Create the necessary Amazon Braket resources in your AWS account.
@@ -87,6 +87,11 @@ python -m ipykernel install --user --name braket
 ```
 jupyter notebook
 ```
+
+## Update to latest changes
+
+1. `cd` into the GitHub repository directory
+2. run `git pull`
 
 ## Sample Notebooks
 TODO 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import find_namespace_packages, setup
 
 setup(
     name="braket-sdk",
-    version="0.1.2",
+    version="0.2.0",
     license="Apache License 2.0",
     python_requires=">= 3.7.2",
     packages=find_namespace_packages(where="src", exclude=("test",)),

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -52,7 +52,7 @@ class AwsSession(object):
                     f"No braket endpoint for {region}, supported regions are {supported_regions}"
                 )
 
-            self.braket_client = self.boto_session.client("aqx", endpoint_url=endpoint)
+            self.braket_client = self.boto_session.client("braket", endpoint_url=endpoint)
 
     #
     # Quantum Tasks

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -34,7 +34,7 @@ def test_bell_pair(simulator_arn, aws_session, s3_destination_folder):
     "simulator_arn",
     [  # TODO Uncomment out below once proper ordering fix has been applied to QS1
         AwsQuantumSimulatorArns.QS1,
-        AwsQuantumSimulatorArns.QS3
+        AwsQuantumSimulatorArns.QS3,
     ],
 )
 def test_qubit_ordering(simulator_arn, aws_session, s3_destination_folder):

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -55,7 +55,7 @@ def test_uses_endpoint_for_region(boto_session):
     AwsSession(boto_session=boto_session, braket_client=None)
 
     boto_session.client.assert_called_with(
-        "aqx", endpoint_url=AwsSession.BRAKET_ENDPOINTS[boto_session.region_name]
+        "braket", endpoint_url=AwsSession.BRAKET_ENDPOINTS[boto_session.region_name]
     )
 
 


### PR DESCRIPTION
The service model is being moved from "aqx" to "braket". This change updates all references to "aqx" in terms of the AWS model.