### PR TITLE
Rquire circuit, location and shots in device.run

### DIFF
--- a/src/braket/aws/aws_quantum_simulator.py
+++ b/src/braket/aws/aws_quantum_simulator.py
@@ -11,10 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Union
 
+from braket.annealing.problem import Problem
 from braket.aws.aws_quantum_task import AwsQuantumTask
 from braket.aws.aws_session import AwsSession
+from braket.circuits import Circuit
 from braket.devices.device import Device
 
 
@@ -37,11 +39,22 @@ class AwsQuantumSimulator(Device):
         self._properties: Dict[str, Any] = None
         self.refresh_metadata()
 
-    def run(self, *aws_quantum_task_args, **aws_quantum_task_kwargs) -> AwsQuantumTask:
+    def run(
+        self,
+        task_specification: Union[Circuit, Problem],
+        s3_destination_folder: AwsSession.S3DestinationFolder,
+        shots: Optional[int] = None,
+        *aws_quantum_task_args,
+        **aws_quantum_task_kwargs,
+    ) -> AwsQuantumTask:
         """
         Run a circuit on this AWS quantum device.
 
         Args:
+            task_specification (Union[Circuit, Problem]):  Specification of task
+                (circuit or annealing problem) to run on device.
+            s3_destination_folder: The S3 location to save the task's results
+            shots (Optional[int]): The number of times to run the circuit or annealing task
             *aws_quantum_task_args: Variable length positional arguments for
                 `braket.aws.aws_quantum_task.AwsQuantumTask.create()`.
             **aws_quantum_task_kwargs: Variable length keyword arguments for
@@ -63,7 +76,13 @@ class AwsQuantumSimulator(Device):
             `braket.aws.aws_quantum_task.AwsQuantumTask.create()`
         """
         return AwsQuantumTask.create(
-            self._aws_session, self._arn, *aws_quantum_task_args, **aws_quantum_task_kwargs
+            self._aws_session,
+            self._arn,
+            task_specification,
+            s3_destination_folder,
+            shots,
+            *aws_quantum_task_args,
+            **aws_quantum_task_kwargs,
         )
 
     def refresh_metadata(self) -> None:

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -690,7 +690,11 @@ class PSwap(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["PSWAP({:.3g})".format(angle), "PSWAP({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle,
+            qubit_count=2,
+            ascii_symbols=["PSWAP({:.3g})".format(angle), "PSWAP({:.3g})".format(angle)],
+        )
 
     def to_ir(self, target: QubitSet):
         return ir.PSwap(targets=[target[0], target[1]], angle=self.angle)
@@ -734,7 +738,11 @@ class XY(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["XY({:.3g})".format(angle), "XY({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle,
+            qubit_count=2,
+            ascii_symbols=["XY({:.3g})".format(angle), "XY({:.3g})".format(angle)],
+        )
 
     def to_ir(self, target: QubitSet):
         return ir.XY(targets=[target[0], target[1]], angle=self.angle)
@@ -780,7 +788,9 @@ class CPhaseShift(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE({:.3g})".format(angle)]
+        )
 
     def to_ir(self, target: QubitSet) -> np.ndarray:
         return ir.CPhaseShift(control=target[0], target=target[1], angle=self.angle)
@@ -818,7 +828,9 @@ class CPhaseShift00(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE00({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE00({:.3g})".format(angle)]
+        )
 
     def to_ir(self, target: QubitSet) -> np.ndarray:
         return ir.CPhaseShift00(control=target[0], target=target[1], angle=self.angle)
@@ -856,7 +868,9 @@ class CPhaseShift01(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE01({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE01({:.3g})".format(angle)]
+        )
 
     def to_ir(self, target: QubitSet) -> np.ndarray:
         return ir.CPhaseShift01(control=target[0], target=target[1], angle=self.angle)
@@ -894,7 +908,9 @@ class CPhaseShift10(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE10({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE10({:.3g})".format(angle)]
+        )
 
     def to_ir(self, target: QubitSet) -> np.ndarray:
         return ir.CPhaseShift10(control=target[0], target=target[1], angle=self.angle)
@@ -1006,7 +1022,11 @@ class XX(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["XX({:.3g})".format(angle), "XX({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle,
+            qubit_count=2,
+            ascii_symbols=["XX({:.3g})".format(angle), "XX({:.3g})".format(angle)],
+        )
 
     def to_ir(self, target: QubitSet):
         return ir.XX(targets=[target[0], target[1]], angle=self.angle)
@@ -1051,7 +1071,11 @@ class YY(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["YY({:.3g})".format(angle), "YY({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle,
+            qubit_count=2,
+            ascii_symbols=["YY({:.3g})".format(angle), "YY({:.3g})".format(angle)],
+        )
 
     def to_ir(self, target: QubitSet):
         return ir.YY(targets=[target[0], target[1]], angle=self.angle)
@@ -1098,7 +1122,11 @@ class ZZ(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=2, ascii_symbols=["ZZ({:.3g})".format(angle), "ZZ({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle,
+            qubit_count=2,
+            ascii_symbols=["ZZ({:.3g})".format(angle), "ZZ({:.3g})".format(angle)],
+        )
 
     def to_ir(self, target: QubitSet):
         return ir.ZZ(targets=[target[0], target[1]], angle=self.angle)

--- a/src/braket/devices/device.py
+++ b/src/braket/devices/device.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Optional, Union
 
 from braket.annealing.problem import Problem
 from braket.circuits import Circuit
@@ -36,13 +36,16 @@ class Device(ABC):
         self._status_reason = status_reason
 
     @abstractmethod
-    def run(self, task_specification: Union[Circuit, Problem], shots: int) -> QuantumTask:
+    def run(
+        self, task_specification: Union[Circuit, Problem], location, shots: Optional[int]
+    ) -> QuantumTask:
         """ Run a quantum task specification (circuit or annealing program) on this quantum device.
 
         Args:
             task_specification (Union[Circuit, Problem]):  Specification of task
                 (circuit or annealing problem) to run on device.
-            shots (int): The number of times to run the circuit or annealing task on the device.
+            location: The location to save the task's results
+            shots (Optional[int]): The number of times to run the circuit or annealing task
 
         Returns:
             QuantumTask: The QuantumTask tracking task execution on this device


### PR DESCRIPTION
These fields are always required regardless for task creation,
so they should also be part of the device.run contract.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
