### PR TITLE
Move isort before black in tox as it reverts blacks changes; ignore E…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ include_trailing_comma = true
 [flake8]
 ignore =
     E203,  # not pep8, black adds whitespace before ':'
+    E231,  # not pep8, https://www.python.org/dev/peps/pep-0008/#pet-peeves
     W503,  # not pep8, black adds line break before binary operator
 max_line_length = 100
 max-complexity = 10

--- a/src/braket/circuits/__init__.py
+++ b/src/braket/circuits/__init__.py
@@ -13,6 +13,7 @@
 
 # Execute initialization code in circuit module
 import braket.circuits.circuit as circuit  # noqa: F401
+
 # Execute initialization code in gates module
 import braket.circuits.gates as gates  # noqa: F401
 from braket.circuits.angled_gate import AngledGate  # noqa: F401

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,13 @@ extras = test
 basepython = python3.7
 skip_install = true
 deps =
-    {[testenv:black]deps}
     {[testenv:isort]deps}
+    {[testenv:black]deps}
     {[testenv:flake8]deps}
 commands =
-    {[testenv:black]commands}
+    # isort MUST come before black as it will revert any changes made by black
     {[testenv:isort]commands}
+    {[testenv:black]commands}
     {[testenv:flake8]commands}
 
 [testenv:flake8]


### PR DESCRIPTION
Move isort before black in tox as it reverts blacks changes; ignore E231 as it is not PEP8

*Issue #, if available:*

*Description of changes:*
Move isort before black in tox as it reverts blacks changes; ignore E231 as it is not PEP8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
