### PR TITLE
Fix 2 control and 2 target gate subroutine parameters

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -624,11 +624,12 @@ class Swap(Gate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def swap(targets: QubitSet) -> Instruction:
+    def swap(target1: QubitInput, target2: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (QubitSet): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
 
         Returns:
             Instruction: Swap instruction.
@@ -636,7 +637,7 @@ class Swap(Gate):
         Examples:
             >>> circ = Circuit().swap(0, 1)
         """
-        return Instruction(Gate.Swap(), target=targets)
+        return Instruction(Gate.Swap(), target=[target1, target2])
 
 
 Gate.register_gate(Swap)
@@ -664,11 +665,12 @@ class ISwap(Gate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def iswap(targets: QubitSet) -> Instruction:
+    def iswap(target1: QubitInput, target2: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (QubitSet): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
 
         Returns:
             Instruction: ISwap instruction.
@@ -676,7 +678,7 @@ class ISwap(Gate):
         Examples:
             >>> circ = Circuit().iswap(0, 1)
         """
-        return Instruction(Gate.ISwap(), target=targets)
+        return Instruction(Gate.ISwap(), target=[target1, target2])
 
 
 Gate.register_gate(ISwap)
@@ -712,11 +714,12 @@ class PSwap(AngledGate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def pswap(targets: QubitSet, angle: float) -> Instruction:
+    def pswap(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (Qubit or int): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
 
         Returns:
             Instruction: PSwap instruction.
@@ -724,7 +727,7 @@ class PSwap(AngledGate):
         Examples:
             >>> circ = Circuit().pswap(0, 1, 0.15)
         """
-        return Instruction(Gate.PSwap(angle), target=targets)
+        return Instruction(Gate.PSwap(angle), target=[target1, target2])
 
 
 Gate.register_gate(PSwap)
@@ -762,11 +765,12 @@ class XY(AngledGate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def xy(targets: QubitSet, angle: float) -> Instruction:
+    def xy(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (Qubit or int): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
 
         Returns:
             Instruction: XY instruction.
@@ -774,7 +778,7 @@ class XY(AngledGate):
         Examples:
             >>> circ = Circuit().xy(0, 1, 0.15)
         """
-        return Instruction(Gate.XY(angle), target=targets)
+        return Instruction(Gate.XY(angle), target=[target1, target2])
 
 
 Gate.register_gate(XY)
@@ -1044,11 +1048,12 @@ class XX(AngledGate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def xx(targets: QubitSet, angle: float) -> Instruction:
+    def xx(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (Qubit or int): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
             angle (float): Angle in radians.
 
         Returns:
@@ -1057,7 +1062,7 @@ class XX(AngledGate):
         Examples:
             >>> circ = Circuit().xx(0, 1, 0.15)
         """
-        return Instruction(Gate.XX(angle), target=targets)
+        return Instruction(Gate.XX(angle), target=[target1, target2])
 
 
 Gate.register_gate(XX)
@@ -1095,11 +1100,12 @@ class YY(AngledGate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def yy(targets: QubitSet, angle: float) -> Instruction:
+    def yy(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (Qubit or int): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
             angle (float): Angle in radians.
 
         Returns:
@@ -1108,7 +1114,7 @@ class YY(AngledGate):
         Examples:
             >>> circ = Circuit().yy(0, 1, 0.15)
         """
-        return Instruction(Gate.YY(angle), target=targets)
+        return Instruction(Gate.YY(angle), target=[target1, target2])
 
 
 Gate.register_gate(YY)
@@ -1144,11 +1150,12 @@ class ZZ(AngledGate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def zz(targets: QubitSet, angle: float) -> Instruction:
+    def zz(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            targets (Qubit or int): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
             angle (float): Angle in radians.
 
         Returns:
@@ -1157,7 +1164,7 @@ class ZZ(AngledGate):
         Examples:
             >>> circ = Circuit().zz(0, 1, 0.15)
         """
-        return Instruction(Gate.ZZ(angle), target=targets)
+        return Instruction(Gate.ZZ(angle), target=[target1, target2])
 
 
 Gate.register_gate(ZZ)
@@ -1192,20 +1199,21 @@ class CCNot(Gate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def ccnot(controls: QubitSet, target: QubitInput) -> Instruction:
+    def ccnot(control1: QubitInput, control2: QubitInput, target: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
-            controls (QubitSet): Control qubit indices.
+            control1 (Qubit or int): Control qubit 1 index.
+            control2 (Qubit or int): Control qubit 2 index.
             target (Qubit or int): Target qubit index.
 
         Returns:
             Instruction: CCNot instruction.
 
         Examples:
-            >>> circ = Circuit().ccnot(controls=[0, 1], target=2)
+            >>> circ = Circuit().ccnot(0, 1, 2)
         """
-        return Instruction(Gate.CCNot(), target=[controls[0], controls[1], target])
+        return Instruction(Gate.CCNot(), target=[control1, control2, target])
 
 
 Gate.register_gate(CCNot)
@@ -1237,12 +1245,13 @@ class CSwap(Gate):
 
     @staticmethod
     @circuit.subroutine(register=True)
-    def cswap(control: QubitInput, targets: QubitSet) -> Instruction:
+    def cswap(control: QubitInput, target1: QubitInput, target2: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
 
         Args:
             control (Qubit or int): Control qubit index
-            targets (QubitSet): Target qubit indices.
+            target1 (Qubit or int): Target qubit 1 index.
+            target2 (Qubit or int): Target qubit 2 index.
 
         Returns:
             Instruction: CSwap instruction.
@@ -1250,7 +1259,7 @@ class CSwap(Gate):
         Examples:
             >>> circ = Circuit().cswap(0, 1, 2)
         """
-        return Instruction(Gate.CSwap(), target=[control, targets[0], targets[1]])
+        return Instruction(Gate.CSwap(), target=[control, target1, target2])
 
 
 Gate.register_gate(CSwap)

--- a/test/unit_tests/braket/circuits/test_ascii_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_ascii_circuit_diagram.py
@@ -147,7 +147,7 @@ def test_overlapping_qubits():
 
 
 def test_overlapping_qubits_angled_gates():
-    circ = Circuit().zz([0, 2], 0.15).cnot(1, 3).h(0)
+    circ = Circuit().zz(0, 2, 0.15).cnot(1, 3).h(0)
     expected = (
         "T  : |    0     |1|",
         "                   ",

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -115,8 +115,12 @@ def single_target_valid_input(**kwargs):
     return {"target": 2}
 
 
-def double_target_valid_input(**kwargs):
+def double_target_valid_ir_input(**kwargs):
     return {"targets": [2, 3]}
+
+
+def double_target_valid_input(**kwargs):
+    return {"target1": 2, "target2": 3}
 
 
 def angle_valid_input(**kwargs):
@@ -127,8 +131,12 @@ def single_control_valid_input(**kwargs):
     return {"control": 0}
 
 
-def double_control_valid_input(**kwargs):
+def double_control_valid_ir_input(**kwargs):
     return {"controls": [0, 1]}
+
+
+def double_control_valid_input(**kwargs):
+    return {"control1": 0, "control2": 1}
 
 
 def multi_target_valid_input(**kwargs):
@@ -146,17 +154,22 @@ def two_dimensional_matrix_valid_input(**kwargs):
 
 valid_ir_switcher = {
     "SingleTarget": single_target_valid_input,
-    "DoubleTarget": double_target_valid_input,
+    "DoubleTarget": double_target_valid_ir_input,
     "Angle": angle_valid_input,
     "SingleControl": single_control_valid_input,
-    "DoubleControl": double_control_valid_input,
+    "DoubleControl": double_control_valid_ir_input,
     "MultiTarget": multi_target_valid_input,
     "TwoDimensionalMatrix": two_dimensional_matrix_valid_ir_input,
 }
 
 
 valid_subroutine_switcher = dict(
-    valid_ir_switcher, **{"TwoDimensionalMatrix": two_dimensional_matrix_valid_input,}
+    valid_ir_switcher,
+    **{
+        "TwoDimensionalMatrix": two_dimensional_matrix_valid_input,
+        "DoubleTarget": double_target_valid_input,
+        "DoubleControl": double_control_valid_input,
+    }
 )
 
 
@@ -184,13 +197,13 @@ def create_valid_target_input(irsubclasses):
         if subclass == SingleTarget:
             qubit_set.extend(list(single_target_valid_input().values()))
         elif subclass == DoubleTarget:
-            qubit_set.extend(list(double_target_valid_input().values()))
+            qubit_set.extend(list(double_target_valid_ir_input().values()))
         elif subclass == MultiTarget:
             qubit_set.extend(list(multi_target_valid_input().values()))
         elif subclass == SingleControl:
             qubit_set = list(single_control_valid_input().values()) + qubit_set
         elif subclass == DoubleControl:
-            qubit_set = list(double_control_valid_input().values()) + qubit_set
+            qubit_set = list(double_control_valid_ir_input().values()) + qubit_set
         elif subclass == Angle or subclass == TwoDimensionalMatrix:
             pass
         else:


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes: 
* Fix 2 control and 2 target gate subroutine parameters. Previously, gate subroutines for 2 controls or 2 targets took these as lists while the docs indicated that these are input as separate ints/qubits. 
* For instance, in the docs, it has the example `Circuit().swap(0, 1)` while in reality only `Circuit().swap([0, 1])` would have worked. 
* This PR is fixing that so that we have the more precise `Circuit().swap(0, 1)` instead of `Circuit().swap([0, 1])` because swap is only a 2-qubit gate.

[build_files.tar.gz](https://github.com/aws/braket-python-sdk/files/4301135/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
