### PR TITLE
Remove SDK references in Instruction.to_ir()

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 from typing import Callable, Dict, Iterable, TypeVar
 
 from braket.circuits.ascii_circuit_diagram import AsciiCircuitDiagram
@@ -126,7 +128,7 @@ class Circuit:
         instruction: Instruction,
         target: QubitSetInput = None,
         target_mapping: Dict[QubitInput, QubitInput] = {},
-    ) -> "Circuit":
+    ) -> Circuit:
         """
         Add an instruction to `self`, returns `self` for chaining ability.
 
@@ -191,10 +193,10 @@ class Circuit:
 
     def add_circuit(
         self,
-        circuit: "Circuit",
+        circuit: Circuit,
         target: QubitSetInput = None,
         target_mapping: Dict[QubitInput, QubitInput] = {},
-    ) -> "Circuit":
+    ) -> Circuit:
         """
         Add a `circuit` to self, returns self for chaining ability. This is a composite form of
         `add_instruction()` since it adds all of the instructions of `circuit` to this circuit.
@@ -256,7 +258,7 @@ class Circuit:
 
         return self
 
-    def add(self, addable: AddableTypes, *args, **kwargs) -> "Circuit":
+    def add(self, addable: AddableTypes, *args, **kwargs) -> Circuit:
         """
         Generic add method for adding instruction-like item(s) to self. Any arguments that
         `add_circuit()` and / or `add_instruction()` supports are supported by this method.
@@ -335,7 +337,7 @@ class Circuit:
         ir_instructions = [instr.to_ir() for instr in self.instructions]
         return Program(instructions=ir_instructions)
 
-    def _copy(self) -> "Circuit":
+    def _copy(self) -> Circuit:
         """
         Return a shallow copy of the circuit.
 
@@ -344,10 +346,10 @@ class Circuit:
         """
         return Circuit().add(self.instructions)
 
-    def __iadd__(self, addable: AddableTypes) -> "Circuit":
+    def __iadd__(self, addable: AddableTypes) -> Circuit:
         return self.add(addable)
 
-    def __add__(self, addable: AddableTypes) -> "Circuit":
+    def __add__(self, addable: AddableTypes) -> Circuit:
         new = self._copy()
         new.add(addable)
         return new

--- a/src/braket/circuits/instruction.py
+++ b/src/braket/circuits/instruction.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict
 
 from braket.circuits.operator import Operator
@@ -74,11 +76,11 @@ class Instruction:
         Converts the operator into the canonical intermediate representation.
         If the operator is passed in a request, this method is called before it is passed.
         """
-        return self.operator.to_ir(self.target)
+        return self._operator.to_ir([int(qubit) for qubit in self._target])
 
     def copy(
         self, target_mapping: Dict[QubitInput, QubitInput] = {}, target: QubitSetInput = None
-    ) -> "Instruction":
+    ) -> Instruction:
         """
         Return a shallow copy of the instruction.
 
@@ -114,14 +116,14 @@ class Instruction:
         if target_mapping and target is not None:
             raise TypeError("Only 'target_mapping' or 'target' can be supplied, but not both.")
         elif target is not None:
-            return Instruction(self.operator, target)
+            return Instruction(self._operator, target)
         else:
-            return Instruction(self.operator, self.target.map(target_mapping))
+            return Instruction(self._operator, self._target.map(target_mapping))
 
     def __repr__(self):
-        return f"Instruction('operator': {self.operator}, 'target': {self.target})"
+        return f"Instruction('operator': {self._operator}, 'target': {self._target})"
 
     def __eq__(self, other):
         if isinstance(other, Instruction):
-            return (self.operator, self.target) == (other.operator, other.target)
+            return (self._operator, self._target) == (other._operator, other._target)
         return NotImplemented

--- a/src/braket/circuits/qubit.py
+++ b/src/braket/circuits/qubit.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 from typing import Union
 
 QubitInput = Union["Qubit", int]
@@ -45,7 +47,7 @@ class Qubit(int):
         return self.__repr__()
 
     @staticmethod
-    def new(qubit: QubitInput) -> "Qubit":
+    def new(qubit: QubitInput) -> Qubit:
         """
         Helper constructor - if input is a Qubit it returns the same value,
         else a new Qubit is constructed.

--- a/src/braket/circuits/qubit_set.py
+++ b/src/braket/circuits/qubit_set.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, Iterable, Union
 
 from boltons.setutils import IndexedSet
@@ -61,7 +63,7 @@ class QubitSet(IndexedSet):
         _qubits = [Qubit.new(qubit) for qubit in _flatten(qubits)]
         super().__init__(_qubits)
 
-    def map(self, mapping: Dict[QubitInput, QubitInput]) -> "QubitSet":
+    def map(self, mapping: Dict[QubitInput, QubitInput]) -> QubitSet:
         """
         Creates a new QubitSet where this instance's qubits are mapped to the values in `mapping`.
         If this instance contains a qubit that is not in the `mapping` that qubit is not modified.


### PR DESCRIPTION
So users working with IR don't see SDK classes like `Qubit`:

Before:

```python
>>> bell.to_ir()
Program(instructions=[H(target=Qubit(0), type=<Type.h: 'h'>), CNot(control=Qubit(0), target=Qubit(1), type=<Type.cnot: 'cnot'>)])
```

After:

```python
>>> bell.to_ir()
Program(instructions=[H(target=0, type=<Type.h: 'h'>), CNot(control=0, target=1, type=<Type.cnot: 'cnot'>)])
```

Also imported `__future__.annotations` so type hints for a class within the same class don't need to be quoted.

[build_files.tar.gz](https://github.com/aws/braket-python-sdk/files/4379036/build_files.tar.gz)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
