### PR TITLE
Remove unused vars in test_quantum_operator_helpers.py

### DIFF
--- a/test/unit_tests/braket/circuits/test_quantum_operator_helpers.py
+++ b/test/unit_tests/braket/circuits/test_quantum_operator_helpers.py
@@ -1,5 +1,4 @@
 import functools
-import itertools
 
 import numpy as np
 import pytest
@@ -28,16 +27,7 @@ invalid_hermitian_matrices_false = [(np.array([[1, 0], [0, 1j]])), (np.array([[1
 
 invalid_matrix_type_error = np.array([[0, 1], ["a", 0]])
 
-x_matrix = np.array([[0, 1], [1, 0]])
-y_matrix = np.array([[0, -1j], [1j, 0]])
 z_matrix = np.array([[1, 0], [0, -1]])
-h_matrix = 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])
-
-standard_observables = [x_matrix, y_matrix, z_matrix, h_matrix]
-
-matrix_pairs = [
-    np.kron(x, y) for x, y in list(itertools.product(standard_observables, standard_observables))
-]
 
 
 def test_verify_quantum_operator_matrix_dimensions():
@@ -82,20 +72,17 @@ def test_is_unitary_exception():
     is_unitary(invalid_matrix_type_error)
 
 
-@pytest.mark.parametrize("pauli", standard_observables)
-def test_get_pauli_eigenvalues_correct_eigenvalues_one_qubit(pauli):
+def test_get_pauli_eigenvalues_correct_eigenvalues_one_qubit():
     """Test the get_pauli_eigenvalues function for one qubit"""
     assert np.array_equal(get_pauli_eigenvalues(1), np.diag(z_matrix))
 
 
-@pytest.mark.parametrize("pauli_product", matrix_pairs)
-def test_get_pauli_eigenvalues_correct_eigenvalues_two_qubits(pauli_product):
+def test_get_pauli_eigenvalues_correct_eigenvalues_two_qubits():
     """Test the get_pauli_eigenvalues function for two qubits"""
     assert np.array_equal(get_pauli_eigenvalues(2), np.diag(np.kron(z_matrix, z_matrix)))
 
 
-@pytest.mark.parametrize("pauli_product", matrix_pairs)
-def test_get_pauli_eigenvalues_correct_eigenvalues_three_qubits(pauli_product):
+def test_get_pauli_eigenvalues_correct_eigenvalues_three_qubits():
     """Test the get_pauli_eigenvalues function for three qubits"""
     assert np.array_equal(
         get_pauli_eigenvalues(3), np.diag(np.kron(z_matrix, np.kron(z_matrix, z_matrix))),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove unused vars in test_quantum_operator_helpers.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
