### PR TITLE
Omit braket/simulator from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ source =
     braket
 omit = 
     **/braket/ir/*
+    **/braket/simulator/*
 
 [paths]
 source =


### PR DESCRIPTION
[build_files.tar.gz](https://github.com/aws/braket-python-sdk/files/4685338/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
