### PR TITLE
Add version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ pip show amazon-braket-default-simulator-python
 pip show braket-ir
 pip show braket-sdk
 ```
+
+You can also check your version of `braket-python-sdk` from within Python:
+
+```
+>>> import braket._sdk as braket_sdk
+>>> braket_sdk.__version___
+```
+
 Compare the version displayed in your local environment with the latest version listed for each of the following release pages:
 - [amazon-braket-default-simulator-python](https://github.com/aws/amazon-braket-default-simulator-python/releases) 
 - [braket-python-ir](https://github.com/aws/braket-python-ir/releases)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@
 
 from setuptools import find_namespace_packages, setup
 
+with open("src/braket/_sdk/_version.py") as f:
+    version = f.readlines()[-1].split()[-1].strip("\"'")
+
 setup(
     name="braket-sdk",
-    version="0.4.0",
+    version=version,
     license="Apache License 2.0",
     python_requires=">= 3.7.2",
     packages=find_namespace_packages(where="src", exclude=("test",)),

--- a/src/braket/_sdk/__init__.py
+++ b/src/braket/_sdk/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from ._version import __version__  # noqa: F401

--- a/src/braket/_sdk/_version.py
+++ b/src/braket/_sdk/_version.py
@@ -1,0 +1,18 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Version information.
+   Version number (major.minor.patch[-label])
+"""
+
+__version__ = "0.4.0"


### PR DESCRIPTION
Users can now check the version of the SDK by running

```python
>>> import braket._sdk as braket_sdk
>>> braket_sdk.__version___

0.4.0
```

[build_files.tar.gz](https://github.com/aws/braket-python-sdk/files/4738491/build_files.tar.gz)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
