### PR TITLE
Add supported result types to AwsQuantumSimulator and allow basis_rot…

### DIFF
--- a/src/braket/_sdk/_version.py
+++ b/src/braket/_sdk/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/braket/aws/aws_quantum_simulator.py
+++ b/src/braket/aws/aws_quantum_simulator.py
@@ -111,7 +111,8 @@ class AwsQuantumSimulator(Device):
         self._status = simulator_metadata.get("status")
         self._status_reason = simulator_metadata.get("statusReason")
         self._properties = {
-            k: simulator_metadata.get(k) for k in ["supportedQuantumOperations", "qubitCount"]
+            k: simulator_metadata.get(k)
+            for k in ["supportedQuantumOperations", "qubitCount", "supportedResultTypes"]
         }
 
     @property

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -149,8 +149,8 @@ class Circuit:
         added_observables_targets = set()
         for return_type in observable_return_types:
             observable: Observable = return_type.observable
-            targets: List[List[int]] = [return_type.target] if return_type.target else [
-                QubitSet(qubit) for qubit in self._moments.qubits
+            targets: List[List[int]] = [list(return_type.target)] if return_type.target else [
+                list([qubit]) for qubit in self._moments.qubits
             ]
 
             for target in targets:
@@ -166,15 +166,15 @@ class Circuit:
         return basis_rotation_instructions
 
     @staticmethod
-    def _observable_to_instruction(observable: Observable, targets: List[int]):
+    def _observable_to_instruction(observable: Observable, target_list: List[int]):
         if isinstance(observable, TensorProduct):
             instructions = []
             for factor in observable.factors:
-                target = [targets.pop(0) for _ in range(factor.qubit_count)]
+                target = [target_list.pop(0) for _ in range(factor.qubit_count)]
                 instructions += Circuit._observable_to_instruction(factor, target)
             return instructions
         else:
-            return [Instruction(gate, targets) for gate in observable.basis_rotation_gates]
+            return [Instruction(gate, target_list) for gate in observable.basis_rotation_gates]
 
     @property
     def moments(self) -> Moments:

--- a/test/unit_tests/braket/aws/common_test_utils.py
+++ b/test/unit_tests/braket/aws/common_test_utils.py
@@ -143,6 +143,15 @@ class MockDevices:
             "gateModelProperties": {
                 "qubitCount": 23,
                 "supportedQuantumOperations": ["CNOT", "H", "RZ", "RY", "RZ", "Toffoli"],
+                "supportedResultTypes": [
+                    {
+                        "name": "Sample",
+                        "observables": ["X", "Y", "Z"],
+                        "minShots": 1,
+                        "maxShots": 100,
+                    },
+                    {"name": "Probability", "minShots": 1, "maxShots": 100,},
+                ],
             }
         },
         "name": "integ_test_simulator",
@@ -163,6 +172,14 @@ class MockDevices:
                     "Toffoli",
                     "Phase",
                     "CPhase",
+                ],
+                "supportedResultTypes": [
+                    {
+                        "name": "Sample",
+                        "observables": ["X", "Y", "Z"],
+                        "minShots": 1,
+                        "maxShots": 100,
+                    }
                 ],
             }
         },

--- a/test/unit_tests/braket/aws/test_aws_quantum_simulator.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_simulator.py
@@ -50,6 +50,9 @@ def test_simulator_refresh_metadata_success():
     assert simulator.properties["supportedQuantumOperations"] == expected_metadata.get(
         "supportedQuantumOperations"
     )
+    assert simulator.properties["supportedResultTypes"] == expected_metadata.get(
+        "supportedResultTypes"
+    )
     assert simulator.status == expected_metadata.get("status")
     assert simulator.status_reason is None
 
@@ -62,6 +65,9 @@ def test_simulator_refresh_metadata_success():
     assert simulator.properties["qubitCount"] == expected_metadata.get("qubitCount")
     assert simulator.properties["supportedQuantumOperations"] == expected_metadata.get(
         "supportedQuantumOperations"
+    )
+    assert simulator.properties["supportedResultTypes"] == expected_metadata.get(
+        "supportedResultTypes"
     )
     assert simulator.status == expected_metadata.get("status")
     assert simulator.status_reason == expected_metadata.get("statusReason")

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -533,6 +533,20 @@ def test_basis_rotation_instructions_multiple_result_types_different_hermitian_t
     assert circ.basis_rotation_instructions == expected
 
 
+def test_basis_rotation_instructions_call_twice():
+    circ = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
+        .sample(observable=Observable.H() @ Observable.X(), target=[0, 1])
+        .variance(observable=Observable.H() @ Observable.X(), target=[0, 1])
+    )
+    expected = [Instruction(Gate.Ry(-np.pi / 4), 0), Instruction(Gate.H(), 1)]
+    assert circ.basis_rotation_instructions == expected
+    assert circ.basis_rotation_instructions == expected
+
+
 def test_depth_getter(h):
     assert h.depth is h._moments.depth
 


### PR DESCRIPTION
…ation_gates to be run twice on circuit

*Issue #, if available:*

*Description of changes:*
* Add supported result types to AwsQuantumSimulator
* Allow basis_rotation_gates to be called twice. Previously, calling basis_rotation_gates was mutating the targets of an observable

[build_files.tar.gz](https://github.com/aws/braket-python-sdk/files/4748940/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
