### PR TITLE
Validate compatible IR for LocalSimulator

### DIFF
--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -20,7 +20,7 @@ from braket.annealing.problem import Problem
 from braket.circuits import Circuit
 from braket.circuits.circuit_helpers import validate_circuit_and_shots
 from braket.devices.device import Device
-from braket.simulator import BraketSimulator, IrType
+from braket.simulator import BraketSimulator
 from braket.tasks import AnnealingQuantumTaskResult, GateModelQuantumTaskResult
 from braket.tasks.local_quantum_task import LocalQuantumTask
 
@@ -125,7 +125,7 @@ def _run_internal(
 
 @_run_internal.register
 def _(circuit: Circuit, simulator: BraketSimulator, shots, *args, **kwargs):
-    if IrType.JAQCD not in simulator.properties["supportedIrTypes"]:
+    if "jaqcd" not in simulator.properties["supportedIrTypes"]:
         raise NotImplementedError(f"{type(simulator)} does not support qubit gate-based programs")
     validate_circuit_and_shots(circuit, shots)
     program = circuit.to_ir()
@@ -136,7 +136,7 @@ def _(circuit: Circuit, simulator: BraketSimulator, shots, *args, **kwargs):
 
 @_run_internal.register
 def _(problem: Problem, simulator: BraketSimulator, shots, *args, **kwargs):
-    if IrType.ANNEALING not in simulator.properties["supportedIrTypes"]:
+    if "annealing" not in simulator.properties["supportedIrTypes"]:
         raise NotImplementedError(f"{type(simulator)} does not support quantum annealing problems")
     ir = problem.to_ir()
     results_dict = simulator.run(ir, shots, *args, *kwargs)

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -20,7 +20,7 @@ import pytest
 from braket.annealing import Problem, ProblemType
 from braket.circuits import Circuit
 from braket.devices import LocalSimulator, local_simulator
-from braket.simulator import BraketSimulator, IrType
+from braket.simulator import BraketSimulator
 from braket.tasks import AnnealingQuantumTaskResult, GateModelQuantumTaskResult
 
 GATE_MODEL_RESULT = {
@@ -55,7 +55,7 @@ class DummyCircuitSimulator(BraketSimulator):
 
     @property
     def properties(self) -> Dict[str, Any]:
-        return {"supportedIrTypes": [IrType.JAQCD], "supportedQuantumOperations": ["I", "X"]}
+        return {"supportedIrTypes": ["jaqcd"], "supportedQuantumOperations": ["I", "X"]}
 
     def assert_shots(self, shots):
         assert self._shots == shots
@@ -70,7 +70,7 @@ class DummyAnnealingSimulator(BraketSimulator):
 
     @property
     def properties(self) -> Dict[str, Any]:
-        return {"supportedIrTypes": [IrType.ANNEALING]}
+        return {"supportedIrTypes": ["annealing"]}
 
 
 mock_entry = Mock()
@@ -141,7 +141,7 @@ def test_run_qubit_gate_unsupported():
 def test_properties():
     sim = LocalSimulator(DummyCircuitSimulator())
     expected_properties = {
-        "supportedIrTypes": [IrType.JAQCD],
+        "supportedIrTypes": ["jaqcd"],
         "supportedQuantumOperations": ["I", "X"],
     }
     assert sim.properties == expected_properties


### PR DESCRIPTION
LocalSimulator now fails fast when the wrong type of task is supplied to
a BraketSimulator implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
