### PR TITLE
Add exception if amplitude states is not a list

### DIFF
--- a/examples/bell_result_types.py
+++ b/examples/bell_result_types.py
@@ -25,7 +25,7 @@ bell = (
     .cnot(0, 1)
     .probability(target=[0])
     .expectation(observable=Observable.Z(), target=[1])
-    .amplitude(state="00")
+    .amplitude(state=["00"])
     .state_vector()
 )
 

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -82,13 +82,19 @@ class Amplitude(ResultType):
             state (List[str]): list of quantum states as strings with "0" and "1"
 
         Raises:
-            ValueError: If state is None or an empty list
+            ValueError: If state is None or an empty list, or
+                state is not a list of strings of '0' and '1'
 
         Examples:
             >>> ResultType.Amplitude(state=['01', '10'])
         """
-        if not state or not all(
-            isinstance(amplitude, str) and re.fullmatch("^[01]+$", amplitude) for amplitude in state
+        if (
+            not state
+            or not isinstance(state, List)
+            or not all(
+                isinstance(amplitude, str) and re.fullmatch("^[01]+$", amplitude)
+                for amplitude in state
+            )
         ):
             raise ValueError(
                 "A non-empty list of states must be specified in binary encoding e.g. ['01', '10']"

--- a/test/unit_tests/braket/circuits/test_result_types.py
+++ b/test/unit_tests/braket/circuits/test_result_types.py
@@ -112,7 +112,8 @@ def test_result_equality(testclass, subroutine_name, irclass, input, ir_input):
 
 @pytest.mark.xfail(raises=ValueError)
 @pytest.mark.parametrize(
-    "state", ((["2", "11"]), ([1, 0]), ([0.1, 0]), ("-0", "1"), (["", ""]), (None), ([None, None]))
+    "state",
+    ((["2", "11"]), ([1, 0]), ([0.1, 0]), ("-0", "1"), (["", ""]), (None), ([None, None]), ("10")),
 )
 def test_amplitude_init_invalid_state_value_error(state):
     ResultType.Amplitude(state=state)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add exception if amplitude states is not a list
* Fixed amplitude states in example

Check for len(state) == number of qubits will be in local simulator, similar to how there's a validation exception in the Braket service for this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
