### PR TITLE
Setting whitelist_externals envconfig setting to "coverage" to stop a…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = linters,docs,unit-tests
 
 [testenv:unit-tests]
 basepython = python3.7
+whitelist_externals = coverage
 # {posargs} contains additional arguments specified when invoking tox. e.g. tox -- -s -k test_foo.py
 commands =
     coverage run -m pytest {posargs}


### PR DESCRIPTION
Setting whitelist_externals envconfig setting to "coverage" to stop a warning.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
