### PR TITLE
Fix missing backticks/spaces that caused None to render incorrectly i…

### DIFF
--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -35,7 +35,7 @@ class AngledGate(Gate):
 
         Raises:
             ValueError: If the `qubit_count` is less than 1, `ascii_symbols` are `None`, or
-                `ascii_symbols` length != `qubit_count`, or `angle` is`None`
+                `ascii_symbols` length != `qubit_count`, or `angle` is `None`
         """
         super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
         if angle is None:

--- a/src/braket/circuits/gate.py
+++ b/src/braket/circuits/gate.py
@@ -36,7 +36,7 @@ class Gate(QuantumOperator):
                 correlate a symbol with that index.
 
         Raises:
-            ValueError: `qubit_count` is less than 1, `ascii_symbols` are None, or
+            ValueError: `qubit_count` is less than 1, `ascii_symbols` are `None`, or
                 `ascii_symbols` length != `qubit_count`
         """
         super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)

--- a/src/braket/circuits/quantum_operator.py
+++ b/src/braket/circuits/quantum_operator.py
@@ -32,7 +32,7 @@ class QuantumOperator(Operator):
                 correlate a symbol with that index.
 
         Raises:
-            ValueError: `qubit_count` is less than 1, `ascii_symbols` are None, or
+            ValueError: `qubit_count` is less than 1, `ascii_symbols` are `None`, or
                 `ascii_symbols` length != `qubit_count`
         """
 


### PR DESCRIPTION
…n the documentation

*Issue #, if available:*

*Description of changes:*

Some of the `None`s in the documentation don't render properly because they are missing a backtick or a space was missing in front of their first backtick. One didn't have backticks and I added them for consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Cedric asked me to make him a reviewer so he can see how the GH review process works.