### PR TITLE
Fix indenting for ValueError

### DIFF
--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -234,7 +234,7 @@ class Expectation(ObservableResultType):
 
         Raises:
             ValueError: If the observable's qubit count does not equal the number of target
-            qubits, or if `target=None` and the observable's qubit count is not 1.
+                qubits, or if `target=None` and the observable's qubit count is not 1.
 
         Examples:
             >>> ResultType.Expectation(observable=Observable.Z(), target=0)
@@ -301,7 +301,7 @@ class Sample(ObservableResultType):
 
         Raises:
             ValueError: If the observable's qubit count is not equal to the number of target
-            qubits, or if `target=None` and the observable's qubit count is not 1.
+                qubits, or if `target=None` and the observable's qubit count is not 1.
 
         Examples:
             >>> ResultType.Sample(observable=Observable.Z(), target=0)
@@ -369,7 +369,7 @@ class Variance(ObservableResultType):
 
         Raises:
             ValueError: If the observable's qubit count does not equal the number of target
-            qubits, or if `target=None` and the observable's qubit count is not 1.
+                qubits, or if `target=None` and the observable's qubit count is not 1.
 
         Examples:
             >>> ResultType.Variance(observable=Observable.Z(), target=0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `ValueError` descriptions didn't indent the second line and so right now it renders as its own bullet point.

<img width="632" alt="Screen Shot 2020-07-22 at 3 51 38 PM" src="https://user-images.githubusercontent.com/67932820/88221985-428a9c00-cc33-11ea-8cbc-8fbaa173c392.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
