### PR TITLE
Fix typo for get_quantum_task function docstring.

### DIFF
--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -101,7 +101,7 @@ class AwsSession(object):
         Gets the quantum task.
 
         Args:
-            arn (str): The ARN of the quantum task to cancel.
+            arn (str): The ARN of the quantum task to get.
 
         Returns:
             Dict[str, Any]: The response from the Amazon Braket `GetQuantumTask` operation.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix typo for get_quantum_task function docstring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
