### PR TITLE
feature: Updated AwsQuantumTask to use new device parameters

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -125,7 +125,9 @@ class AwsDevice(Device):
             >>> )
             >>> device = AwsDevice("arn3")
             >>> device.run(problem, ("bucket-foo", "key-bar"),
-            >>>     device_parameters = {"dWaveParameters": {"postprocessingType": "SAMPLING"}})
+            >>>     device_parameters={
+            >>>         "providerLevelParameters": {"postprocessingType": "SAMPLING"}}
+            >>> )
 
         See Also:
             `braket.aws.aws_quantum_task.AwsQuantumTask.create()`

--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -42,7 +42,7 @@ def s3_bucket(s3_resource, boto_session):
 
     region_name = boto_session.region_name
     account_id = boto_session.client("sts").get_caller_identity()["Account"]
-    bucket_name = f"braket-sdk-integ-tests-{account_id}"
+    bucket_name = f"amazon-braket-sdk-integ-tests-{account_id}"
     bucket = s3_resource.Bucket(bucket_name)
 
     try:


### PR DESCRIPTION
*Description of changes:*
Updated the aws_quantum_task module to use the new device parameters and updated all documentation references to use the new structures.

*Testing done:*
Integration tests against prod are failing since the latest changes cannot be pushed yet. I ran the integration tests against Beta and all but IonQ tests were passing (this is due to me running the tests in beta pdx and cross region code was trying to call us-east-1 in beta which has no device).
[build_files.tar.gz](https://github.com/aws/amazon-braket-sdk-python/files/5053317/build_files.tar.gz)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python#braket-python-sdk-api-reference-documentation) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 