### PR TITLE
fix: Convert amplitude result to a complex number

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -426,12 +426,7 @@ def _format_result(result):
 
 @_format_result.register
 def _(result: GateModelTaskResult) -> GateModelQuantumTaskResult:
-    if result.resultTypes:
-        for result_type in result.resultTypes:
-            type = result_type.type.type
-            if type == "amplitude":
-                for state in result_type.value:
-                    result_type.value[state] = complex(*result_type.value[state])
+    GateModelQuantumTaskResult.cast_result_types(result)
     return GateModelQuantumTaskResult.from_object(result)
 
 

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -310,7 +310,6 @@ class AwsQuantumTask(QuantumTask):
                     current_metadata["outputS3Bucket"],
                     current_metadata["outputS3Directory"] + f"/{AwsQuantumTask.RESULTS_FILENAME}",
                 )
-                print(f"Result string is \n {result_string}")
                 self._result = _format_result(BraketSchemaBase.parse_raw_schema(result_string))
                 return self._result
             elif task_status in AwsQuantumTask.NO_RESULT_TERMINAL_STATES:

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -310,6 +310,7 @@ class AwsQuantumTask(QuantumTask):
                     current_metadata["outputS3Bucket"],
                     current_metadata["outputS3Directory"] + f"/{AwsQuantumTask.RESULTS_FILENAME}",
                 )
+                print(f"Result string is \n {result_string}")
                 self._result = _format_result(BraketSchemaBase.parse_raw_schema(result_string))
                 return self._result
             elif task_status in AwsQuantumTask.NO_RESULT_TERMINAL_STATES:
@@ -426,6 +427,12 @@ def _format_result(result):
 
 @_format_result.register
 def _(result: GateModelTaskResult) -> GateModelQuantumTaskResult:
+    if result.resultTypes:
+        for result_type in result.resultTypes:
+            type = result_type.type.type
+            if type == "amplitude":
+                for state in result_type.value:
+                    result_type.value[state] = complex(*result_type.value[state])
     return GateModelQuantumTaskResult.from_object(result)
 
 

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -217,16 +217,7 @@ class GateModelQuantumTaskResult:
                 in the result dict
         """
         obj = GateModelTaskResult.parse_raw(result)
-        if obj.resultTypes:
-            for result_type in obj.resultTypes:
-                type = result_type.type.type
-                if type == "probability":
-                    result_type.value = np.array(result_type.value)
-                elif type == "statevector":
-                    result_type.value = np.array([complex(*value) for value in result_type.value])
-                elif type == "amplitude":
-                    for state in result_type.value:
-                        result_type.value[state] = complex(*result_type.value[state])
+        GateModelQuantumTaskResult.cast_result_types(obj)
         return GateModelQuantumTaskResult._from_object_internal(obj)
 
     @classmethod
@@ -302,6 +293,26 @@ class GateModelQuantumTaskResult:
             result_types=result_types,
             values=values,
         )
+
+    @staticmethod
+    def cast_result_types(gate_model_task_result: GateModelTaskResult) -> None:
+        """
+        Casts the result types to the types expected by the SDK.
+
+        Args:
+            gate_model_task_result (GateModelTaskResult): GateModelTaskResult representing the
+                results.
+        """
+        if gate_model_task_result.resultTypes:
+            for result_type in gate_model_task_result.resultTypes:
+                type = result_type.type.type
+                if type == "probability":
+                    result_type.value = np.array(result_type.value)
+                elif type == "statevector":
+                    result_type.value = np.array([complex(*value) for value in result_type.value])
+                elif type == "amplitude":
+                    for state in result_type.value:
+                        result_type.value[state] = complex(*result_type.value[state])
 
     @staticmethod
     def _calculate_result_types(

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -51,27 +51,31 @@ def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]
     assert len(result.measurements) == shots
 
 
-def result_types_zero_shots_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_zero_shots_bell_pair_testing(
+    device: Device, include_state_vector: bool, run_kwargs: Dict[str, Any]
+):
     circuit = (
         Circuit()
         .h(0)
         .cnot(0, 1)
         .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
-        .state_vector()
         .amplitude(["01", "10", "00", "11"])
     )
+    if include_state_vector:
+        circuit.state_vector()
     result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 3
+    assert len(result.result_types) == 3 if include_state_vector else 2
     assert np.allclose(
         result.get_value_by_result_type(
             ResultType.Expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
         ),
         1 / np.sqrt(2),
     )
-    assert np.allclose(
-        result.get_value_by_result_type(ResultType.StateVector()),
-        np.array([1, 0, 0, 1]) / np.sqrt(2),
-    )
+    if include_state_vector:
+        assert np.allclose(
+            result.get_value_by_result_type(ResultType.StateVector()),
+            np.array([1, 0, 0, 1]) / np.sqrt(2),
+        )
     assert result.get_value_by_result_type(ResultType.Amplitude(["01", "10", "00", "11"])) == {
         "01": 0j,
         "10": 0j,

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -44,7 +44,7 @@ def test_qubit_ordering():
 
 
 def test_result_types_no_shots():
-    result_types_zero_shots_bell_pair_testing(DEVICE, {"shots": 0})
+    result_types_zero_shots_bell_pair_testing(DEVICE, True, {"shots": 0})
 
 
 def test_result_types_nonzero_shots_bell_pair():

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -26,6 +26,7 @@ from gate_model_device_testing_utils import (
     result_types_tensor_z_h_y_testing,
     result_types_tensor_z_hermitian_testing,
     result_types_tensor_z_z_testing,
+    result_types_zero_shots_bell_pair_testing,
 )
 
 from braket.aws import AwsDevice
@@ -46,6 +47,14 @@ def test_no_result_types_bell_pair(simulator_arn, aws_session, s3_destination_fo
 def test_qubit_ordering(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     qubit_ordering_testing(device, {"shots": SHOTS, "s3_destination_folder": s3_destination_folder})
+
+
+@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+def test_result_types_no_shots(simulator_arn, aws_session, s3_destination_folder):
+    device = AwsDevice(simulator_arn, aws_session)
+    result_types_zero_shots_bell_pair_testing(
+        device, False, {"shots": 0, "s3_destination_folder": s3_destination_folder}
+    )
 
 
 @pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
@@ -74,7 +83,7 @@ def test_result_types_bell_pair_marginal_probability(
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_tensor_x_y(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_x_y_testing(
@@ -82,7 +91,7 @@ def test_result_types_tensor_x_y(simulator_arn, shots, aws_session, s3_destinati
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_tensor_z_h_y(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_z_h_y_testing(
@@ -90,7 +99,7 @@ def test_result_types_tensor_z_h_y(simulator_arn, shots, aws_session, s3_destina
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_hermitian(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_hermitian_testing(
@@ -98,7 +107,7 @@ def test_result_types_hermitian(simulator_arn, shots, aws_session, s3_destinatio
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_tensor_z_z(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_z_z_testing(
@@ -106,7 +115,7 @@ def test_result_types_tensor_z_z(simulator_arn, shots, aws_session, s3_destinati
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_tensor_hermitian_hermitian(
     simulator_arn, shots, aws_session, s3_destination_folder
 ):
@@ -116,7 +125,7 @@ def test_result_types_tensor_hermitian_hermitian(
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_tensor_y_hermitian(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_y_hermitian_testing(
@@ -124,7 +133,7 @@ def test_result_types_tensor_y_hermitian(simulator_arn, shots, aws_session, s3_d
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
 def test_result_types_tensor_z_hermitian(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_z_hermitian_testing(

--- a/test/unit_tests/braket/aws/common_test_utils.py
+++ b/test/unit_tests/braket/aws/common_test_utils.py
@@ -45,6 +45,44 @@ class MockS3:
         }
     )
 
+    MOCK_S3_RESULT_GATE_MODEL_WITH_RESULT_TYPES = json.dumps(
+        {
+            "braketSchemaHeader": {
+                "name": "braket.task_result.gate_model_task_result",
+                "version": "1",
+            },
+            "measurements": [[0, 0], [0, 0], [0, 0], [1, 1]],
+            "measuredQubits": [0, 1],
+            "resultTypes": [
+                {
+                    "type": {"observable": ["h", "x"], "targets": [0, 1], "type": "expectation"},
+                    "value": 0.7071067811865474,
+                },
+                {
+                    "type": {"states": ["01", "10", "00", "11"], "type": "amplitude"},
+                    "value": {
+                        "01": [0.0, 0.0],
+                        "10": [0.0, 0.0],
+                        "00": [0.7071067811865475, 0.0],
+                        "11": [0.7071067811865475, 0.0],
+                    },
+                },
+            ],
+            "taskMetadata": {
+                "braketSchemaHeader": {"name": "braket.task_result.task_metadata", "version": "1"},
+                "id": "task_arn",
+                "shots": 100,
+                "deviceId": "default",
+            },
+            "additionalMetadata": {
+                "action": {
+                    "braketSchemaHeader": {"name": "braket.ir.jaqcd.program", "version": "1"},
+                    "instructions": [{"control": 0, "target": 1, "type": "cnot"}],
+                },
+            },
+        }
+    )
+
     MOCK_S3_RESULT_ANNEALING = json.dumps(
         {
             "braketSchemaHeader": {

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -190,9 +190,13 @@ def test_result_annealing(annealing_task):
     )
 
 
-def test_result_is_cached(circuit_task):
+@pytest.mark.parametrize(
+    "result_string",
+    [MockS3.MOCK_S3_RESULT_GATE_MODEL, MockS3.MOCK_S3_RESULT_GATE_MODEL_WITH_RESULT_TYPES],
+)
+def test_result_is_cached(circuit_task, result_string):
     _mock_metadata(circuit_task._aws_session, "COMPLETED")
-    _mock_s3(circuit_task._aws_session, MockS3.MOCK_S3_RESULT_GATE_MODEL)
+    _mock_s3(circuit_task._aws_session, result_string)
     circuit_task.result()
 
     _mock_s3(circuit_task._aws_session, "")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Converted amplitude result types to a complex number.
* Added integration test for validating amplitudes for SV1. 
* Enabled integration tests for simulators for shots=0.

*Testing done:*
```
>>> import boto3
>>> from braket.aws import AwsDevice
>>> from braket.circuits import Circuit
>>>
>>> aws_account_id = boto3.client("sts").get_caller_identity()["Account"]
>>> c = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
>>> s3_folder = (f"amazon-braket-{aws_account_id}", "folder-name")
>>> c = Circuit().x(0).amplitude(state=["1"])
>>> task = device.run(c, s3_folder, shots=0)
>>> print(task.result().values[0])
{'1': (1+0j)}
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
