### PR TITLE
fix: Call async_result() before calling asyncio.get_event_loop()

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -236,7 +236,8 @@ class AwsQuantumTask(QuantumTask):
         Consecutive calls to this method return a cached result from the preceding request.
         """
         try:
-            return asyncio.get_event_loop().run_until_complete(self.async_result())
+            async_result = self.async_result()
+            return asyncio.get_event_loop().run_until_complete(async_result)
         except asyncio.CancelledError:
             # Future was cancelled, return whatever is in self._result if anything
             self._logger.warning("Task future was cancelled")

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -13,6 +13,7 @@
 
 import pytest
 from gate_model_device_testing_utils import (
+    multithreaded_bell_pair_testing,
     no_result_types_bell_pair_testing,
     qubit_ordering_testing,
     result_types_all_selected_testing,
@@ -33,6 +34,10 @@ from braket.devices import LocalSimulator
 
 DEVICE = LocalSimulator()
 SHOTS = 8000
+
+
+def test_multithreaded_bell_pair():
+    multithreaded_bell_pair_testing(DEVICE, {"shots": SHOTS})
 
 
 def test_no_result_types_bell_pair():

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -13,6 +13,7 @@
 
 import pytest
 from gate_model_device_testing_utils import (
+    multithreaded_bell_pair_testing,
     no_result_types_bell_pair_testing,
     qubit_ordering_testing,
     result_types_all_selected_testing,
@@ -33,6 +34,14 @@ from braket.aws import AwsDevice
 
 SHOTS = 8000
 SIMULATOR_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+
+
+@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+def test_multithreaded_bell_pair(simulator_arn, aws_session, s3_destination_folder):
+    device = AwsDevice(simulator_arn, aws_session)
+    multithreaded_bell_pair_testing(
+        device, {"shots": SHOTS, "s3_destination_folder": s3_destination_folder}
+    )
 
 
 @pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When calling task.result(), task.async_result() was called in the same line and then passed as a parameter. This fix moves the call to async_result() to a preceding line.

Without this fix, calls to task.result() will fail if called from worker threads. The reason is that before this fix, get_event_loop() is called before the event loop is created in async_result(), in case the event loop doesn't already exist. Separating the call to async_result() ensures that the event loop is always created first if necessary.

*Testing done:*
Added integration test that fails before the change and succeeds afterwards.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
