### PR TITLE
fix: Add error message for running a circuit without instructions

### DIFF
--- a/src/braket/circuits/circuit_helpers.py
+++ b/src/braket/circuits/circuit_helpers.py
@@ -23,9 +23,9 @@ def validate_circuit_and_shots(circuit: Circuit, shots: int) -> None:
         shots (int): shots to validate
 
     Raises:
-        ValueError: If no result types specified for circuit and `shots=0`.
-            See `braket.circuit.result_types`. Or, if `StateVector` or `Amplitude`
-            are specified as result types when `shots > 0`.
+        ValueError: If circuit has no instructions. Also, if no result types
+            specified for circuit and `shots=0`. See `braket.circuit.result_types`.
+            Or, if `StateVector` or `Amplitude` are specified as result types when `shots > 0`.
     """
     if not circuit.instructions:
         raise ValueError("Circuit must have instructions to run on a device")

--- a/src/braket/circuits/circuit_helpers.py
+++ b/src/braket/circuits/circuit_helpers.py
@@ -27,6 +27,8 @@ def validate_circuit_and_shots(circuit: Circuit, shots: int) -> None:
             See `braket.circuit.result_types`. Or, if `StateVector` or `Amplitude`
             are specified as result types when `shots > 0`.
     """
+    if not circuit.instructions:
+        raise ValueError("Circuit must have instructions to run on a device")
     if not shots and not circuit.result_types:
         raise ValueError(
             "No result types specified for circuit and shots=0. See `braket.circuit.result_types`"

--- a/test/unit_tests/braket/circuits/test_circuit_helpers.py
+++ b/test/unit_tests/braket/circuits/test_circuit_helpers.py
@@ -18,6 +18,16 @@ from braket.circuits.circuit_helpers import validate_circuit_and_shots
 
 
 @pytest.mark.xfail(raises=ValueError)
+def test_validate_circuit_and_shots_no_instructions():
+    validate_circuit_and_shots(Circuit(), 100)
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_validate_circuit_and_shots_0_no_instructions():
+    validate_circuit_and_shots(Circuit(), 0)
+
+
+@pytest.mark.xfail(raises=ValueError)
 def test_validate_circuit_and_shots_0_no_results():
     validate_circuit_and_shots(Circuit().h(0), 0)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add error message for running a circuit without instructions. Before, for circuits without any gates (only observables, for example), an uninformative validation error is returned: "max() arg is an empty sequence"

*Testing done:*
* Added unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
