### PR TITLE
fix: Add error for target qubit set size not equal to operator qubit …

### DIFF
--- a/src/braket/circuits/instruction.py
+++ b/src/braket/circuits/instruction.py
@@ -39,7 +39,8 @@ class Instruction:
 
         Raises:
             ValueError: If `operator` is empty or any integer in `target` does not meet the `Qubit`
-                or `QubitSet` class requirements.
+                or `QubitSet` class requirements. Also, if operator qubit count does not equal
+                the size of the target qubit set.
             TypeError: If a `Qubit` class can't be constructed from `target` due to an incorrect
                 `typing`.
 
@@ -57,6 +58,14 @@ class Instruction:
             raise ValueError("Operator cannot be empty")
         self._operator = operator
         self._target = QubitSet(target)
+        if (
+            hasattr(self._operator, "qubit_count")
+            and len(self._target) != self._operator.qubit_count
+        ):
+            raise ValueError(
+                f"Operator qubit count {self._operator.qubit_count} must be "
+                f"equal to size of target qubit set {self._target}"
+            )
 
     @property
     def operator(self) -> InstructionOperator:

--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -163,7 +163,8 @@ class ObservableResultType(ResultType):
         else:
             if self._observable.qubit_count != len(self._target):
                 raise ValueError(
-                    "Observable's qubit count and the number of target qubits must be equal"
+                    f"Observable's qubit count {self._observable.qubit_count} and "
+                    f"the size of the target qubit set {self._target} must be equal"
                 )
             if self._observable.qubit_count != len(self.ascii_symbols):
                 raise ValueError(

--- a/test/unit_tests/braket/circuits/test_instruction.py
+++ b/test/unit_tests/braket/circuits/test_instruction.py
@@ -31,6 +31,11 @@ def test_empty_operator():
     Instruction(None, target=0)
 
 
+@pytest.mark.xfail(raises=ValueError)
+def test_non_matching_qubit_set_and_qubit_count():
+    Instruction(Gate.CNot, target=[0, 0])
+
+
 def test_init_with_qubits():
     target = QubitSet([0, 1])
     instr = Instruction(Gate.CNot(), target)
@@ -50,9 +55,9 @@ def test_init_with_int():
 
 
 def test_init_with_sequence():
-    target = [0, Qubit(1), 2]
+    target = [0, Qubit(1)]
     instr = Instruction(Gate.CNot(), target)
-    assert instr.target == QubitSet([0, 1, 2])
+    assert instr.target == QubitSet([0, 1])
 
 
 def test_getters():


### PR DESCRIPTION
…size in instruction

*Issue #, if available:*

*Description of changes:*
* Added error for target qubit set size not equal to operator qubit size in instruction
* Also improved the error message for result types

*Testing done:*
* Added unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
