### PR TITLE
infra: Change bucket creation setup for integ tests

### DIFF
--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -15,7 +15,6 @@ import os
 
 import boto3
 import pytest
-from botocore.exceptions import ClientError
 
 from braket.aws.aws_session import AwsSession
 
@@ -44,20 +43,8 @@ def s3_bucket(s3_resource, boto_session):
     account_id = boto_session.client("sts").get_caller_identity()["Account"]
     bucket_name = f"amazon-braket-sdk-integ-tests-{account_id}"
     bucket = s3_resource.Bucket(bucket_name)
-
-    try:
+    if not bucket.creation_date:
         bucket.create(ACL="private", CreateBucketConfiguration={"LocationConstraint": region_name})
-    except ClientError as e:
-        code = e.response["Error"]["Code"]
-
-        # Bucket exists in profile region
-        if code == "BucketAlreadyOwnedByYou":
-            pass
-        # Bucket exists in another region
-        elif code == "IllegalLocationConstraintException" and bucket.creation_date:
-            pass
-        else:
-            raise e
 
     return bucket_name
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* change bucket creation setup for integ tests because by just trying to create the bucket, we can get an error for too many buckets created even though the bucket already exists

*Testing done:*
* Ran integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
