### PR TITLE
fix: add observable targets not in instructions to circuit qubit coun…

### DIFF
--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -52,6 +52,21 @@ def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]
     assert len(result.measurements) == shots
 
 
+def result_types_observable_not_in_instructions(device: Device, run_kwargs: Dict[str, Any]):
+    shots = run_kwargs["shots"]
+    tol = get_tol(shots)
+    bell = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .expectation(observable=Observable.X(), target=[2])
+        .variance(observable=Observable.Y(), target=[3])
+    )
+    result = device.run(bell, **run_kwargs).result()
+    assert np.allclose(result.values[0], 0, **tol)
+    assert np.allclose(result.values[1], 1, **tol)
+
+
 def result_types_zero_shots_bell_pair_testing(
     device: Device, include_state_vector: bool, run_kwargs: Dict[str, Any]
 ):

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -21,6 +21,7 @@ from gate_model_device_testing_utils import (
     result_types_bell_pair_marginal_probability_testing,
     result_types_hermitian_testing,
     result_types_nonzero_shots_bell_pair_testing,
+    result_types_observable_not_in_instructions,
     result_types_tensor_hermitian_hermitian_testing,
     result_types_tensor_x_y_testing,
     result_types_tensor_y_hermitian_testing,
@@ -104,3 +105,8 @@ def test_result_types_tensor_y_hermitian(shots):
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_all_selected(shots):
     result_types_all_selected_testing(DEVICE, {"shots": shots})
+
+
+@pytest.mark.parametrize("shots", [0, SHOTS])
+def test_result_types_observable_not_in_instructions(shots):
+    result_types_observable_not_in_instructions(DEVICE, {"shots": shots})

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -21,6 +21,7 @@ from gate_model_device_testing_utils import (
     result_types_bell_pair_marginal_probability_testing,
     result_types_hermitian_testing,
     result_types_nonzero_shots_bell_pair_testing,
+    result_types_observable_not_in_instructions,
     result_types_tensor_hermitian_hermitian_testing,
     result_types_tensor_x_y_testing,
     result_types_tensor_y_hermitian_testing,
@@ -154,5 +155,15 @@ def test_result_types_tensor_z_hermitian(simulator_arn, shots, aws_session, s3_d
 def test_result_types_all_selected(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_all_selected_testing(
+        device, {"shots": shots, "s3_destination_folder": s3_destination_folder}
+    )
+
+
+@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+def test_result_types_observable_not_in_instructions(
+    simulator_arn, shots, aws_session, s3_destination_folder
+):
+    device = AwsDevice(simulator_arn, aws_session)
+    result_types_observable_not_in_instructions(
         device, {"shots": shots, "s3_destination_folder": s3_destination_folder}
     )

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -608,6 +608,64 @@ def test_qubit_count_setter(h):
     h.qubit_count = 1
 
 
+@pytest.mark.parametrize(
+    "circuit,expected_qubit_count",
+    [
+        (Circuit().h(0).h(1).h(2), 3),
+        (
+            Circuit()
+            .h(0)
+            .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
+            .sample(observable=Observable.H() @ Observable.X(), target=[0, 1]),
+            2,
+        ),
+        (
+            Circuit().h(0).probability([1, 2]).state_vector(),
+            1,
+        ),
+        (
+            Circuit()
+            .h(0)
+            .variance(observable=Observable.H(), target=1)
+            .state_vector()
+            .amplitude(["01"]),
+            2,
+        ),
+    ],
+)
+def test_qubit_count(circuit, expected_qubit_count):
+    assert circuit.qubit_count == expected_qubit_count
+
+
+@pytest.mark.parametrize(
+    "circuit,expected_qubits",
+    [
+        (Circuit().h(0).h(1).h(2), QubitSet([0, 1, 2])),
+        (
+            Circuit()
+            .h(0)
+            .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
+            .sample(observable=Observable.H() @ Observable.X(), target=[0, 1]),
+            QubitSet([0, 1]),
+        ),
+        (
+            Circuit().h(0).probability([1, 2]).state_vector(),
+            QubitSet([0]),
+        ),
+        (
+            Circuit()
+            .h(0)
+            .variance(observable=Observable.H(), target=1)
+            .state_vector()
+            .amplitude(["01"]),
+            QubitSet([0, 1]),
+        ),
+    ],
+)
+def test_circuit_qubits(circuit, expected_qubits):
+    assert circuit.qubits == expected_qubits
+
+
 def test_qubits_getter(h):
     assert h.qubits == h._moments.qubits
     assert h.qubits is not h._moments.qubits


### PR DESCRIPTION
…t and qubits

*Issue #, if available:*

*Description of changes:*
* This is to add observable targets that are not in instructions to circuit qubit count and qubits
* Examples can be found in tests added

*Testing done:*
* Unit/integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
