### PR TITLE
feature: support tags parameter for create method in AwsQuantumTask

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -55,6 +55,7 @@ class AwsQuantumTask(QuantumTask):
         s3_destination_folder: AwsSession.S3DestinationFolder,
         shots: int,
         device_parameters: Dict[str, Any] = None,
+        tags: Dict[str, str] = None,
         *args,
         **kwargs,
     ) -> AwsQuantumTask:
@@ -83,6 +84,9 @@ class AwsQuantumTask(QuantumTask):
                 For example, for D-Wave:
                 `{"providerLevelParameters": {"postprocessingType": "OPTIMIZATION"}}`
 
+            tags (Dict[str, str]): Tags, which are Key-Value pairs to add to this quantum task,
+                Example: {"state": "washington"}
+
         Returns:
             AwsQuantumTask: AwsQuantumTask tracking the task execution on the device.
 
@@ -106,6 +110,8 @@ class AwsQuantumTask(QuantumTask):
             s3_destination_folder,
             shots if shots is not None else AwsQuantumTask.DEFAULT_SHOTS,
         )
+        if tags is not None:
+            create_task_kwargs.update({"tags": tags})
         return _create_internal(
             task_specification,
             aws_session,

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -84,8 +84,9 @@ class AwsQuantumTask(QuantumTask):
                 For example, for D-Wave:
                 `{"providerLevelParameters": {"postprocessingType": "OPTIMIZATION"}}`
 
-            tags (Dict[str, str]): Tags, which are Key-Value pairs to add to this quantum task,
-                Example: {"state": "washington"}
+            tags (Dict[str, str]): Tags, which are Key-Value pairs to add to this quantum task.
+                An example would be:
+                `{"state": "washington"}`
 
         Returns:
             AwsQuantumTask: AwsQuantumTask tracking the task execution on the device.

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -350,6 +350,37 @@ def test_from_annealing(device_parameters, aws_session, arn, problem):
     )
 
 
+@pytest.mark.parametrize(
+    "device_arn,device_parameters_class",
+    [
+        ("device/qpu/ionq", IonqDeviceParameters),
+        ("device/qpu/rigetti", RigettiDeviceParameters),
+        ("device/quantum-simulator", GateModelSimulatorDeviceParameters),
+    ],
+)
+def test_create_with_tags(device_arn, device_parameters_class, aws_session, circuit):
+    mocked_task_arn = "task-arn-tags"
+    aws_session.create_quantum_task.return_value = mocked_task_arn
+    shots = 53
+    tags = {"state": "washington"}
+
+    task = AwsQuantumTask.create(aws_session, device_arn, circuit, S3_TARGET, shots, tags=tags)
+    assert task == AwsQuantumTask(
+        mocked_task_arn, aws_session, GateModelQuantumTaskResult.from_string
+    )
+    _assert_create_quantum_task_called_with(
+        aws_session,
+        device_arn,
+        circuit,
+        S3_TARGET,
+        shots,
+        device_parameters_class(
+            paradigmParameters=GateModelParameters(qubitCount=circuit.qubit_count)
+        ),
+        tags,
+    )
+
+
 def test_init_new_thread(aws_session, arn):
     tasks_list = []
     threading.Thread(target=_init_and_add_to_list, args=(aws_session, arn, tasks_list)).start()
@@ -374,18 +405,19 @@ def _init_and_add_to_list(aws_session, arn, task_list):
 
 
 def _assert_create_quantum_task_called_with(
-    aws_session, arn, task_description, s3_results_prefix, shots, device_parameters
+    aws_session, arn, task_description, s3_results_prefix, shots, device_parameters, tags=None
 ):
-    aws_session.create_quantum_task.assert_called_with(
-        **{
-            "deviceArn": arn,
-            "outputS3Bucket": s3_results_prefix[0],
-            "outputS3KeyPrefix": s3_results_prefix[1],
-            "action": task_description.to_ir().json(),
-            "deviceParameters": device_parameters.json(),
-            "shots": shots,
-        }
-    )
+    test_kwargs = {
+        "deviceArn": arn,
+        "outputS3Bucket": s3_results_prefix[0],
+        "outputS3KeyPrefix": s3_results_prefix[1],
+        "action": task_description.to_ir().json(),
+        "deviceParameters": device_parameters.json(),
+        "shots": shots,
+    }
+    if tags is not None:
+        test_kwargs.update({"tags": tags})
+    aws_session.create_quantum_task.assert_called_with(**test_kwargs)
 
 
 def _mock_metadata(aws_session, state):


### PR DESCRIPTION
*Issue #, if available:*
Add tags parameter to create quantum task

*Description of changes:*
As part of integration with tags for braket, the create method accepts tags as a parameter. Adding the same here

*Testing done:*
Unit tests and Integration Tests succeeded

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
