### PR TITLE
Fix: Use the user-provided max_workers when fetching batched results

### DIFF
--- a/src/braket/aws/aws_quantum_task_batch.py
+++ b/src/braket/aws/aws_quantum_task_batch.py
@@ -96,6 +96,8 @@ class AwsQuantumTaskBatch:
         self._results = None
         self._unsuccessful = set()
 
+        self._max_workers = max_workers
+
     @staticmethod
     def _execute(
         aws_session,
@@ -189,9 +191,7 @@ class AwsQuantumTaskBatch:
         """
         if self._results and not retry:
             return list(self._results)
-        with ThreadPoolExecutor(
-            max_workers=AwsQuantumTaskBatch.MAX_CONNECTIONS_DEFAULT
-        ) as executor:
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             result_futures = [
                 executor.submit(AwsQuantumTaskBatch._get_task_result, task, self._unsuccessful)
                 for task in self._tasks


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the user-provided max_workers when fetching batched results
*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
