### PR TITLE
Fix: Change AwsQuantumTaskBatch.results() to take in the keyword use_cached_value instead of retry.

### DIFF
--- a/src/braket/aws/aws_quantum_task_batch.py
+++ b/src/braket/aws/aws_quantum_task_batch.py
@@ -173,7 +173,7 @@ class AwsQuantumTaskBatch:
             time.sleep(poll_interval_seconds)
         return task
 
-    def results(self, fail_unsuccessful=False, retry=False):
+    def results(self, fail_unsuccessful=False, use_cached_value=True):
         """Retrieves the result of every task in the batch.
 
         Polling for results happens in parallel; this method returns when all tasks
@@ -182,14 +182,14 @@ class AwsQuantumTaskBatch:
         Args:
             fail_unsuccessful (bool): If set to True, this method will fail
                 if any task in the batch is in the FAILED or CANCELLED state.
-            retry (bool): Whether to refetch the results from S3,
-                even when results have already been cached. Default: False
+            use_cached_value (bool): If False, will refetch the results from S3,
+                even when results have already been cached. Default: True
 
         Returns:
             List[AwsQuantumTask]: The results of all of the tasks in the batch.
                 FAILED or CANCELLED tasks will have a result of None
         """
-        if self._results and not retry:
+        if self._results and use_cached_value:
             return list(self._results)
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             result_futures = [

--- a/test/unit_tests/braket/aws/test_aws_quantum_task_batch.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task_batch.py
@@ -73,7 +73,7 @@ def test_unsuccessful(mock_create):
     assert batch.results(fail_unsuccessful=True) == [None]  # Result is cached
     batch._unsuccessful = set()
     with pytest.raises(RuntimeError):
-        batch.results(fail_unsuccessful=True, retry=True)
+        batch.results(fail_unsuccessful=True, use_cached_value=False)
     assert batch.unsuccessful == {task_id}
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`AwsQuantumTaskBatch.results()` currently takes in a keyword `retry` that indicates whether the results are to be refetched from S3. This is misleading because it could suggest that failed tasks will be retried (they are not), and also doesn't match our previous use of `use_cached_value` in `AwsQuantumTask` to indicate whether cached results should be used or not.

This PR changes the method argument to use `use_cached_value` instead. Unfortunately, it is a breaking change (if used as a positional argument, the boolean value will need to be flipped).

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
