### PR TITLE
Fix: Move defaults for max_parallel in AwsQuantumTaskBatch to AwsDevice

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -58,6 +58,8 @@ class AwsDevice(Device):
     DEFAULT_SHOTS_QPU = 1000
     DEFAULT_SHOTS_SIMULATOR = 0
 
+    DEFAULT_MAX_PARALLEL = 10
+
     def __init__(self, arn: str, aws_session: Optional[AwsSession] = None):
         """
         Args:
@@ -160,7 +162,7 @@ class AwsDevice(Device):
         task_specifications: List[Union[Circuit, Problem]],
         s3_destination_folder: AwsSession.S3DestinationFolder,
         shots: Optional[int] = None,
-        max_parallel: int = AwsQuantumTaskBatch.MAX_PARALLEL_DEFAULT,
+        max_parallel: Optional[int] = None,
         max_connections: int = AwsQuantumTaskBatch.MAX_CONNECTIONS_DEFAULT,
         poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
         poll_interval_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
@@ -201,7 +203,7 @@ class AwsDevice(Device):
             task_specifications,
             s3_destination_folder,
             shots if shots is not None else self._default_shots,
-            max_parallel=max_parallel,
+            max_parallel=max_parallel if max_parallel is not None else self._default_max_parallel,
             max_workers=max_connections,
             poll_timeout_seconds=poll_timeout_seconds,
             poll_interval_seconds=poll_interval_seconds,
@@ -295,6 +297,10 @@ class AwsDevice(Device):
         return (
             AwsDevice.DEFAULT_SHOTS_QPU if "qpu" in self.arn else AwsDevice.DEFAULT_SHOTS_SIMULATOR
         )
+
+    @property
+    def _default_max_parallel(self):
+        return AwsDevice.DEFAULT_MAX_PARALLEL
 
     @staticmethod
     def _aws_session_for_device(device_arn: str, aws_session: Optional[AwsSession]) -> AwsSession:

--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -177,7 +177,7 @@ class AwsDevice(Device):
             s3_destination_folder: The S3 location to save the tasks' results
             shots (int, optional): The number of times to run the circuit or annealing problem.
                 Default is 1000 for QPUs and 0 for simulators.
-            max_parallel (int): The maximum number of tasks to run on AWS in parallel.
+            max_parallel (int, optional): The maximum number of tasks to run on AWS in parallel.
                 Batch creation will fail if this value is greater than the maximum allowed
                 concurrent tasks on the device. Default: 10
             max_connections (int): The maximum number of connections in the Boto3 connection pool.

--- a/src/braket/aws/aws_quantum_task_batch.py
+++ b/src/braket/aws/aws_quantum_task_batch.py
@@ -35,7 +35,6 @@ class AwsQuantumTaskBatch:
     since results will not be available until the window opens.
     """
 
-    MAX_PARALLEL_DEFAULT = 10
     MAX_CONNECTIONS_DEFAULT = 100
     MAX_RETRIES = 3
 
@@ -46,7 +45,7 @@ class AwsQuantumTaskBatch:
         task_specifications: List[Union[Circuit, Problem]],
         s3_destination_folder: AwsSession.S3DestinationFolder,
         shots: int,
-        max_parallel: int = MAX_PARALLEL_DEFAULT,
+        max_parallel: int,
         max_workers: int = MAX_CONNECTIONS_DEFAULT,
         poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
         poll_interval_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
@@ -69,7 +68,7 @@ class AwsQuantumTaskBatch:
                 will compute the exact results based on the task specification.
             max_parallel (int): The maximum number of tasks to run on AWS in parallel.
                 Batch creation will fail if this value is greater than the maximum allowed
-                concurrent tasks on the device. Default: 10
+                concurrent tasks on the device.
             max_workers (int): The maximum number of thread pool workers. Default: 100
             poll_timeout_seconds (float): The polling timeout for AwsQuantumTask.result(),
                 in seconds. Default: 5 days.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move the defaults for the `max_parallel` keyword for task batches to `AwsDevice`.
This will allow setting device-dependent defaults, like we currently do for `shots`.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
