### PR TITLE
fix: Use current region for simulators in get_devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ print(batch.results()[0].measurement_counts)  # The result of the first task in 
 ```
 
 ### Available Simulators
-Amazon Braket provides access to two types of simulators: the fully managed simulator, available through the Amazon Braket service, and the local simulator that is part of the Amazon Braket SDK.
+Amazon Braket provides access to two types of simulators: fully managed simulators, available through the Amazon Braket service, and the local simulator that is part of the Amazon Braket SDK.
 
 - Fully managed simulators offer high-performance circuit simulations. These simulators can handle circuits larger than circuits that run on quantum hardware. For example, the SV1 state vector simulator shown in the previous examples requires approximately 1 or 2 hours to complete a 34-qubit, dense, and square circuit (circuit depth = 34), depending on the type of gates used and other factors. For a list of available simulators and their features, consult the [Amazon Braket Developer Guide](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html).
 

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -39,15 +39,20 @@ def qubit_ordering_testing(device: Device, run_kwargs: Dict[str, Any]):
     assert result.measurement_counts.most_common(1)[0][0] == "001"
 
 
-def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
+def no_result_types_testing(
+    circuit: Circuit, device: Device, run_kwargs: Dict[str, Any], expected: Dict[str, float]
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
-    bell = Circuit().h(0).cnot(0, 1)
-    result = device.run(bell, **run_kwargs).result()
-
-    assert np.allclose(result.measurement_probabilities["00"], 0.5, **tol)
-    assert np.allclose(result.measurement_probabilities["11"], 0.5, **tol)
+    result = device.run(circuit, **run_kwargs).result()
+    probabilities = result.measurement_probabilities
+    for bitstring in probabilities:
+        assert np.allclose(probabilities[bitstring], expected[bitstring], **tol)
     assert len(result.measurements) == shots
+
+
+def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
+    no_result_types_testing(Circuit().h(0).cnot(0, 1), device, run_kwargs, {"00": 0.5, "11": 0.5})
 
 
 def result_types_observable_not_in_instructions(device: Device, run_kwargs: Dict[str, Any]):

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -35,18 +35,12 @@ from gate_model_device_testing_utils import (
 from braket.aws import AwsDevice
 
 SHOTS = 8000
-SIMULATOR_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+SV1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+SIMULATOR_ARNS = [SV1_ARN]
+ARNS_WITH_SHOTS = [(SV1_ARN, SHOTS), (SV1_ARN, 0)]
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
-def test_multithreaded_bell_pair(simulator_arn, aws_session, s3_destination_folder):
-    device = AwsDevice(simulator_arn, aws_session)
-    multithreaded_bell_pair_testing(
-        device, {"shots": SHOTS, "s3_destination_folder": s3_destination_folder}
-    )
-
-
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_no_result_types_bell_pair(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     no_result_types_bell_pair_testing(
@@ -54,13 +48,13 @@ def test_no_result_types_bell_pair(simulator_arn, aws_session, s3_destination_fo
     )
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_qubit_ordering(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     qubit_ordering_testing(device, {"shots": SHOTS, "s3_destination_folder": s3_destination_folder})
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_result_types_no_shots(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_zero_shots_bell_pair_testing(
@@ -68,7 +62,7 @@ def test_result_types_no_shots(simulator_arn, aws_session, s3_destination_folder
     )
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_result_types_nonzero_shots_bell_pair(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_nonzero_shots_bell_pair_testing(
@@ -76,7 +70,7 @@ def test_result_types_nonzero_shots_bell_pair(simulator_arn, aws_session, s3_des
     )
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_result_types_bell_pair_full_probability(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_bell_pair_full_probability_testing(
@@ -84,7 +78,7 @@ def test_result_types_bell_pair_full_probability(simulator_arn, aws_session, s3_
     )
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_result_types_bell_pair_marginal_probability(
     simulator_arn, aws_session, s3_destination_folder
 ):
@@ -94,7 +88,7 @@ def test_result_types_bell_pair_marginal_probability(
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_tensor_x_y(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_x_y_testing(
@@ -102,7 +96,7 @@ def test_result_types_tensor_x_y(simulator_arn, shots, aws_session, s3_destinati
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_tensor_z_h_y(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_z_h_y_testing(
@@ -110,7 +104,7 @@ def test_result_types_tensor_z_h_y(simulator_arn, shots, aws_session, s3_destina
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_hermitian(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_hermitian_testing(
@@ -118,7 +112,7 @@ def test_result_types_hermitian(simulator_arn, shots, aws_session, s3_destinatio
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_tensor_z_z(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_z_z_testing(
@@ -126,7 +120,7 @@ def test_result_types_tensor_z_z(simulator_arn, shots, aws_session, s3_destinati
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_tensor_hermitian_hermitian(
     simulator_arn, shots, aws_session, s3_destination_folder
 ):
@@ -136,7 +130,7 @@ def test_result_types_tensor_hermitian_hermitian(
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_tensor_y_hermitian(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_y_hermitian_testing(
@@ -144,7 +138,7 @@ def test_result_types_tensor_y_hermitian(simulator_arn, shots, aws_session, s3_d
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS), (SIMULATOR_ARN, 0)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_tensor_z_hermitian(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_tensor_z_hermitian_testing(
@@ -152,7 +146,7 @@ def test_result_types_tensor_z_hermitian(simulator_arn, shots, aws_session, s3_d
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_all_selected(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     result_types_all_selected_testing(
@@ -160,7 +154,7 @@ def test_result_types_all_selected(simulator_arn, shots, aws_session, s3_destina
     )
 
 
-@pytest.mark.parametrize("simulator_arn,shots", [(SIMULATOR_ARN, SHOTS)])
+@pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_observable_not_in_instructions(
     simulator_arn, shots, aws_session, s3_destination_folder
 ):
@@ -170,7 +164,15 @@ def test_result_types_observable_not_in_instructions(
     )
 
 
-@pytest.mark.parametrize("simulator_arn", [SIMULATOR_ARN])
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
+def test_multithreaded_bell_pair(simulator_arn, aws_session, s3_destination_folder):
+    device = AwsDevice(simulator_arn, aws_session)
+    multithreaded_bell_pair_testing(
+        device, {"shots": SHOTS, "s3_destination_folder": s3_destination_folder}
+    )
+
+
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_batch_bell_pair(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
     batch_bell_pair_testing(

--- a/test/integ_tests/test_tensor_network_simulator.py
+++ b/test/integ_tests/test_tensor_network_simulator.py
@@ -1,0 +1,84 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import math
+import random
+
+import pytest
+from gate_model_device_testing_utils import no_result_types_testing
+
+from braket.aws import AwsDevice
+from braket.circuits import Circuit
+
+SHOTS = 1000
+TN1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/tn1"
+SIMULATOR_ARNS = [TN1_ARN]
+
+
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
+def test_ghz(simulator_arn, aws_session, s3_destination_folder):
+    num_qubits = 50
+    circuit = _ghz(num_qubits)
+    device = AwsDevice(simulator_arn, aws_session)
+    no_result_types_testing(
+        circuit,
+        device,
+        {"shots": SHOTS, "s3_destination_folder": s3_destination_folder},
+        {"0" * num_qubits: 0.5, "1" * num_qubits: 0.5},
+    )
+
+
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
+def test_qft_iqft_h(simulator_arn, aws_session, s3_destination_folder):
+    num_qubits = 24
+    h_qubit = random.randint(0, num_qubits)
+    circuit = _inverse_qft(_qft(Circuit().h(h_qubit), num_qubits), num_qubits)
+    device = AwsDevice(simulator_arn, aws_session)
+    no_result_types_testing(
+        circuit,
+        device,
+        {"shots": SHOTS, "s3_destination_folder": s3_destination_folder},
+        {"0" * num_qubits: 0.5, "0" * h_qubit + "1" + "0" * (num_qubits - h_qubit - 1): 0.5},
+    )
+
+
+def _ghz(num_qubits):
+    circuit = Circuit()
+    circuit.h(0)
+    for qubit in range(num_qubits - 1):
+        circuit.cnot(qubit, qubit + 1)
+    return circuit
+
+
+def _qft(circuit, num_qubits):
+    for i in range(num_qubits):
+        circuit.h(i)
+        for j in range(1, num_qubits - i):
+            circuit.cphaseshift(i + j, i, math.pi / (2 ** j))
+
+    for qubit in range(math.floor(num_qubits / 2)):
+        circuit.swap(qubit, num_qubits - qubit - 1)
+
+    return circuit
+
+
+def _inverse_qft(circuit, num_qubits):
+    for qubit in range(math.floor(num_qubits / 2)):
+        circuit.swap(qubit, num_qubits - qubit - 1)
+
+    for i in reversed(range(num_qubits)):
+        for j in reversed(range(1, num_qubits - i)):
+            circuit.cphaseshift(i + j, i, -math.pi / (2 ** j))
+        circuit.h(i)
+
+    return circuit

--- a/test/unit_tests/braket/aws/common_test_utils.py
+++ b/test/unit_tests/braket/aws/common_test_utils.py
@@ -19,7 +19,7 @@ from braket.aws import AwsQuantumTaskBatch
 DWAVE_ARN = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
 RIGETTI_ARN = "arn:aws:braket:::device/qpu/rigetti/Aspen-8"
 IONQ_ARN = "arn:aws:braket:::device/qpu/ionq/ionQdevice"
-SIMULATOR_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+SV1_ARN = "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
 
 
 class MockS3:


### PR DESCRIPTION
AwsDevice.get_devices() creates a new AwsSession object for each region
that devices can be found and then creates an AwsDevice object for each
device found, using the last AwsSession created. However, there is no
guarantee that each device even exists in the session's region.

This is fine for QPUs, since the correct region is automatically used;
this is not the case for simulators, which have been assumed to exist in
every region. TN1 does not exist in every region, get_devices() will
always fail.

This commit fixes the bug by only instantiating simulators that are
available in the current region in AwsDevice.get_devices.

Also added integ tests for TN1.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
