### PR TITLE
fix: Do not search for simulators in wrong region

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -402,10 +402,10 @@ class AwsDevice(Device):
         device_regions_set = AwsDevice._get_devices_regions_set(arns, provider_names)
         for region in device_regions_set:
             session_region = aws_session.boto_session.region_name
-            # If the region is not the same as the current region's
-            # and only simulators are requested, then search_devices
-            # will not be called at all because simulators are only
-            # retrieved for the current region
+            # If the region is not the same as the current session's region
+            # and only simulators are requested, then search_devices will not
+            # be called at all because simulators are only retrieved for the
+            # current region
             if region == session_region or types != {AwsDeviceType.SIMULATOR}:
                 session_for_region = AwsDevice._copy_aws_session(aws_session, [region])
                 # Simulators are only instantiated in the same region as the AWS session


### PR DESCRIPTION
Do not call search_devices at all if requesting simulators only and in a different region.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
