### PR TITLE
fix: Update range of random qubit in test_qft_iqft_h

### DIFF
--- a/test/integ_tests/test_tensor_network_simulator.py
+++ b/test/integ_tests/test_tensor_network_simulator.py
@@ -41,7 +41,7 @@ def test_ghz(simulator_arn, aws_session, s3_destination_folder):
 @pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_qft_iqft_h(simulator_arn, aws_session, s3_destination_folder):
     num_qubits = 24
-    h_qubit = random.randint(0, num_qubits)
+    h_qubit = random.randint(0, num_qubits - 1)
     circuit = _inverse_qft(_qft(Circuit().h(h_qubit), num_qubits), num_qubits)
     device = AwsDevice(simulator_arn, aws_session)
     no_result_types_testing(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* `random.randint(a, b)` picks a random integer `N` such that `a <= N <= b`. In case the `h_qubit` picked is 24 (in `test_qft_iqft_h`), the expected result of `"0" * num_qubits` is incorrect.
* Updated the `h_qubit` to be picked in the range [0, 24) instead.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
