### PR TITLE
change: update result_types in circuit to use hashing

### DIFF
--- a/src/braket/_sdk/_version.py
+++ b/src/braket/_sdk/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.5.3"
+__version__ = "1.5.4.dev0"

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -108,7 +108,7 @@ class Circuit:
 
         """
         self._moments: Moments = Moments()
-        self._result_types: List[ResultType] = []
+        self._result_types: Dict[ResultType] = {}
         self._qubit_observable_mapping: Dict[Union[int, Circuit._ALL_QUBITS], Observable] = {}
         self._qubit_target_mapping: Dict[int, Tuple[int]] = {}
         self._qubit_observable_set = set()
@@ -128,8 +128,8 @@ class Circuit:
 
     @property
     def result_types(self) -> List[ResultType]:
-        """List[ResultType]: Get a list of requested result types in the circuit."""
-        return self._result_types
+        """Set[ResultType]: Get a list of requested result types in the circuit."""
+        return list(self._result_types.keys())
 
     @property
     def basis_rotation_instructions(self) -> List[Instruction]:
@@ -197,7 +197,7 @@ class Circuit:
 
 
         Note: target and target_mapping will only be applied to those requested result types with
-        the attribute `target`. The result_type will be appended to the end of the list of
+        the attribute `target`. The result_type will be appended to the end of the dict keys of
         `circuit.result_types` only if it does not already exist in `circuit.result_types`
 
         Returns:
@@ -246,7 +246,7 @@ class Circuit:
         if result_type_to_add not in self._result_types:
             self._add_to_qubit_observable_mapping(result_type_to_add)
             self._add_to_qubit_observable_set(result_type_to_add)
-            self._result_types.append(result_type_to_add)
+            self._result_types[result_type_to_add] = None   # using dict as an ordered set, value is arbitrary
         return self
 
     def _add_to_qubit_observable_mapping(self, result_type: ResultType) -> None:
@@ -614,7 +614,7 @@ class Circuit:
         if isinstance(other, Circuit):
             return (
                 list(self.instructions) == list(other.instructions)
-                and self.result_types == self.result_types
+                and self.result_types == other.result_types
             )
         return NotImplemented
 

--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -125,6 +125,9 @@ class ResultType:
     def __repr__(self) -> str:
         return f"{self.name}()"
 
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
 
 class ObservableResultType(ResultType):
     """
@@ -197,3 +200,6 @@ class ObservableResultType(ResultType):
 
     def __copy__(self) -> ObservableResultType:
         return type(self)(observable=self.observable, target=self.target)
+
+    def __hash__(self) -> int:
+        return super().__hash__()

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -65,6 +65,11 @@ class StateVector(ResultType):
     def __copy__(self) -> StateVector:
         return type(self)()
 
+    # must redefine __hash__ since __eq__ is overwritten
+    # https://docs.python.org/3/reference/datamodel.html#object.__hash__
+    def __hash__(self) -> int:
+        return super().__hash__()
+
 
 ResultType.register_result_type(StateVector)
 
@@ -134,6 +139,9 @@ class Amplitude(ResultType):
 
     def __copy__(self):
         return type(self)(state=self.state)
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
 
 ResultType.register_result_type(Amplitude)
@@ -206,6 +214,9 @@ class Probability(ResultType):
 
     def __copy__(self) -> Probability:
         return type(self)(target=self.target)
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
 
 ResultType.register_result_type(Probability)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use a dict to hold the result types to speed up checking if a result type is in _result_types. result_types property still interfaces as a list. Python 3.7+ officially guarantees order for dicts, so result_types is expected to be in order.

*Testing done:*
Unit and integ tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
