### PR TITLE
change: update result_types to use hashing

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -108,7 +108,7 @@ class Circuit:
 
         """
         self._moments: Moments = Moments()
-        self._result_types: List[ResultType] = []
+        self._result_types: Dict[ResultType] = {}
         self._qubit_observable_mapping: Dict[Union[int, Circuit._ALL_QUBITS], Observable] = {}
         self._qubit_target_mapping: Dict[int, Tuple[int]] = {}
         self._qubit_observable_set = set()
@@ -129,7 +129,7 @@ class Circuit:
     @property
     def result_types(self) -> List[ResultType]:
         """List[ResultType]: Get a list of requested result types in the circuit."""
-        return self._result_types
+        return list(self._result_types.keys())
 
     @property
     def basis_rotation_instructions(self) -> List[Instruction]:
@@ -197,7 +197,7 @@ class Circuit:
 
 
         Note: target and target_mapping will only be applied to those requested result types with
-        the attribute `target`. The result_type will be appended to the end of the list of
+        the attribute `target`. The result_type will be appended to the end of the dict keys of
         `circuit.result_types` only if it does not already exist in `circuit.result_types`
 
         Returns:
@@ -246,7 +246,8 @@ class Circuit:
         if result_type_to_add not in self._result_types:
             self._add_to_qubit_observable_mapping(result_type_to_add)
             self._add_to_qubit_observable_set(result_type_to_add)
-            self._result_types.append(result_type_to_add)
+            # using dict as an ordered set, value is arbitrary
+            self._result_types[result_type_to_add] = None
         return self
 
     def _add_to_qubit_observable_mapping(self, result_type: ResultType) -> None:
@@ -614,7 +615,7 @@ class Circuit:
         if isinstance(other, Circuit):
             return (
                 list(self.instructions) == list(other.instructions)
-                and self.result_types == self.result_types
+                and self.result_types == other.result_types
             )
         return NotImplemented
 

--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -125,6 +125,9 @@ class ResultType:
     def __repr__(self) -> str:
         return f"{self.name}()"
 
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
 
 class ObservableResultType(ResultType):
     """
@@ -197,3 +200,6 @@ class ObservableResultType(ResultType):
 
     def __copy__(self) -> ObservableResultType:
         return type(self)(observable=self.observable, target=self.target)
+
+    def __hash__(self) -> int:
+        return super().__hash__()

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -65,6 +65,11 @@ class StateVector(ResultType):
     def __copy__(self) -> StateVector:
         return type(self)()
 
+    # must redefine __hash__ since __eq__ is overwritten
+    # https://docs.python.org/3/reference/datamodel.html#object.__hash__
+    def __hash__(self) -> int:
+        return super().__hash__()
+
 
 ResultType.register_result_type(StateVector)
 
@@ -134,6 +139,9 @@ class Amplitude(ResultType):
 
     def __copy__(self):
         return type(self)(state=self.state)
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
 
 ResultType.register_result_type(Amplitude)
@@ -206,6 +214,9 @@ class Probability(ResultType):
 
     def __copy__(self) -> Probability:
         return type(self)(target=self.target)
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
 
 ResultType.register_result_type(Probability)

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -182,7 +182,8 @@ class Probability(ResultType):
 
     def to_ir(self) -> ir.Probability:
         if self.target:
-            return ir.Probability.construct(targets=list(self.target))
+            # convert qubits to int as required by the ir type
+            return ir.Probability.construct(targets=[int(qubit) for qubit in self.target])
         else:
             return ir.Probability.construct()
 
@@ -262,7 +263,7 @@ class Expectation(ObservableResultType):
     def to_ir(self) -> ir.Expectation:
         if self.target:
             return ir.Expectation.construct(
-                observable=self.observable.to_ir(), targets=list(self.target)
+                observable=self.observable.to_ir(), targets=[int(qubit) for qubit in self.target]
             )
         else:
             return ir.Expectation.construct(observable=self.observable.to_ir())
@@ -329,7 +330,7 @@ class Sample(ObservableResultType):
     def to_ir(self) -> ir.Sample:
         if self.target:
             return ir.Sample.construct(
-                observable=self.observable.to_ir(), targets=list(self.target)
+                observable=self.observable.to_ir(), targets=[int(qubit) for qubit in self.target]
             )
         else:
             return ir.Sample.construct(observable=self.observable.to_ir())
@@ -397,7 +398,7 @@ class Variance(ObservableResultType):
     def to_ir(self) -> ir.Variance:
         if self.target:
             return ir.Variance.construct(
-                observable=self.observable.to_ir(), targets=list(self.target)
+                observable=self.observable.to_ir(), targets=[int(qubit) for qubit in self.target]
             )
         else:
             return ir.Variance.construct(observable=self.observable.to_ir())

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from braket.circuits import Observable, ResultType, StandardObservable
 from braket.circuits.observables import observable_from_ir
+from braket.ir.jaqcd import Expectation, Probability, Sample, Variance
 from braket.task_result import (
     AdditionalMetadata,
     GateModelTaskResult,
@@ -29,6 +30,10 @@ from braket.task_result import (
 )
 
 T = TypeVar("T")
+
+
+def rt_type_hash(rt_type):
+    return repr(dict(sorted(dict(rt_type).items(), key=lambda x: x[0])))
 
 
 @dataclass
@@ -79,8 +84,8 @@ class GateModelQuantumTaskResult:
 
     task_metadata: TaskMetadata
     additional_metadata: AdditionalMetadata
-    result_types: List[Dict[str, str]]
-    values: List[Any]
+    result_types: List[ResultTypeValue] = None
+    values: List[Any] = None
     measurements: np.ndarray = None
     measured_qubits: List[int] = None
     measurement_counts: Counter = None
@@ -88,6 +93,17 @@ class GateModelQuantumTaskResult:
     measurements_copied_from_device: bool = None
     measurement_counts_copied_from_device: bool = None
     measurement_probabilities_copied_from_device: bool = None
+
+    _result_types_indices: Dict[str, int] = None
+
+    def __post_init__(self):
+        if self._result_types_indices is None:
+            if self.result_types is not None:
+                self._result_types_indices = dict(
+                    (rt_type_hash(rt.type), i) for i, rt in enumerate(self.result_types)
+                )
+            else:
+                self._result_types_indices = {}
 
     def get_value_by_result_type(self, result_type: ResultType) -> Any:
         """
@@ -105,13 +121,14 @@ class GateModelQuantumTaskResult:
                 Result types must be added to the circuit before the circuit is run on a device.
         """
         rt_ir = result_type.to_ir()
-        for rt in self.result_types:
-            if rt_ir == rt.type:
-                return rt.value
-        raise ValueError(
-            "Result type not found in result. "
-            + "Result types must be added to circuit before circuit is run on device."
-        )
+        try:
+            result_type_index = self._result_types_indices[rt_type_hash(rt_ir)]
+            return self.values[result_type_index]
+        except KeyError:
+            raise ValueError(
+                "Result type not found in result. "
+                + "Result types must be added to circuit before circuit is run on device."
+            )
 
     def __eq__(self, other) -> bool:
         if isinstance(other, GateModelQuantumTaskResult):
@@ -318,7 +335,7 @@ class GateModelQuantumTaskResult:
     @staticmethod
     def _calculate_result_types(
         ir_string: str, measurements: np.ndarray, measured_qubits: List[int]
-    ) -> List[Dict[str, Any]]:
+    ) -> List[ResultTypeValue]:
         ir = json.loads(ir_string)
         result_types = []
         if not ir.get("results"):
@@ -332,6 +349,7 @@ class GateModelQuantumTaskResult:
                 value = GateModelQuantumTaskResult._probability_from_measurements(
                     measurements, measured_qubits, targets
                 )
+                casted_result_type = Probability(targets=targets)
             elif rt_type == "sample":
                 value = GateModelQuantumTaskResult._calculate_for_targets(
                     GateModelQuantumTaskResult._samples_from_measurements,
@@ -340,6 +358,7 @@ class GateModelQuantumTaskResult:
                     observable,
                     targets,
                 )
+                casted_result_type = Sample(targets=targets, observable=observable.to_ir())
             elif rt_type == "variance":
                 value = GateModelQuantumTaskResult._calculate_for_targets(
                     GateModelQuantumTaskResult._variance_from_measurements,
@@ -348,6 +367,7 @@ class GateModelQuantumTaskResult:
                     observable,
                     targets,
                 )
+                casted_result_type = Variance(targets=targets, observable=observable.to_ir())
             elif rt_type == "expectation":
                 value = GateModelQuantumTaskResult._calculate_for_targets(
                     GateModelQuantumTaskResult._expectation_from_measurements,
@@ -356,9 +376,10 @@ class GateModelQuantumTaskResult:
                     observable,
                     targets,
                 )
+                casted_result_type = Expectation(targets=targets, observable=observable.to_ir())
             else:
                 raise ValueError(f"Unknown result type {rt_type}")
-            result_types.append(ResultTypeValue.construct(type=result_type, value=value))
+            result_types.append(ResultTypeValue.construct(type=casted_result_type, value=value))
         return result_types
 
     @staticmethod


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

use a dict to hold the result types to speed up checking if a result type is in _result_types. result_types property still interfaces as a list. Python 3.7+ officially guarantees order for dicts, so result_types is expected to be in order


*Testing done:*

tox testing


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
