### PR TITLE
add placeholder methods for result types to enable ide compatibility

### DIFF
--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -125,6 +125,26 @@ class ResultType:
     def __repr__(self) -> str:
         return f"{self.name}()"
 
+    @classmethod
+    def StateVector(cls):
+        raise NotImplementedError("Result type not registered")
+
+    @classmethod
+    def Amplitude(cls, state: List[str]):
+        raise NotImplementedError("Result type not registered")
+
+    @classmethod
+    def Probability(cls, target: QubitSetInput = None):
+        raise NotImplementedError("Result type not registered")
+
+    @classmethod
+    def Expectation(cls, observable: Observable, target: QubitSetInput = None):
+        raise NotImplementedError("Result type not registered")
+
+    @classmethod
+    def Sample(cls, observable: Observable, target: QubitSetInput = None):
+        raise NotImplementedError("Result type not registered")
+
 
 class ObservableResultType(ResultType):
     """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, ResultType.StateVector() for example would not be recognized as valid by the IDE, since result type constructors as ResultType classmethods are defined dynamically. Adding placeholder classmethods for established result types so the IDE recognizes them as valid.

*Testing done:*

existing tox and manual verification that result types work as previously (no logic was changed)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
