### PR TITLE
fix: ensure AngledGate casts its angle argument to float so it can be…

### DIFF
--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -40,7 +40,7 @@ class AngledGate(Gate):
         super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
         if angle is None:
             raise ValueError("angle must not be None")
-        self._angle = angle
+        self._angle = float(angle)  # explicit casting in case angle is e.g. np.float32
 
     @property
     def angle(self) -> float:

--- a/test/unit_tests/braket/circuits/test_angled_gate.py
+++ b/test/unit_tests/braket/circuits/test_angled_gate.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import re
+
 import numpy as np
 import pytest
 from pydantic import BaseModel
@@ -50,7 +52,7 @@ def test_angle_setter(angled_gate):
 
 def test_np_float_angle_json():
     angled_gate = AngledGate(angle=np.float32(0.15), qubit_count=1, ascii_symbols=["foo"])
-    assert (
-        BaseModel.construct(target=[0], angle=angled_gate.angle).json()
-        == '{"target": [0], "angle": 0.15000000596046448}'
-    )
+    angled_gate_json = BaseModel.construct(target=[0], angle=angled_gate.angle).json()
+    match = re.match(r'\{"target": \[0], "angle": (\d*\.?\d*)}', angled_gate_json)
+    angle_value = float(match.group(1))
+    assert np.isclose(angle_value, 0.15)

--- a/test/unit_tests/braket/circuits/test_angled_gate.py
+++ b/test/unit_tests/braket/circuits/test_angled_gate.py
@@ -11,7 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import numpy as np
 import pytest
+from pydantic import BaseModel
 
 from braket.circuits import AngledGate, Gate
 
@@ -44,3 +46,11 @@ def test_getters():
 @pytest.mark.xfail(raises=AttributeError)
 def test_angle_setter(angled_gate):
     angled_gate.angle = 0.14
+
+
+def test_np_float_angle_json():
+    angled_gate = AngledGate(angle=np.float32(0.15), qubit_count=1, ascii_symbols=["foo"])
+    assert (
+        BaseModel.construct(target=[0], angle=angled_gate.angle).json()
+        == '{"target": [0], "angle": 0.15000000596046448}'
+    )

--- a/test/unit_tests/braket/circuits/test_angled_gate.py
+++ b/test/unit_tests/braket/circuits/test_angled_gate.py
@@ -55,4 +55,4 @@ def test_np_float_angle_json():
     angled_gate_json = BaseModel.construct(target=[0], angle=angled_gate.angle).json()
     match = re.match(r'\{"target": \[0], "angle": (\d*\.?\d*)}', angled_gate_json)
     angle_value = float(match.group(1))
-    assert np.isclose(angle_value, 0.15)
+    assert np.isclose(angle_value, angled_gate.angle)

--- a/test/unit_tests/braket/circuits/test_angled_gate.py
+++ b/test/unit_tests/braket/circuits/test_angled_gate.py
@@ -55,4 +55,4 @@ def test_np_float_angle_json():
     angled_gate_json = BaseModel.construct(target=[0], angle=angled_gate.angle).json()
     match = re.match(r'\{"target": \[0], "angle": (\d*\.?\d*)}', angled_gate_json)
     angle_value = float(match.group(1))
-    assert np.isclose(angle_value, angled_gate.angle)
+    assert angle_value == angled_gate.angle


### PR DESCRIPTION
… serialized to json

*Issue #, if available:*

https://github.com/aws/amazon-braket-sdk-python/issues/200

*Description of changes:*

Cast angle argument to float so it can be serialized to json (previously np.float32 would throw an error)

*Testing done:*

Added unit test to test_angled_gate where angle is instantiated from np.float32

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
