### PR TITLE
change: More scalable eigenvalue calculation

### DIFF
--- a/src/braket/circuits/observable.py
+++ b/src/braket/circuits/observable.py
@@ -19,7 +19,6 @@ import numpy as np
 
 from braket.circuits.gate import Gate
 from braket.circuits.quantum_operator import QuantumOperator
-from braket.circuits.quantum_operator_helpers import get_pauli_eigenvalues
 
 
 class Observable(QuantumOperator):
@@ -39,7 +38,7 @@ class Observable(QuantumOperator):
         raise NotImplementedError
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         """Tuple[Gate]: Returns the basis rotation gates for this observable."""
         raise NotImplementedError
 
@@ -91,13 +90,13 @@ class Observable(QuantumOperator):
 
 class StandardObservable(Observable):
     """
-    Class `StandardObservable` to represent a standard quantum observable with
-    eigenvalues of +/-1, each with a multiplicity of 1.
+    Class `StandardObservable` to represent a Pauli-like quantum observable with
+    eigenvalues of (+1, -1), each with a multiplicity of 1.
     """
 
-    def __init__(self, qubit_count: int, ascii_symbols: Sequence[str]):
-        super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
-        self._eigenvalues = tuple(get_pauli_eigenvalues(qubit_count))  # immutable
+    def __init__(self, ascii_symbols: Sequence[str]):
+        super().__init__(qubit_count=1, ascii_symbols=ascii_symbols)
+        self._eigenvalues = (1.0, -1.0)
 
     @property
     def eigenvalues(self) -> np.ndarray:

--- a/src/braket/circuits/observable.py
+++ b/src/braket/circuits/observable.py
@@ -48,6 +48,20 @@ class Observable(QuantumOperator):
         """np.ndarray: Returns the eigenvalues of this observable."""
         raise NotImplementedError
 
+    def eigenvalue(self, index: int) -> float:
+        """Returns the the eigenvalue of this observable at the given index.
+
+        The eigenvalues are ordered by their corresponding computational basis state
+        after diagonalization.
+
+        Args:
+            index: The index of the desired eigenvalue
+
+        Returns:
+            float: The `index`th eigenvalue of the observable.
+        """
+        raise NotImplementedError
+
     @classmethod
     def register_observable(cls, observable: Observable) -> None:
         """Register an observable implementation by adding it into the `Observable` class.
@@ -83,7 +97,11 @@ class StandardObservable(Observable):
 
     def __init__(self, qubit_count: int, ascii_symbols: Sequence[str]):
         super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
+        self._eigenvalues = tuple(get_pauli_eigenvalues(qubit_count))  # immutable
 
     @property
     def eigenvalues(self) -> np.ndarray:
-        return get_pauli_eigenvalues(self.qubit_count)
+        return np.array(self._eigenvalues)
+
+    def eigenvalue(self, index: int) -> float:
+        return self._eigenvalues[index]

--- a/src/braket/circuits/observable.py
+++ b/src/braket/circuits/observable.py
@@ -96,7 +96,7 @@ class StandardObservable(Observable):
 
     def __init__(self, ascii_symbols: Sequence[str]):
         super().__init__(qubit_count=1, ascii_symbols=ascii_symbols)
-        self._eigenvalues = (1.0, -1.0)
+        self._eigenvalues = (1.0, -1.0)  # immutable
 
     @property
     def eigenvalues(self) -> np.ndarray:

--- a/src/braket/circuits/observable.py
+++ b/src/braket/circuits/observable.py
@@ -91,7 +91,7 @@ class Observable(QuantumOperator):
 class StandardObservable(Observable):
     """
     Class `StandardObservable` to represent a Pauli-like quantum observable with
-    eigenvalues of (+1, -1), each with a multiplicity of 1.
+    eigenvalues of (+1, -1).
     """
 
     def __init__(self, ascii_symbols: Sequence[str]):

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -314,7 +314,7 @@ class Hermitian(Observable):
         eigendecomposition = Hermitian._get_eigendecomposition(self._matrix)
         self._eigenvalues = eigendecomposition["eigenvalues"]
         self._diagonalizing_gates = (
-            Gate.Unitary(matrix=eigendecomposition["eigenvectors_conj_t"]),
+            Gate.Unitary(matrix=eigendecomposition["eigenvectors"].conj().T),
         )
 
         super().__init__(qubit_count=qubit_count, ascii_symbols=[display_name] * qubit_count)
@@ -360,10 +360,8 @@ class Hermitian(Observable):
         if mat_key not in Hermitian._eigenpairs:
             eigenvalues, eigenvectors = np.linalg.eigh(matrix)
             eigenvalues.setflags(write=False)
-            eigenvectors_conj_t = eigenvectors.conj().T
-            eigenvectors_conj_t.setflags(write=False)
             Hermitian._eigenpairs[mat_key] = {
-                "eigenvectors_conj_t": eigenvectors_conj_t,
+                "eigenvectors": eigenvectors,
                 "eigenvalues": eigenvalues,
             }
         return Hermitian._eigenpairs[mat_key]

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -314,7 +314,7 @@ class Hermitian(Observable):
         eigendecomposition = Hermitian._get_eigendecomposition(self._matrix)
         self._eigenvalues = eigendecomposition["eigenvalues"]
         self._diagonalizing_gates = (
-            Gate.Unitary(matrix=eigendecomposition["eigenvectors"].conj().T),
+            Gate.Unitary(matrix=eigendecomposition["eigenvectors_conj_t"]),
         )
 
         super().__init__(qubit_count=qubit_count, ascii_symbols=[display_name] * qubit_count)
@@ -338,6 +338,9 @@ class Hermitian(Observable):
     def eigenvalues(self):
         return self._eigenvalues
 
+    def eigenvalue(self, index: int) -> float:
+        return self._eigenvalues[index]
+
     @staticmethod
     def _get_eigendecomposition(matrix) -> Dict[str, np.ndarray]:
         """
@@ -357,9 +360,11 @@ class Hermitian(Observable):
         if mat_key not in Hermitian._eigenpairs:
             eigenvalues, eigenvectors = np.linalg.eigh(matrix)
             eigenvalues.setflags(write=False)
+            eigenvectors_conj_t = eigenvectors.conj().T
+            eigenvectors_conj_t.setflags(write=False)
             Hermitian._eigenpairs[mat_key] = {
-                "eigenvalues": eigenvalues.real,  # guaranteed to be real
-                "eigenvectors": eigenvectors,
+                "eigenvectors_conj_t": eigenvectors_conj_t,
+                "eigenvalues": eigenvalues,
             }
         return Hermitian._eigenpairs[mat_key]
 

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -78,7 +78,7 @@ class I(Observable):  # noqa: E742, E261
         return np.array([1, 1])
 
     def eigenvalue(self, index: int) -> float:
-        return 1
+        return 1.
 
 
 Observable.register_observable(I)

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -78,7 +78,7 @@ class I(Observable):  # noqa: E742, E261
         return np.array([1, 1])
 
     def eigenvalue(self, index: int) -> float:
-        return 1.
+        return 1.0
 
 
 Observable.register_observable(I)

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -35,9 +35,9 @@ class H(StandardObservable):
     def __init__(self):
         """
         Examples:
-            >>> Observable.I()
+            >>> Observable.H()
         """
-        super().__init__(qubit_count=1, ascii_symbols=["H"])
+        super().__init__(ascii_symbols=["H"])
 
     def to_ir(self) -> List[str]:
         return ["h"]
@@ -46,7 +46,7 @@ class H(StandardObservable):
         return 1.0 / np.sqrt(2.0) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex)
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         return tuple([Gate.Ry(-math.pi / 4)])
 
 
@@ -70,7 +70,7 @@ class I(Observable):  # noqa: E742, E261
         return np.array([[1.0, 0.0], [0.0, 1.0]], dtype=complex)
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         return ()
 
     @property
@@ -92,7 +92,7 @@ class X(StandardObservable):
         Examples:
             >>> Observable.X()
         """
-        super().__init__(qubit_count=1, ascii_symbols=["X"])
+        super().__init__(ascii_symbols=["X"])
 
     def to_ir(self) -> List[str]:
         return ["x"]
@@ -101,7 +101,7 @@ class X(StandardObservable):
         return np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex)
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         return tuple([Gate.H()])
 
 
@@ -116,7 +116,7 @@ class Y(StandardObservable):
         Examples:
             >>> Observable.Y()
         """
-        super().__init__(qubit_count=1, ascii_symbols=["Y"])
+        super().__init__(ascii_symbols=["Y"])
 
     def to_ir(self) -> List[str]:
         return ["y"]
@@ -125,7 +125,7 @@ class Y(StandardObservable):
         return np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=complex)
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         return tuple([Gate.Z(), Gate.S(), Gate.H()])
 
 
@@ -140,7 +140,7 @@ class Z(StandardObservable):
         Examples:
             >>> Observable.Z()
         """
-        super().__init__(qubit_count=1, ascii_symbols=["Z"])
+        super().__init__(ascii_symbols=["Z"])
 
     def to_ir(self) -> List[str]:
         return ["z"]
@@ -149,7 +149,7 @@ class Z(StandardObservable):
         return np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         return ()
 
 
@@ -198,7 +198,7 @@ class TensorProduct(Observable):
         return ir
 
     @property
-    def factors(self) -> Tuple[Observable]:
+    def factors(self) -> Tuple[Observable, ...]:
         """ Tuple[Observable]: The observables that comprise this tensor product."""
         return self._factors
 
@@ -206,7 +206,7 @@ class TensorProduct(Observable):
         return functools.reduce(np.kron, [obs.to_matrix() for obs in self.factors])
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         gates = []
         for obs in self.factors:
             gates.extend(obs.basis_rotation_gates)
@@ -331,7 +331,7 @@ class Hermitian(Observable):
         return self.matrix_equivalence(other)
 
     @property
-    def basis_rotation_gates(self) -> Tuple[Gate]:
+    def basis_rotation_gates(self) -> Tuple[Gate, ...]:
         return self._diagonalizing_gates
 
     @property

--- a/src/braket/circuits/quantum_operator.py
+++ b/src/braket/circuits/quantum_operator.py
@@ -80,7 +80,7 @@ class QuantumOperator(Operator):
         """
         raise NotImplementedError("to_ir has not been implemented yet.")
 
-    def to_matrix(self, *args, **kwargs) -> Any:
+    def to_matrix(self, *args, **kwargs) -> np.ndarray:
         """Returns a matrix representation of the quantum operator
 
         Returns:

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Counter, Dict, List, Optional, TypeVar, Union
 import numpy as np
 
 from braket.circuits import Observable, ResultType, StandardObservable
-from braket.circuits.observables import observable_from_ir
+from braket.circuits.observables import TensorProduct, observable_from_ir
 from braket.ir.jaqcd import Expectation, Probability, Sample, Variance
 from braket.task_result import (
     AdditionalMetadata,
@@ -474,7 +474,9 @@ class GateModelQuantumTaskResult:
         # Replace the basis state in the computational basis with the correct eigenvalue.
         # Extract only the columns of the basis samples required based on ``targets``.
         indices = GateModelQuantumTaskResult._measurements_base_10(measurements)
-        return np.array([observable.eigenvalue(index).real for index in indices])
+        if isinstance(observable, TensorProduct):
+            return np.array([observable.eigenvalue(index).real for index in indices])
+        return observable.eigenvalues[indices].real
 
     @staticmethod
     def _result_type_hash(rt_type):

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -474,7 +474,7 @@ class GateModelQuantumTaskResult:
         # Replace the basis state in the computational basis with the correct eigenvalue.
         # Extract only the columns of the basis samples required based on ``targets``.
         indices = GateModelQuantumTaskResult._measurements_base_10(measurements)
-        return observable.eigenvalues[indices].real
+        return np.array([observable.eigenvalue(index).real for index in indices])
 
     @staticmethod
     def _result_type_hash(rt_type):

--- a/test/unit_tests/braket/circuits/test_observable.py
+++ b/test/unit_tests/braket/circuits/test_observable.py
@@ -24,7 +24,7 @@ def observable():
 
 @pytest.fixture
 def standard_observable():
-    return StandardObservable(qubit_count=1, ascii_symbols=["foo"])
+    return StandardObservable(ascii_symbols=["foo"])
 
 
 def test_is_operator(observable):

--- a/test/unit_tests/braket/circuits/test_observable.py
+++ b/test/unit_tests/braket/circuits/test_observable.py
@@ -95,6 +95,11 @@ def test_eigenvalues_not_implemented_by_default(observable):
     observable.eigenvalues
 
 
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_eigenvalue_not_implemented_by_default(observable):
+    observable.eigenvalue(0)
+
+
 def test_str(observable):
     expected = "{}('qubit_count': {})".format(observable.name, observable.qubit_count)
     assert str(observable) == expected

--- a/test/unit_tests/braket/circuits/test_observables.py
+++ b/test/unit_tests/braket/circuits/test_observables.py
@@ -78,11 +78,7 @@ def test_basis_rotation_gates(
     "testobject,gateobject,expected_ir,basis_rotation_gates,eigenvalues", testdata
 )
 def test_eigenvalues(testobject, gateobject, expected_ir, basis_rotation_gates, eigenvalues):
-    assert np.allclose(testobject.eigenvalues, eigenvalues)
-    assert np.allclose(
-        np.array([testobject.eigenvalue(i) for i in range(2 ** testobject.qubit_count)]),
-        eigenvalues,
-    )
+    compare_eigenvalues(testobject, eigenvalues)
 
 
 @pytest.mark.parametrize(
@@ -127,7 +123,7 @@ def test_hermitian_to_ir():
     ],
 )
 def test_hermitian_eigenvalues(matrix, eigenvalues):
-    assert np.allclose(Observable.Hermitian(matrix=matrix).eigenvalues, eigenvalues)
+    compare_eigenvalues(Observable.Hermitian(matrix=matrix), eigenvalues)
 
 
 @pytest.mark.parametrize(
@@ -213,7 +209,7 @@ def test_tensor_product_matmul_observable():
 
 
 @pytest.mark.xfail(raises=ValueError)
-def test_tensor_product_eigenvalue():
+def test_tensor_product_eigenvalue_index_out_of_bounds():
     obs = Observable.TensorProduct([Observable.Z(), Observable.I(), Observable.X()])
     obs.eigenvalue(8)
 
@@ -246,18 +242,10 @@ def test_tensor_product_rmatmul_value_error():
     ],
 )
 def test_tensor_product_eigenvalues(observable, eigenvalues):
-    assert np.allclose(observable.eigenvalues, eigenvalues)
-    assert np.allclose(
-        np.array([observable.eigenvalue(i) for i in range(2 ** observable.qubit_count)]),
-        eigenvalues,
-    )
+    compare_eigenvalues(observable, eigenvalues)
     # Test caching
     observable._factors = ()
-    assert np.allclose(observable.eigenvalues, eigenvalues)
-    assert np.allclose(
-        np.array([observable.eigenvalue(i) for i in range(2 ** observable.qubit_count)]),
-        eigenvalues,
-    )
+    compare_eigenvalues(observable, eigenvalues)
 
 
 @pytest.mark.parametrize(
@@ -288,3 +276,11 @@ def test_observable_from_ir_tensor_product():
 @pytest.mark.xfail(raises=ValueError)
 def test_observable_from_ir_tensor_product_value_error():
     observable_from_ir(["z", "i", "foo"])
+
+
+def compare_eigenvalues(observable, expected):
+    assert np.allclose(observable.eigenvalues, expected)
+    assert np.allclose(
+        np.array([observable.eigenvalue(i) for i in range(2 ** observable.qubit_count)]),
+        expected,
+    )

--- a/test/unit_tests/braket/circuits/test_observables.py
+++ b/test/unit_tests/braket/circuits/test_observables.py
@@ -239,6 +239,14 @@ def test_tensor_product_rmatmul_value_error():
         (Observable.X() @ Observable.Y(), np.array([1, -1, -1, 1])),
         (Observable.X() @ Observable.Y() @ Observable.Z(), np.array([1, -1, -1, 1, -1, 1, 1, -1])),
         (Observable.X() @ Observable.Y() @ Observable.I(), np.array([1, 1, -1, -1, -1, -1, 1, 1])),
+        (
+            Observable.X()
+            @ Observable.Hermitian(
+                np.array([[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+            )
+            @ Observable.Y(),
+            np.array([-1, 1, -1, 1, 1, -1, 1, -1, 1, -1, 1, -1, -1, 1, -1, 1]),
+        ),
     ],
 )
 def test_tensor_product_eigenvalues(observable, eigenvalues):

--- a/test/unit_tests/braket/circuits/test_observables.py
+++ b/test/unit_tests/braket/circuits/test_observables.py
@@ -79,6 +79,10 @@ def test_basis_rotation_gates(
 )
 def test_eigenvalues(testobject, gateobject, expected_ir, basis_rotation_gates, eigenvalues):
     assert np.allclose(testobject.eigenvalues, eigenvalues)
+    assert np.allclose(
+        np.array([testobject.eigenvalue(i) for i in range(2 ** testobject.qubit_count)]),
+        eigenvalues,
+    )
 
 
 @pytest.mark.parametrize(
@@ -209,6 +213,12 @@ def test_tensor_product_matmul_observable():
 
 
 @pytest.mark.xfail(raises=ValueError)
+def test_tensor_product_eigenvalue():
+    obs = Observable.TensorProduct([Observable.Z(), Observable.I(), Observable.X()])
+    obs.eigenvalue(8)
+
+
+@pytest.mark.xfail(raises=ValueError)
 def test_tensor_product_value_error():
     Observable.TensorProduct([Observable.Z(), Observable.I(), Observable.X()]) @ "a"
 
@@ -237,6 +247,17 @@ def test_tensor_product_rmatmul_value_error():
 )
 def test_tensor_product_eigenvalues(observable, eigenvalues):
     assert np.allclose(observable.eigenvalues, eigenvalues)
+    assert np.allclose(
+        np.array([observable.eigenvalue(i) for i in range(2 ** observable.qubit_count)]),
+        eigenvalues,
+    )
+    # Test caching
+    observable._factors = ()
+    assert np.allclose(observable.eigenvalues, eigenvalues)
+    assert np.allclose(
+        np.array([observable.eigenvalue(i) for i in range(2 ** observable.qubit_count)]),
+        eigenvalues,
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
@@ -188,9 +188,11 @@ test_ir_results = [
         ],
     ),
     (jaqcd.Expectation(targets=[1], observable=["z"]), 0.2),
+    (jaqcd.Expectation(targets=[1], observable=[[[[-1, 0], [0, 0]], [[0, 0], [1, 0]]]]), -0.2),
     (jaqcd.Expectation(targets=[1, 2], observable=["z", "y"]), 0.6),
     (jaqcd.Expectation(observable=["z"]), [0.4, 0.2, -0.2, -0.4]),
     (jaqcd.Variance(targets=[1], observable=["z"]), 0.96),
+    (jaqcd.Variance(targets=[1], observable=[[[[-1, 0], [0, 0]], [[0, 0], [1, 0]]]]), 0.96),
     (jaqcd.Variance(targets=[1, 2], observable=["z", "y"]), 0.64),
     (jaqcd.Variance(observable=["z"]), [0.84, 0.96, 0.96, 0.84]),
 ]


### PR DESCRIPTION
Currently, whenever an observable is instantiated, _all_ of its
eigenvalues are calculated and stored in an array. This means a
tensor product on n qubits will instantiate an array of length 2^n,
which obviously isn't scalable for large n.

This change calculates the eigenvalues only at desired indices.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
