### PR TITLE
fix: AngledGate equality checks angles

### DIFF
--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import math
 from typing import Sequence
 
 from braket.circuits.gate import Gate
@@ -51,6 +52,11 @@ class AngledGate(Gate):
             angle (float): The angle of the gate in radians
         """
         return self._angle
+
+    def __eq__(self, other):
+        if isinstance(other, AngledGate):
+            return self.name == other.name and math.isclose(self.angle, other.angle)
+        return NotImplemented
 
     def __repr__(self):
         return f"{self.name}('angle': {self.angle}, 'qubit_count': {self.qubit_count})"

--- a/test/unit_tests/braket/circuits/test_angled_gate.py
+++ b/test/unit_tests/braket/circuits/test_angled_gate.py
@@ -50,6 +50,17 @@ def test_angle_setter(angled_gate):
     angled_gate.angle = 0.14
 
 
+def test_equality(angled_gate):
+    gate = AngledGate(angle=0.15, qubit_count=1, ascii_symbols=["foo"])
+    other_gate = AngledGate(angle=0.3, qubit_count=1, ascii_symbols=["foo"])
+    non_gate = "non gate"
+
+    assert angled_gate == gate
+    assert angled_gate is not gate
+    assert angled_gate != other_gate
+    assert angled_gate != non_gate
+
+
 def test_np_float_angle_json():
     angled_gate = AngledGate(angle=np.float32(0.15), qubit_count=1, ascii_symbols=["foo"])
     angled_gate_json = BaseModel.construct(target=[0], angle=angled_gate.angle).json()


### PR DESCRIPTION
*Issue #, if available:*
#213

*Description of changes:*

Currently `AngledGate` does not check for angle equality (just type equality) in `__eq__`. This change fixes this.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
