### PR TITLE
fix: Unitary equality checks matrix

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -1310,6 +1310,11 @@ class Unitary(Gate):
             matrix=Unitary._transform_matrix_to_ir(self._matrix),
         )
 
+    def __eq__(self, other):
+        if isinstance(other, Unitary):
+            return self.matrix_equivalence(other)
+        return NotImplemented
+
     @staticmethod
     def _transform_matrix_to_ir(matrix: np.ndarray):
         return [[[element.real, element.imag] for element in row] for row in matrix.tolist()]

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -607,7 +607,7 @@ def test_basis_rotation_instructions_multiple_result_types_different_hermitian_t
     expected = [
         Instruction(
             Gate.Unitary(
-                matrix=1.0 / np.sqrt(2.0) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex)
+                matrix=1.0 / np.sqrt(2.0) * np.array([[-1.0, 1.0], [1.0, 1.0]], dtype=complex)
             ),
             target=[0],
         ),
@@ -637,7 +637,7 @@ def test_basis_rotation_instructions_multiple_result_types_tensor_product_hermit
         Instruction(Gate.Ry(-np.pi / 4), 1),
         Instruction(
             Gate.Unitary(
-                matrix=1.0 / np.sqrt(2.0) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex)
+                matrix=1.0 / np.sqrt(2.0) * np.array([[-1.0, 1.0], [1.0, 1.0]], dtype=complex)
             ),
             target=[2],
         ),

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -299,6 +299,18 @@ def test_gate_to_matrix(testclass, subroutine_name, irclass, irsubclasses, kwarg
 # Additional Unitary gate tests
 
 
+def test_equality():
+    u1 = Gate.Unitary(np.array([[0 + 0j, 1 + 0j], [1 + 0j, 0 + 0j]]))
+    u2 = Gate.Unitary(np.array([[0, 1], [1, 0]], dtype=np.float32), display_name=["u2"])
+    other_gate = Gate.Unitary(np.array([[1, 0], [0, 1]]))
+    non_gate = "non gate"
+
+    assert u1 == u2
+    assert u1 is not u2
+    assert u1 != other_gate
+    assert u1 != non_gate
+
+
 @pytest.mark.xfail(raises=ValueError)
 @pytest.mark.parametrize("matrix", invalid_unitary_matrices)
 def test_unitary_invalid_matrix(matrix):

--- a/test/unit_tests/braket/circuits/test_observables.py
+++ b/test/unit_tests/braket/circuits/test_observables.py
@@ -130,7 +130,7 @@ def test_hermitian_eigenvalues(matrix, eigenvalues):
     "matrix,basis_rotation_matrix",
     [
         (
-            np.array([[1.0, 0.0], [0.0, 1.0]]),
+            np.array([[0.0, 1.0], [1.0, 0.0]]),
             np.array([[-0.70710678, 0.70710678], [0.70710678, 0.70710678]]).conj().T,
         ),
         (
@@ -156,7 +156,7 @@ def test_hermitian_basis_rotation_gates(matrix, basis_rotation_matrix):
     expected_unitary = Gate.Unitary(matrix=basis_rotation_matrix)
     actual_rotation_gates = Observable.Hermitian(matrix=matrix).basis_rotation_gates
     assert actual_rotation_gates == tuple([expected_unitary])
-    assert expected_unitary.matrix_equivalence(actual_rotation_gates)
+    assert expected_unitary.matrix_equivalence(actual_rotation_gates[0])
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
Before, `Unitary.__eq__` only checked that the types were the same.
This change ensures that the actual matrices are also equivalent.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
