### PR TITLE
fix: check for task completion before entering async event loop

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -272,6 +272,8 @@ class AwsQuantumTask(QuantumTask):
         """
         if self._result or self._status(True) in self.NO_RESULT_TERMINAL_STATES:
             return self._result
+        if self._status(True) in self.RESULTS_READY_STATES:
+            return self._download_result()
         try:
             async_result = self.async_result()
             return async_result.get_loop().run_until_complete(async_result)
@@ -287,9 +289,7 @@ class AwsQuantumTask(QuantumTask):
             self._logger.debug(e)
             self._logger.info("No event loop found; creating new event loop")
             asyncio.set_event_loop(asyncio.new_event_loop())
-        if not hasattr(self, "_future"):
-            self._future = asyncio.get_event_loop().run_until_complete(self._create_future())
-        elif (
+        if not hasattr(self, "_future") or (
             self._future.done()
             and not self._future.cancelled()
             and self._result is None
@@ -339,15 +339,9 @@ class AwsQuantumTask(QuantumTask):
         while (time.time() - start_time) < self._poll_timeout_seconds:
             # Used cached metadata if cached status is terminal
             task_status = self._update_status_if_nonterminal()
-            current_metadata = self.metadata(True)
             self._logger.debug(f"Task {self._arn}: task status {task_status}")
             if task_status in AwsQuantumTask.RESULTS_READY_STATES:
-                result_string = self._aws_session.retrieve_s3_object_body(
-                    current_metadata["outputS3Bucket"],
-                    current_metadata["outputS3Directory"] + f"/{AwsQuantumTask.RESULTS_FILENAME}",
-                )
-                self._result = _format_result(BraketSchemaBase.parse_raw_schema(result_string))
-                return self._result
+                return self._download_result()
             elif task_status in AwsQuantumTask.NO_RESULT_TERMINAL_STATES:
                 self._result = None
                 return None
@@ -363,6 +357,15 @@ class AwsQuantumTask(QuantumTask):
         )
         self._result = None
         return None
+
+    def _download_result(self):
+        current_metadata = self.metadata(True)
+        result_string = self._aws_session.retrieve_s3_object_body(
+            current_metadata["outputS3Bucket"],
+            current_metadata["outputS3Directory"] + f"/{AwsQuantumTask.RESULTS_FILENAME}",
+        )
+        self._result = _format_result(BraketSchemaBase.parse_raw_schema(result_string))
+        return self._result
 
     def __repr__(self) -> str:
         return f"AwsQuantumTask('id':{self.id})"

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -272,7 +272,7 @@ class AwsQuantumTask(QuantumTask):
         """
         if self._result or self._status(True) in self.NO_RESULT_TERMINAL_STATES:
             return self._result
-        if self._status(True) in self.RESULTS_READY_STATES:
+        if self._metadata and self._status(True) in self.RESULTS_READY_STATES:
             return self._download_result()
         try:
             async_result = self.async_result()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add check for completeness in task.result() and directly download the result if available

Will be adding more commits to this pull request for related changes

*Testing done:*

unit/integ

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
