### PR TITLE
change: Update user_agent for AwsSession

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ source =
 
 [report]
 show_missing = True
+ignore_errors = True
 
 [html]
 directory = build/coverage

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -45,6 +45,13 @@ class AwsSession(object):
         self._update_user_agent()
 
     def _update_user_agent(self):
+        """
+        Updates the `User-Agent` header forwarded by boto3 to include the braket-sdk,
+        braket-schemas and the notebook instance version. The header is a string of space delimited
+        values (For example: "Boto3/1.14.43 Python/3.7.9 Botocore/1.17.44"). See:
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore.config.Config
+        """
+
         def _notebook_instance_version():
             # TODO: Replace with lifecycle configuration version once we have a way to access those
             nbi_metadata_path = "/opt/ml/metadata/resource-metadata.json"

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -18,7 +18,7 @@ import backoff
 import boto3
 from botocore.exceptions import ClientError
 
-import braket._schemas as braket_schemas  # pragma: no cover
+import braket._schemas as braket_schemas
 import braket._sdk as braket_sdk
 
 

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -65,6 +65,8 @@ def test_config(boto_session):
     [
         (True, None),
         (False, None),
+        (True, ""),
+        (False, ""),
         (True, "Boto3/1.17.18 Python/3.7.10"),
         (False, "Boto3/1.17.18 Python/3.7.10 exec-env/AWS_Lambda_python3.7"),
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updated `user_agent` field to append the Braket SDK, Braket Schemas and Notebook Instance versions. Notebook instance version information is currently unavailable and a value of 0 is used for now.
* `.coveragerc` was updated to work around the following error:
```
No source for code: '/Volumes/workplace/chhabrk/sdkn/amazon-braket-sdk-python/src/braket/_schemas/__init__.py'.
Aborting report output, consider using -i
```

*Testing done:*
* Validated that the correct user agent was being set both for local installations and notebook instances.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
