### PR TITLE
fix: remove unneeded get_quantum_task calls

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -251,7 +251,7 @@ class AwsQuantumTask(QuantumTask):
     def _update_status_if_nonterminal(self):
         # If metadata has not been populated, the first call to _status will fetch it,
         # so the second _status call will no longer need to
-        metadata_absent = self._metadata is None
+        metadata_absent = not self._metadata
         cached = self._status(True)
         return cached if cached in self.TERMINAL_STATES else self._status(metadata_absent)
 
@@ -270,7 +270,9 @@ class AwsQuantumTask(QuantumTask):
             if the task completed successfully; returns `None` if the task did not complete
             successfully or the future timed out.
         """
-        if self._result or self._status(True) in self.NO_RESULT_TERMINAL_STATES:
+        if self._result or (
+            self._metadata and self._status(True) in self.NO_RESULT_TERMINAL_STATES
+        ):
             return self._result
         try:
             async_result = self.async_result()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes two bugs when polling statuses.

First, in _update_status_if_nonterminal we check whether metadata is absent by comparing self._metadata with None. This check will always fail, since self._metadata starts out as the empty dict {}.

Second, when calling task.result() we always start out by checking for task completion before entering the async loop, even if we've never polled before. This PR changes the behavior to enter the async loop directly if polling hasn't been done.

*Testing done:*
Unit tests.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
