### PR TITLE
fix: Added /taskArn to id field in AwsQuantumTask __repr__

### DIFF
--- a/src/braket/annealing/problem.py
+++ b/src/braket/annealing/problem.py
@@ -32,7 +32,7 @@ class ProblemType(str, Enum):
 
 
 class Problem:
-    """ Represents an annealing problem."""
+    """Represents an annealing problem."""
 
     def __init__(
         self,

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -370,7 +370,7 @@ class AwsQuantumTask(QuantumTask):
         return self._result
 
     def __repr__(self) -> str:
-        return f"AwsQuantumTask('id':{self.id})"
+        return f"AwsQuantumTask('id/taskArn':'{self.id}')"
 
     def __eq__(self, other) -> bool:
         if isinstance(other, AwsQuantumTask):

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -199,7 +199,7 @@ class TensorProduct(Observable):
 
     @property
     def factors(self) -> Tuple[Observable, ...]:
-        """ Tuple[Observable]: The observables that comprise this tensor product."""
+        """Tuple[Observable]: The observables that comprise this tensor product."""
         return self._factors
 
     def to_matrix(self) -> np.ndarray:

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -84,7 +84,7 @@ def test_equality(arn, aws_session):
 
 
 def test_str(quantum_task):
-    expected = "AwsQuantumTask('id':{})".format(quantum_task.id)
+    expected = "AwsQuantumTask('id/taskArn':'{}')".format(quantum_task.id)
     assert str(quantum_task) == expected
 
 


### PR DESCRIPTION
*Issue #, if available:*
AWS Internal
*Description of changes:*
Added /taskArn to string representation of AwsQauntumTask. This is to help users quickly understand that the id and task ARN are the same. Also added single quotes around the ARN to further clarify.

*Testing done:*
ran unit tests and integ tests
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
