### PR TITLE
fix: copy the boto3 session using the default botocore session

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -325,12 +325,15 @@ class AwsDevice(Device):
         session_region = aws_session.boto_session.region_name
         new_region = region or session_region
         creds = aws_session.boto_session.get_credentials()
-        boto_session = boto3.Session(
-            aws_access_key_id=creds.access_key,
-            aws_secret_access_key=creds.secret_key,
-            aws_session_token=creds.token,
-            region_name=new_region,
-        )
+        if creds.method == "explicit":
+            boto_session = boto3.Session(
+                aws_access_key_id=creds.access_key,
+                aws_secret_access_key=creds.secret_key,
+                aws_session_token=creds.token,
+                region_name=new_region,
+            )
+        else:
+            boto_session = boto3.Session(region_name=new_region)
         return AwsSession(boto_session=boto_session, config=config)
 
     def __repr__(self):


### PR DESCRIPTION
*Description of changes:*

- Copy the boto3 session using the default botocore session, unless the customer created the session using explicit credentials. This should allow sessions to refresh credentials if they are open for more than an hour.

*Testing done:*
- tox
- Verified that explicit credentials still work as before
- Verified that copied sessions will use the refreshed credentials after the previous ones expire

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
