### PR TITLE
fix: Get qubit count without instantiating op

### DIFF
--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import math
-from typing import Sequence
+from typing import Optional, Sequence
 
 from braket.circuits.gate import Gate
 
@@ -22,11 +22,11 @@ class AngledGate(Gate):
     Class `AngledGate` represents a quantum gate that operates on N qubits and an angle.
     """
 
-    def __init__(self, angle: float, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(self, angle: float, qubit_count: Optional[int], ascii_symbols: Sequence[str]):
         """
         Args:
             angle (float): The angle of the gate in radians.
-            qubit_count (int): The number of qubits that this gate interacts with.
+            qubit_count (int, optional): The number of qubits that this gate interacts with.
             ascii_symbols (Sequence[str]): ASCII string symbols for the gate. These are used when
                 printing a diagram of a circuit. The length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with the target ordering on the instruction.

--- a/src/braket/circuits/gate.py
+++ b/src/braket/circuits/gate.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence
 
 from braket.circuits.quantum_operator import QuantumOperator
 from braket.circuits.qubit_set import QubitSet
@@ -24,10 +24,10 @@ class Gate(QuantumOperator):
     the metadata that defines what a gate is and what it does.
     """
 
-    def __init__(self, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(self, qubit_count: Optional[int], ascii_symbols: Sequence[str]):
         """
         Args:
-            qubit_count (int): Number of qubits this gate interacts with.
+            qubit_count (int, optional): Number of qubits this gate interacts with.
             ascii_symbols (Sequence[str]): ASCII string symbols for the gate. These are used when
                 printing a diagram of circuits. Length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with target ordering on the instruction.

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -42,6 +42,8 @@ To add a new gate:
 class H(Gate):
     """Hadamard gate."""
 
+    qubit_count = 2
+
     def __init__(self):
         super().__init__(qubit_count=1, ascii_symbols=["H"])
 

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -43,7 +43,7 @@ class H(Gate):
     """Hadamard gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=self.fixed_qubit_count(), ascii_symbols=["H"])
+        super().__init__(qubit_count=None, ascii_symbols=["H"])
 
     def to_ir(self, target: QubitSet):
         return ir.H.construct(target=target[0])

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -42,16 +42,18 @@ To add a new gate:
 class H(Gate):
     """Hadamard gate."""
 
-    qubit_count = 2
-
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["H"])
+        super().__init__(qubit_count=self.fixed_qubit_count(), ascii_symbols=["H"])
 
     def to_ir(self, target: QubitSet):
         return ir.H.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return 1.0 / np.sqrt(2.0) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -68,7 +70,7 @@ class H(Gate):
             >>> circ = Circuit().h(0)
             >>> circ = Circuit().h([0, 1, 2])
         """
-        return [Instruction(Gate.H(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(H(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(H)
@@ -78,13 +80,17 @@ class I(Gate):  # noqa: E742, E261
     """Identity gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["I"])
+        super().__init__(qubit_count=None, ascii_symbols=["I"])
 
     def to_ir(self, target: QubitSet):
         return ir.I.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.eye(2, dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -101,7 +107,7 @@ class I(Gate):  # noqa: E742, E261
             >>> circ = Circuit().i(0)
             >>> circ = Circuit().i([0, 1, 2])
         """
-        return [Instruction(Gate.I(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(I(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(I)
@@ -111,13 +117,17 @@ class X(Gate):
     """Pauli-X gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["X"])
+        super().__init__(qubit_count=None, ascii_symbols=["X"])
 
     def to_ir(self, target: QubitSet):
         return ir.X.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -134,7 +144,7 @@ class X(Gate):
             >>> circ = Circuit().x(0)
             >>> circ = Circuit().x([0, 1, 2])
         """
-        return [Instruction(Gate.X(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(X(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(X)
@@ -144,13 +154,17 @@ class Y(Gate):
     """Pauli-Y gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["Y"])
+        super().__init__(qubit_count=None, ascii_symbols=["Y"])
 
     def to_ir(self, target: QubitSet):
         return ir.Y.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -167,7 +181,7 @@ class Y(Gate):
             >>> circ = Circuit().y(0)
             >>> circ = Circuit().y([0, 1, 2])
         """
-        return [Instruction(Gate.Y(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Y(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Y)
@@ -177,13 +191,17 @@ class Z(Gate):
     """Pauli-Z gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["Z"])
+        super().__init__(qubit_count=None, ascii_symbols=["Z"])
 
     def to_ir(self, target: QubitSet):
         return ir.Z.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -200,7 +218,7 @@ class Z(Gate):
             >>> circ = Circuit().z(0)
             >>> circ = Circuit().z([0, 1, 2])
         """
-        return [Instruction(Gate.Z(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Z(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Z)
@@ -210,7 +228,7 @@ class S(Gate):
     """S gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["S"])
+        super().__init__(qubit_count=None, ascii_symbols=["S"])
 
     def to_ir(self, target: QubitSet):
         return ir.S.construct(target=target[0])
@@ -218,6 +236,10 @@ class S(Gate):
     def to_matrix(self) -> np.ndarray:
 
         return np.array([[1.0, 0.0], [0.0, 1.0j]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -234,7 +256,7 @@ class S(Gate):
             >>> circ = Circuit().s(0)
             >>> circ = Circuit().s([0, 1, 2])
         """
-        return [Instruction(Gate.S(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(S(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(S)
@@ -244,13 +266,17 @@ class Si(Gate):
     """Conjugate transpose of S gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["Si"])
+        super().__init__(qubit_count=None, ascii_symbols=["Si"])
 
     def to_ir(self, target: QubitSet):
         return ir.Si.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[1, 0], [0, -1j]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -267,7 +293,7 @@ class Si(Gate):
             >>> circ = Circuit().si(0)
             >>> circ = Circuit().si([0, 1, 2])
         """
-        return [Instruction(Gate.Si(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Si(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Si)
@@ -277,13 +303,17 @@ class T(Gate):
     """T gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["T"])
+        super().__init__(qubit_count=None, ascii_symbols=["T"])
 
     def to_ir(self, target: QubitSet):
         return ir.T.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[1.0, 0.0], [0.0, np.exp(1j * np.pi / 4)]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -300,7 +330,7 @@ class T(Gate):
             >>> circ = Circuit().t(0)
             >>> circ = Circuit().t([0, 1, 2])
         """
-        return [Instruction(Gate.T(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(T(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(T)
@@ -310,13 +340,17 @@ class Ti(Gate):
     """Conjugate transpose of T gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["Ti"])
+        super().__init__(qubit_count=None, ascii_symbols=["Ti"])
 
     def to_ir(self, target: QubitSet):
         return ir.Ti.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[1.0, 0.0], [0.0, np.exp(-1j * np.pi / 4)]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -333,7 +367,7 @@ class Ti(Gate):
             >>> circ = Circuit().ti(0)
             >>> circ = Circuit().ti([0, 1, 2])
         """
-        return [Instruction(Gate.Ti(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Ti(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Ti)
@@ -343,13 +377,17 @@ class V(Gate):
     """Square root of not gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["V"])
+        super().__init__(qubit_count=None, ascii_symbols=["V"])
 
     def to_ir(self, target: QubitSet):
         return ir.V.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -366,7 +404,7 @@ class V(Gate):
             >>> circ = Circuit().v(0)
             >>> circ = Circuit().v([0, 1, 2])
         """
-        return [Instruction(Gate.V(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(V(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(V)
@@ -376,13 +414,17 @@ class Vi(Gate):
     """Conjugate transpose of square root of not gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=1, ascii_symbols=["Vi"])
+        super().__init__(qubit_count=None, ascii_symbols=["Vi"])
 
     def to_ir(self, target: QubitSet):
         return ir.Vi.construct(target=target[0])
 
     def to_matrix(self) -> np.ndarray:
         return np.array(([[0.5 - 0.5j, 0.5 + 0.5j], [0.5 + 0.5j, 0.5 - 0.5j]]), dtype=complex)
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -399,7 +441,7 @@ class Vi(Gate):
             >>> circ = Circuit().vi(0)
             >>> circ = Circuit().vi([0, 1, 2])
         """
-        return [Instruction(Gate.Vi(), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Vi(), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Vi)
@@ -416,7 +458,7 @@ class Rx(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=1, ascii_symbols=["Rx({:.3g})".format(angle)])
+        super().__init__(angle=angle, qubit_count=None, ascii_symbols=["Rx({:.3g})".format(angle)])
 
     def to_ir(self, target: QubitSet):
         return ir.Rx.construct(target=target[0], angle=self.angle)
@@ -427,8 +469,12 @@ class Rx(AngledGate):
         return np.array([[cos, -1j * sin], [-1j * sin, cos]], dtype=complex)
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
+
+    @staticmethod
     @circuit.subroutine(register=True)
-    def rx(target: QubitInput, angle: float) -> Instruction:
+    def rx(target: QubitInput, angle: float) -> Iterable[Instruction]:
         """Registers this function into the circuit class.
 
         Args:
@@ -436,12 +482,12 @@ class Rx(AngledGate):
             angle (float): Angle in radians.
 
         Returns:
-            Instruction: Rx instruction.
+            Iterable[Instruction]: Rx instruction.
 
         Examples:
             >>> circ = Circuit().rx(0, 0.15)
         """
-        return [Instruction(Gate.Rx(angle), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Rx(angle), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Rx)
@@ -455,7 +501,7 @@ class Ry(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=1, ascii_symbols=["Ry({:.3g})".format(angle)])
+        super().__init__(angle=angle, qubit_count=None, ascii_symbols=["Ry({:.3g})".format(angle)])
 
     def to_ir(self, target: QubitSet):
         return ir.Ry.construct(target=target[0], angle=self.angle)
@@ -466,8 +512,12 @@ class Ry(AngledGate):
         return np.array([[cos, -sin], [+sin, cos]], dtype=complex)
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
+
+    @staticmethod
     @circuit.subroutine(register=True)
-    def ry(target: QubitInput, angle: float) -> Instruction:
+    def ry(target: QubitInput, angle: float) -> Iterable[Instruction]:
         """Registers this function into the circuit class.
 
         Args:
@@ -475,12 +525,12 @@ class Ry(AngledGate):
             angle (float): Angle in radians.
 
         Returns:
-            Instruction: Ry instruction.
+            Iterable[Instruction]: Ry instruction.
 
         Examples:
             >>> circ = Circuit().ry(0, 0.15)
         """
-        return [Instruction(Gate.Ry(angle), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Ry(angle), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Ry)
@@ -494,7 +544,7 @@ class Rz(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=1, ascii_symbols=["Rz({:.3g})".format(angle)])
+        super().__init__(angle=angle, qubit_count=None, ascii_symbols=["Rz({:.3g})".format(angle)])
 
     def to_ir(self, target: QubitSet):
         return ir.Rz.construct(target=target[0], angle=self.angle)
@@ -505,8 +555,12 @@ class Rz(AngledGate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
+
+    @staticmethod
     @circuit.subroutine(register=True)
-    def rz(target: QubitInput, angle: float) -> Instruction:
+    def rz(target: QubitInput, angle: float) -> Iterable[Instruction]:
         """Registers this function into the circuit class.
 
         Args:
@@ -514,12 +568,12 @@ class Rz(AngledGate):
             angle (float): Angle in radians.
 
         Returns:
-            Instruction: Rz instruction.
+            Iterable[Instruction]: Rz instruction.
 
         Examples:
             >>> circ = Circuit().rz(0, 0.15)
         """
-        return [Instruction(Gate.Rz(angle), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(Rz(angle), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(Rz)
@@ -533,7 +587,9 @@ class PhaseShift(AngledGate):
     """
 
     def __init__(self, angle: float):
-        super().__init__(angle=angle, qubit_count=1, ascii_symbols=["PHASE({:.3g})".format(angle)])
+        super().__init__(
+            angle=angle, qubit_count=None, ascii_symbols=["PHASE({:.3g})".format(angle)]
+        )
 
     def to_ir(self, target: QubitSet):
         return ir.PhaseShift.construct(target=target[0], angle=self.angle)
@@ -542,8 +598,12 @@ class PhaseShift(AngledGate):
         return np.array([[1.0, 0.0], [0.0, np.exp(1j * self.angle)]], dtype=complex)
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
+
+    @staticmethod
     @circuit.subroutine(register=True)
-    def phaseshift(target: QubitInput, angle: float) -> Instruction:
+    def phaseshift(target: QubitInput, angle: float) -> Iterable[Instruction]:
         """Registers this function into the circuit class.
 
         Args:
@@ -551,12 +611,12 @@ class PhaseShift(AngledGate):
             angle (float): Angle in radians.
 
         Returns:
-            Instruction: PhaseShift instruction.
+            Iterable[Instruction]: PhaseShift instruction.
 
         Examples:
             >>> circ = Circuit().phaseshift(0, 0.15)
         """
-        return [Instruction(Gate.PhaseShift(angle), target=qubit) for qubit in QubitSet(target)]
+        return [Instruction(PhaseShift(angle), target=qubit) for qubit in QubitSet(target)]
 
 
 Gate.register_gate(PhaseShift)
@@ -569,7 +629,7 @@ class CNot(Gate):
     """Controlled NOT gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=2, ascii_symbols=["C", "X"])
+        super().__init__(qubit_count=None, ascii_symbols=["C", "X"])
 
     def to_ir(self, target: QubitSet):
         return ir.CNot.construct(control=target[0], target=target[1])
@@ -586,6 +646,10 @@ class CNot(Gate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def cnot(control: QubitInput, target: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
@@ -600,7 +664,7 @@ class CNot(Gate):
         Examples:
             >>> circ = Circuit().cnot(0, 1)
         """
-        return Instruction(Gate.CNot(), target=[control, target])
+        return Instruction(CNot(), target=[control, target])
 
 
 Gate.register_gate(CNot)
@@ -610,7 +674,7 @@ class Swap(Gate):
     """Swap gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=2, ascii_symbols=["SWAP", "SWAP"])
+        super().__init__(qubit_count=None, ascii_symbols=["SWAP", "SWAP"])
 
     def to_ir(self, target: QubitSet):
         return ir.Swap.construct(targets=[target[0], target[1]])
@@ -627,6 +691,10 @@ class Swap(Gate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def swap(target1: QubitInput, target2: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
@@ -641,7 +709,7 @@ class Swap(Gate):
         Examples:
             >>> circ = Circuit().swap(0, 1)
         """
-        return Instruction(Gate.Swap(), target=[target1, target2])
+        return Instruction(Swap(), target=[target1, target2])
 
 
 Gate.register_gate(Swap)
@@ -651,7 +719,7 @@ class ISwap(Gate):
     """ISwap gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=2, ascii_symbols=["ISWAP", "ISWAP"])
+        super().__init__(qubit_count=None, ascii_symbols=["ISWAP", "ISWAP"])
 
     def to_ir(self, target: QubitSet):
         return ir.ISwap.construct(targets=[target[0], target[1]])
@@ -668,6 +736,10 @@ class ISwap(Gate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def iswap(target1: QubitInput, target2: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
@@ -682,7 +754,7 @@ class ISwap(Gate):
         Examples:
             >>> circ = Circuit().iswap(0, 1)
         """
-        return Instruction(Gate.ISwap(), target=[target1, target2])
+        return Instruction(ISwap(), target=[target1, target2])
 
 
 Gate.register_gate(ISwap)
@@ -698,7 +770,7 @@ class PSwap(AngledGate):
     def __init__(self, angle: float):
         super().__init__(
             angle=angle,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["PSWAP({:.3g})".format(angle), "PSWAP({:.3g})".format(angle)],
         )
 
@@ -717,6 +789,10 @@ class PSwap(AngledGate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def pswap(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
@@ -731,7 +807,7 @@ class PSwap(AngledGate):
         Examples:
             >>> circ = Circuit().pswap(0, 1, 0.15)
         """
-        return Instruction(Gate.PSwap(angle), target=[target1, target2])
+        return Instruction(PSwap(angle), target=[target1, target2])
 
 
 Gate.register_gate(PSwap)
@@ -749,7 +825,7 @@ class XY(AngledGate):
     def __init__(self, angle: float):
         super().__init__(
             angle=angle,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["XY({:.3g})".format(angle), "XY({:.3g})".format(angle)],
         )
 
@@ -770,6 +846,10 @@ class XY(AngledGate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def xy(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
@@ -784,7 +864,7 @@ class XY(AngledGate):
         Examples:
             >>> circ = Circuit().xy(0, 1, 0.15)
         """
-        return Instruction(Gate.XY(angle), target=[target1, target2])
+        return Instruction(XY(angle), target=[target1, target2])
 
 
 Gate.register_gate(XY)
@@ -799,7 +879,7 @@ class CPhaseShift(AngledGate):
 
     def __init__(self, angle: float):
         super().__init__(
-            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE({:.3g})".format(angle)]
+            angle=angle, qubit_count=None, ascii_symbols=["C", "PHASE({:.3g})".format(angle)]
         )
 
     def to_ir(self, target: QubitSet):
@@ -807,6 +887,10 @@ class CPhaseShift(AngledGate):
 
     def to_matrix(self) -> np.ndarray:
         return np.diag([1.0, 1.0, 1.0, np.exp(1j * self.angle)])
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -824,7 +908,7 @@ class CPhaseShift(AngledGate):
         Examples:
             >>> circ = Circuit().cphaseshift(0, 1, 0.15)
         """
-        return Instruction(Gate.CPhaseShift(angle), target=[control, target])
+        return Instruction(CPhaseShift(angle), target=[control, target])
 
 
 Gate.register_gate(CPhaseShift)
@@ -839,7 +923,7 @@ class CPhaseShift00(AngledGate):
 
     def __init__(self, angle: float):
         super().__init__(
-            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE00({:.3g})".format(angle)]
+            angle=angle, qubit_count=None, ascii_symbols=["C", "PHASE00({:.3g})".format(angle)]
         )
 
     def to_ir(self, target: QubitSet):
@@ -847,6 +931,10 @@ class CPhaseShift00(AngledGate):
 
     def to_matrix(self) -> np.ndarray:
         return np.diag([np.exp(1j * self.angle), 1.0, 1.0, 1.0])
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -864,7 +952,7 @@ class CPhaseShift00(AngledGate):
         Examples:
             >>> circ = Circuit().cphaseshift00(0, 1, 0.15)
         """
-        return Instruction(Gate.CPhaseShift00(angle), target=[control, target])
+        return Instruction(CPhaseShift00(angle), target=[control, target])
 
 
 Gate.register_gate(CPhaseShift00)
@@ -879,7 +967,7 @@ class CPhaseShift01(AngledGate):
 
     def __init__(self, angle: float):
         super().__init__(
-            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE01({:.3g})".format(angle)]
+            angle=angle, qubit_count=None, ascii_symbols=["C", "PHASE01({:.3g})".format(angle)]
         )
 
     def to_ir(self, target: QubitSet):
@@ -887,6 +975,10 @@ class CPhaseShift01(AngledGate):
 
     def to_matrix(self) -> np.ndarray:
         return np.diag([1.0, np.exp(1j * self.angle), 1.0, 1.0])
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -904,7 +996,7 @@ class CPhaseShift01(AngledGate):
         Examples:
             >>> circ = Circuit().cphaseshift01(0, 1, 0.15)
         """
-        return Instruction(Gate.CPhaseShift01(angle), target=[control, target])
+        return Instruction(CPhaseShift01(angle), target=[control, target])
 
 
 Gate.register_gate(CPhaseShift01)
@@ -919,7 +1011,7 @@ class CPhaseShift10(AngledGate):
 
     def __init__(self, angle: float):
         super().__init__(
-            angle=angle, qubit_count=2, ascii_symbols=["C", "PHASE10({:.3g})".format(angle)]
+            angle=angle, qubit_count=None, ascii_symbols=["C", "PHASE10({:.3g})".format(angle)]
         )
 
     def to_ir(self, target: QubitSet):
@@ -927,6 +1019,10 @@ class CPhaseShift10(AngledGate):
 
     def to_matrix(self) -> np.ndarray:
         return np.diag([1.0, 1.0, np.exp(1j * self.angle), 1.0])
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -944,7 +1040,7 @@ class CPhaseShift10(AngledGate):
         Examples:
             >>> circ = Circuit().cphaseshift10(0, 1, 0.15)
         """
-        return Instruction(Gate.CPhaseShift10(angle), target=[control, target])
+        return Instruction(CPhaseShift10(angle), target=[control, target])
 
 
 Gate.register_gate(CPhaseShift10)
@@ -954,7 +1050,7 @@ class CY(Gate):
     """Controlled Pauli-Y gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=2, ascii_symbols=["C", "Y"])
+        super().__init__(qubit_count=None, ascii_symbols=["C", "Y"])
 
     def to_ir(self, target: QubitSet):
         return ir.CY.construct(control=target[0], target=target[1])
@@ -971,6 +1067,10 @@ class CY(Gate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def cy(control: QubitInput, target: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
@@ -985,7 +1085,7 @@ class CY(Gate):
         Examples:
             >>> circ = Circuit().cy(0, 1)
         """
-        return Instruction(Gate.CY(), target=[control, target])
+        return Instruction(CY(), target=[control, target])
 
 
 Gate.register_gate(CY)
@@ -995,13 +1095,17 @@ class CZ(Gate):
     """Controlled Pauli-Z gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=2, ascii_symbols=["C", "Z"])
+        super().__init__(qubit_count=None, ascii_symbols=["C", "Z"])
 
     def to_ir(self, target: QubitSet):
         return ir.CZ.construct(control=target[0], target=target[1])
 
     def to_matrix(self) -> np.ndarray:
         return np.diag([1.0, 1.0, 1.0, -1.0])
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -1018,7 +1122,7 @@ class CZ(Gate):
         Examples:
             >>> circ = Circuit().cz(0, 1)
         """
-        return Instruction(Gate.CZ(), target=[control, target])
+        return Instruction(CZ(), target=[control, target])
 
 
 Gate.register_gate(CZ)
@@ -1036,7 +1140,7 @@ class XX(AngledGate):
     def __init__(self, angle: float):
         super().__init__(
             angle=angle,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["XX({:.3g})".format(angle), "XX({:.3g})".format(angle)],
         )
 
@@ -1057,6 +1161,10 @@ class XX(AngledGate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def xx(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
@@ -1072,7 +1180,7 @@ class XX(AngledGate):
         Examples:
             >>> circ = Circuit().xx(0, 1, 0.15)
         """
-        return Instruction(Gate.XX(angle), target=[target1, target2])
+        return Instruction(XX(angle), target=[target1, target2])
 
 
 Gate.register_gate(XX)
@@ -1090,7 +1198,7 @@ class YY(AngledGate):
     def __init__(self, angle: float):
         super().__init__(
             angle=angle,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["YY({:.3g})".format(angle), "YY({:.3g})".format(angle)],
         )
 
@@ -1111,6 +1219,10 @@ class YY(AngledGate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def yy(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
@@ -1126,7 +1238,7 @@ class YY(AngledGate):
         Examples:
             >>> circ = Circuit().yy(0, 1, 0.15)
         """
-        return Instruction(Gate.YY(angle), target=[target1, target2])
+        return Instruction(YY(angle), target=[target1, target2])
 
 
 Gate.register_gate(YY)
@@ -1144,7 +1256,7 @@ class ZZ(AngledGate):
     def __init__(self, angle: float):
         super().__init__(
             angle=angle,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["ZZ({:.3g})".format(angle), "ZZ({:.3g})".format(angle)],
         )
 
@@ -1163,6 +1275,10 @@ class ZZ(AngledGate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def zz(target1: QubitInput, target2: QubitInput, angle: float) -> Instruction:
         """Registers this function into the circuit class.
@@ -1178,7 +1294,7 @@ class ZZ(AngledGate):
         Examples:
             >>> circ = Circuit().zz(0, 1, 0.15)
         """
-        return Instruction(Gate.ZZ(angle), target=[target1, target2])
+        return Instruction(ZZ(angle), target=[target1, target2])
 
 
 Gate.register_gate(ZZ)
@@ -1191,7 +1307,7 @@ class CCNot(Gate):
     """CCNOT gate or Toffoli gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=3, ascii_symbols=["C", "C", "X"])
+        super().__init__(qubit_count=None, ascii_symbols=["C", "C", "X"])
 
     def to_ir(self, target: QubitSet):
         return ir.CCNot.construct(controls=[target[0], target[1]], target=target[2])
@@ -1212,6 +1328,10 @@ class CCNot(Gate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 3
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def ccnot(control1: QubitInput, control2: QubitInput, target: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
@@ -1227,7 +1347,7 @@ class CCNot(Gate):
         Examples:
             >>> circ = Circuit().ccnot(0, 1, 2)
         """
-        return Instruction(Gate.CCNot(), target=[control1, control2, target])
+        return Instruction(CCNot(), target=[control1, control2, target])
 
 
 Gate.register_gate(CCNot)
@@ -1237,7 +1357,7 @@ class CSwap(Gate):
     """Controlled Swap gate."""
 
     def __init__(self):
-        super().__init__(qubit_count=3, ascii_symbols=["C", "SWAP", "SWAP"])
+        super().__init__(qubit_count=None, ascii_symbols=["C", "SWAP", "SWAP"])
 
     def to_ir(self, target: QubitSet):
         return ir.CSwap.construct(control=target[0], targets=[target[1], target[2]])
@@ -1258,6 +1378,10 @@ class CSwap(Gate):
         )
 
     @staticmethod
+    def fixed_qubit_count() -> int:
+        return 3
+
+    @staticmethod
     @circuit.subroutine(register=True)
     def cswap(control: QubitInput, target1: QubitInput, target2: QubitInput) -> Instruction:
         """Registers this function into the circuit class.
@@ -1273,7 +1397,7 @@ class CSwap(Gate):
         Examples:
             >>> circ = Circuit().cswap(0, 1, 2)
         """
-        return Instruction(Gate.CSwap(), target=[control, target1, target2])
+        return Instruction(CSwap(), target=[control, target1, target2])
 
 
 Gate.register_gate(CSwap)
@@ -1347,7 +1471,7 @@ class Unitary(Gate):
         if 2 ** len(targets) != matrix.shape[0]:
             raise ValueError("Dimensions of the supplied unitary are incompatible with the targets")
 
-        return Instruction(Gate.Unitary(matrix, display_name), target=targets)
+        return Instruction(Unitary(matrix, display_name), target=targets)
 
 
 Gate.register_gate(Unitary)

--- a/src/braket/circuits/noise.py
+++ b/src/braket/circuits/noise.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence
 
 from braket.circuits.quantum_operator import QuantumOperator
 from braket.circuits.qubit_set import QubitSet
@@ -26,14 +26,10 @@ class Noise(QuantumOperator):
     the metadata that defines what the noise channel is and what it does.
     """
 
-    def __init__(
-        self,
-        qubit_count: int,
-        ascii_symbols: Sequence[str],
-    ):
+    def __init__(self, qubit_count: Optional[int], ascii_symbols: Sequence[str]):
         """
         Args:
-            qubit_count (int): Number of qubits this noise channel interacts with.
+            qubit_count (int, optional): Number of qubits this noise channel interacts with.
             ascii_symbols (Sequence[str]): ASCII string symbols for this noise channel. These
                 are used when printing a diagram of circuits. Length must be the same as
                 `qubit_count`, and index ordering is expected to correlate with target ordering
@@ -43,17 +39,7 @@ class Noise(QuantumOperator):
             ValueError: `qubit_count` is less than 1, `ascii_symbols` are None, or
                 length of `ascii_symbols` is not equal to `qubit_count`
         """
-        if qubit_count < 1:
-            raise ValueError(f"qubit_count, {qubit_count}, must be greater than zero")
-        self._qubit_count = qubit_count
-
-        if ascii_symbols is None:
-            raise ValueError("ascii_symbols must not be None")
-
-        if len(ascii_symbols) != qubit_count:
-            msg = f"ascii_symbols, {ascii_symbols}, length must equal qubit_count, {qubit_count}"
-            raise ValueError(msg)
-        self._ascii_symbols = tuple(ascii_symbols)
+        super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
 
     @property
     def name(self) -> str:
@@ -107,11 +93,13 @@ class SingleProbabilisticNoise(Noise):
     parameterized by a single probability.
     """
 
-    def __init__(self, probability: float, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(
+        self, probability: float, qubit_count: Optional[int], ascii_symbols: Sequence[str]
+    ):
         """
         Args:
             probability (float): The probability that the noise occurs.
-            qubit_count (int): The number of qubits to apply noise.
+            qubit_count (int, optional): The number of qubits to apply noise.
             ascii_symbols (Sequence[str]): ASCII string symbols for the noise. These are used when
                 printing a diagram of a circuit. The length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with the target ordering on the instruction.
@@ -147,11 +135,13 @@ class SingleProbabilisticNoise_34(Noise):
     channels parameterized by a single probability.
     """
 
-    def __init__(self, probability: float, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(
+        self, probability: float, qubit_count: Optional[int], ascii_symbols: Sequence[str]
+    ):
         """
         Args:
             probability (float): The probability that the noise occurs.
-            qubit_count (int): The number of qubits to apply noise.
+            qubit_count (int, optional): The number of qubits to apply noise.
             ascii_symbols (Sequence[str]): ASCII string symbols for the noise. These are used when
                 printing a diagram of a circuit. The length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with the target ordering on the instruction.
@@ -187,11 +177,13 @@ class SingleProbabilisticNoise_1516(Noise):
     parameterized by a single probability.
     """
 
-    def __init__(self, probability: float, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(
+        self, probability: float, qubit_count: Optional[int], ascii_symbols: Sequence[str]
+    ):
         """
         Args:
             probability (float): The probability that the noise occurs.
-            qubit_count (int): The number of qubits to apply noise.
+            qubit_count (int, optional): The number of qubits to apply noise.
             ascii_symbols (Sequence[str]): ASCII string symbols for the noise. These are used when
                 printing a diagram of a circuit. The length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with the target ordering on the instruction.
@@ -232,14 +224,14 @@ class PauliNoise(Noise):
         probX: float,
         probY: float,
         probZ: float,
-        qubit_count: int,
+        qubit_count: Optional[int],
         ascii_symbols: Sequence[str],
     ):
         """
         Args:
             probX [float], probY [float], probZ [float]: The coefficients of the Kraus operators
                 in the channel.
-            qubit_count (int): The number of qubits to apply noise.
+            qubit_count (int, optional): The number of qubits to apply noise.
             ascii_symbols (Sequence[str]): ASCII string symbols for the noise. These are used when
                 printing a diagram of a circuit. The length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with the target ordering on the instruction.
@@ -306,11 +298,11 @@ class DampingNoise(Noise):
     on N qubits parameterized by gamma.
     """
 
-    def __init__(self, gamma: float, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(self, gamma: float, qubit_count: Optional[int], ascii_symbols: Sequence[str]):
         """
         Args:
             gamma (float): Probability of damping.
-            qubit_count (int): The number of qubits to apply noise.
+            qubit_count (int, optional): The number of qubits to apply noise.
             ascii_symbols (Sequence[str]): ASCII string symbols for the noise. These are used when
                 printing a diagram of a circuit. The length must be the same as `qubit_count`, and
                 index ordering is expected to correlate with the target ordering on the instruction.
@@ -347,7 +339,11 @@ class GeneralizedAmplitudeDampingNoise(DampingNoise):
     """
 
     def __init__(
-        self, gamma: float, probability: float, qubit_count: int, ascii_symbols: Sequence[str]
+        self,
+        gamma: float,
+        probability: float,
+        qubit_count: Optional[int],
+        ascii_symbols: Sequence[str],
     ):
         """
         Args:

--- a/src/braket/circuits/noise_helpers.py
+++ b/src/braket/circuits/noise_helpers.py
@@ -64,8 +64,7 @@ def check_noise_target_gates(noise: Noise, target_gates: Iterable[Type[Gate]]):
         for g in target_gates:
             if g != Gate.Unitary and g().qubit_count != noise.qubit_count:
                 raise ValueError(
-                    "The target_targets must be gates that have the same number of \
-qubits as defined by the multi-qubit noise channel."
+                    "The target_gates must be gates that have the same number of qubits as defined by the multi-qubit noise channel."
                 )
 
 

--- a/src/braket/circuits/noise_helpers.py
+++ b/src/braket/circuits/noise_helpers.py
@@ -66,7 +66,7 @@ def check_noise_target_gates(noise: Noise, target_gates: Iterable[Type[Gate]]):
             if fixed_qubit_count is NotImplemented:
                 raise ValueError(
                     f"Target gate {g} can be instantiated on a variable number of qubits,"
-                    " but noise can only target gates with fixed qubit counts"
+                    " but noise can only target gates with fixed qubit counts."
                 )
             if fixed_qubit_count != noise.qubit_count:
                 raise ValueError(

--- a/src/braket/circuits/noise_helpers.py
+++ b/src/braket/circuits/noise_helpers.py
@@ -62,9 +62,11 @@ def check_noise_target_gates(noise: Noise, target_gates: Iterable[Type[Gate]]):
 
     if noise.qubit_count > 1:
         for g in target_gates:
-            if g != Gate.Unitary and g().qubit_count != noise.qubit_count:
+            fixed_qubit_count = g.fixed_qubit_count()
+            if g != Gate.Unitary and fixed_qubit_count != noise.qubit_count:
                 raise ValueError(
-                    "The target_gates must be gates that have the same number of qubits as defined by the multi-qubit noise channel."
+                    f"Target gate {g} acts on {fixed_qubit_count} qubits"
+                    f"but {noise} acts on {noise.qubit_count} qubits."
                 )
 
 

--- a/src/braket/circuits/noise_helpers.py
+++ b/src/braket/circuits/noise_helpers.py
@@ -63,10 +63,15 @@ def check_noise_target_gates(noise: Noise, target_gates: Iterable[Type[Gate]]):
     if noise.qubit_count > 1:
         for g in target_gates:
             fixed_qubit_count = g.fixed_qubit_count()
-            if g != Gate.Unitary and fixed_qubit_count != noise.qubit_count:
+            if fixed_qubit_count is NotImplemented:
                 raise ValueError(
-                    f"Target gate {g} acts on {fixed_qubit_count} qubits"
-                    f"but {noise} acts on {noise.qubit_count} qubits."
+                    f"Target gate {g} can be instantiated on a variable number of qubits,"
+                    " but noise can only target gates with fixed qubit counts"
+                )
+            if fixed_qubit_count != noise.qubit_count:
+                raise ValueError(
+                    f"Target gate {g} acts on {fixed_qubit_count} qubits,"
+                    f" but {noise} acts on {noise.qubit_count} qubits."
                 )
 
 

--- a/src/braket/circuits/noises.py
+++ b/src/braket/circuits/noises.py
@@ -73,7 +73,7 @@ class BitFlip(SingleProbabilisticNoise):
     def __init__(self, probability: float):
         super().__init__(
             probability=probability,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["BF({:.2g})".format(probability)],
         )
 
@@ -84,6 +84,10 @@ class BitFlip(SingleProbabilisticNoise):
         K0 = np.sqrt(1 - self.probability) * np.eye(2, dtype=complex)
         K1 = np.sqrt(self.probability) * np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex)
         return [K0, K1]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -138,7 +142,7 @@ class PhaseFlip(SingleProbabilisticNoise):
     def __init__(self, probability: float):
         super().__init__(
             probability=probability,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["PF({:.2g})".format(probability)],
         )
 
@@ -149,6 +153,10 @@ class PhaseFlip(SingleProbabilisticNoise):
         K0 = np.sqrt(1 - self.probability) * np.eye(2, dtype=complex)
         K1 = np.sqrt(self.probability) * np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
         return [K0, K1]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -221,7 +229,7 @@ class PauliChannel(PauliNoise):
             probX=probX,
             probY=probY,
             probZ=probZ,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["PC({:.2g},{:.2g},{:.2g})".format(probX, probY, probZ)],
         )
 
@@ -236,6 +244,10 @@ class PauliChannel(PauliNoise):
         K2 = np.sqrt(self.probY) * 1j * np.array([[0.0, -1.0], [1.0, 0.0]], dtype=complex)
         K3 = np.sqrt(self.probZ) * np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
         return [K0, K1, K2, K3]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -311,7 +323,7 @@ class Depolarizing(SingleProbabilisticNoise_34):
     def __init__(self, probability: float):
         super().__init__(
             probability=probability,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["DEPO({:.2g})".format(probability)],
         )
 
@@ -324,6 +336,10 @@ class Depolarizing(SingleProbabilisticNoise_34):
         K2 = np.sqrt(self.probability / 3) * 1j * np.array([[0.0, -1.0], [1.0, 0.0]], dtype=complex)
         K3 = np.sqrt(self.probability / 3) * np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex)
         return [K0, K1, K2, K3]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -399,7 +415,7 @@ class TwoQubitDepolarizing(SingleProbabilisticNoise_1516):
     def __init__(self, probability: float):
         super().__init__(
             probability=probability,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["DEPO({:.2g})".format(probability)] * 2,
         )
 
@@ -423,6 +439,10 @@ class TwoQubitDepolarizing(SingleProbabilisticNoise_1516):
         K_list[1:] = [np.sqrt(self._probability / 15) * i for i in K_list[1:]]
 
         return K_list
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -483,7 +503,7 @@ class TwoQubitDephasing(SingleProbabilisticNoise_34):
     def __init__(self, probability: float):
         super().__init__(
             probability=probability,
-            qubit_count=2,
+            qubit_count=None,
             ascii_symbols=["DEPH({:.2g})".format(probability)] * 2,
         )
 
@@ -502,6 +522,10 @@ class TwoQubitDephasing(SingleProbabilisticNoise_34):
         K3 = np.sqrt(self._probability / 3) * np.kron(SZ, SZ)
 
         return [K0, K1, K2, K3]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -555,7 +579,7 @@ class AmplitudeDamping(DampingNoise):
     def __init__(self, gamma: float):
         super().__init__(
             gamma=gamma,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["AD({:.2g})".format(gamma)],
         )
 
@@ -566,6 +590,10 @@ class AmplitudeDamping(DampingNoise):
         K0 = np.array([[1.0, 0.0], [0.0, np.sqrt(1 - self.gamma)]], dtype=complex)
         K1 = np.array([[0.0, np.sqrt(self.gamma)], [0.0, 0.0]], dtype=complex)
         return [K0, K1]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -633,7 +661,7 @@ class GeneralizedAmplitudeDamping(GeneralizedAmplitudeDampingNoise):
         super().__init__(
             gamma=gamma,
             probability=probability,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["GAD({:.2g},{:.2g})".format(gamma, probability)],
         )
 
@@ -652,6 +680,10 @@ class GeneralizedAmplitudeDamping(GeneralizedAmplitudeDampingNoise):
         K2 = np.sqrt(1 - self.probability) * np.array([[np.sqrt(1 - self.gamma), 0.0], [0.0, 1.0]])
         K3 = np.sqrt(1 - self.probability) * np.array([[0.0, 0.0], [np.sqrt(self.gamma), 0.0]])
         return [K0, K1, K2, K3]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)
@@ -712,7 +744,7 @@ class PhaseDamping(DampingNoise):
     def __init__(self, gamma: float):
         super().__init__(
             gamma=gamma,
-            qubit_count=1,
+            qubit_count=None,
             ascii_symbols=["PD({:.2g})".format(gamma)],
         )
 
@@ -723,6 +755,10 @@ class PhaseDamping(DampingNoise):
         K0 = np.array([[1.0, 0.0], [0.0, np.sqrt(1 - self.gamma)]], dtype=complex)
         K1 = np.array([[0.0, 0.0], [0.0, np.sqrt(self.gamma)]], dtype=complex)
         return [K0, K1]
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 1
 
     @staticmethod
     @circuit.subroutine(register=True)

--- a/src/braket/circuits/quantum_operator.py
+++ b/src/braket/circuits/quantum_operator.py
@@ -29,8 +29,10 @@ class QuantumOperator(Operator):
             qubit_count (int, optional): Number of qubits this quantum operator acts on.
                 If all instances of the operator act on the same number of qubits, this argument
                 should be ``None``, and ``fixed_qubit_count`` should be implemented to return
-                the qubit count. Only pass an int to this argument if instances can have a varying
-                number of qubits, in which case ``fixed_qubit_count`` should not be implemented.
+                the qubit count; if ``fixed_qubit_count`` is implemented and an int is passed in,
+                it must equal ``fixed_qubit_count``, or instantiation will raise a ValueError.
+                An int must be passed in if instances can have a varying number of qubits,
+                in which case ``fixed_qubit_count`` should not be implemented,
             ascii_symbols (Sequence[str]): ASCII string symbols for the quantum operator.
                 These are used when printing a diagram of circuits.
                 Length must be the same as `qubit_count`, and index ordering is expected
@@ -41,14 +43,21 @@ class QuantumOperator(Operator):
 
         Raises:
             TypeError: `qubit_count` is not an int
-            ValueError: `qubit_count` is less than 1, `ascii_symbols` are `None`, or
-                `ascii_symbols` length != `qubit_count`
+            ValueError: `qubit_count` is less than 1, `ascii_symbols` are `None`,
+                ``fixed_qubit_count`` is implemented and and not equal to ``qubit_count``,
+                or ``len(ascii_symbols) != qubit_count``
         """
 
         fixed_qubit_count = self.fixed_qubit_count()
-        self._qubit_count = (
-            qubit_count if fixed_qubit_count is NotImplemented else fixed_qubit_count
-        )
+        if fixed_qubit_count is NotImplemented:
+            self._qubit_count = qubit_count
+        else:
+            if qubit_count and qubit_count != fixed_qubit_count:
+                raise ValueError(
+                    f"Provided qubit count {qubit_count}"
+                    "does not equal fixed qubit count {fixed_qubit_count}"
+                )
+            self._qubit_count = fixed_qubit_count
 
         if not isinstance(self._qubit_count, int):
             raise TypeError(f"qubit_count, {self._qubit_count}, must be an integer")

--- a/src/braket/circuits/quantum_operator.py
+++ b/src/braket/circuits/quantum_operator.py
@@ -10,9 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
-from typing import Any, List, Sequence
+from typing import Any, List, Optional, Sequence
 
 import numpy as np
 
@@ -22,10 +23,14 @@ from braket.circuits.operator import Operator
 class QuantumOperator(Operator):
     """A quantum operator is the definition of a quantum operation for a quantum device."""
 
-    def __init__(self, qubit_count: int, ascii_symbols: Sequence[str]):
+    def __init__(self, qubit_count: Optional[int], ascii_symbols: Sequence[str]):
         """
         Args:
-            qubit_count (int): Number of qubits this quantum operator interacts with.
+            qubit_count (int, optional): Number of qubits this quantum operator acts on.
+                If all instances of the operator act on the same number of qubits, this argument
+                should be ``None``, and ``fixed_qubit_count`` should be implemented to return
+                the qubit count. Only pass an int to this argument if instances can have a varying
+                number of qubits, in which case ``fixed_qubit_count`` should not be implemented.
             ascii_symbols (Sequence[str]): ASCII string symbols for the quantum operator.
                 These are used when printing a diagram of circuits.
                 Length must be the same as `qubit_count`, and index ordering is expected
@@ -35,25 +40,50 @@ class QuantumOperator(Operator):
                 correlate a symbol with that index.
 
         Raises:
+            TypeError: `qubit_count` is not an int
             ValueError: `qubit_count` is less than 1, `ascii_symbols` are `None`, or
                 `ascii_symbols` length != `qubit_count`
         """
 
-        if qubit_count < 1:
-            raise ValueError(f"qubit_count, {qubit_count}, must be greater than zero")
-        self._qubit_count = qubit_count
+        fixed_qubit_count = self.fixed_qubit_count()
+        self._qubit_count = (
+            qubit_count if fixed_qubit_count is NotImplemented else fixed_qubit_count
+        )
+
+        if not isinstance(self._qubit_count, int):
+            raise TypeError(f"qubit_count, {self._qubit_count}, must be an integer")
+
+        if self._qubit_count < 1:
+            raise ValueError(f"qubit_count, {self._qubit_count}, must be greater than zero")
 
         if ascii_symbols is None:
             raise ValueError("ascii_symbols must not be None")
 
-        if len(ascii_symbols) != qubit_count:
-            msg = f"ascii_symbols, {ascii_symbols}, length must equal qubit_count, {qubit_count}"
+        if len(ascii_symbols) != self._qubit_count:
+            msg = (
+                f"ascii_symbols, {ascii_symbols},"
+                f" length must equal qubit_count, {self._qubit_count}"
+            )
             raise ValueError(msg)
         self._ascii_symbols = tuple(ascii_symbols)
 
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        """
+        Returns the number of qubits this quantum operator acts on,
+        if instances are guaranteed to act on the same number of qubits.
+
+        If different instances can act on a different number of qubits,
+        this method returns ``NotImplemented``.
+
+        Returns:
+            int: The number of qubits this quantum operator acts on.
+        """
+        return NotImplemented
+
     @property
     def qubit_count(self) -> int:
-        """int: Returns number of qubits this quantum operator interacts with."""
+        """int: The number of qubits this quantum operator acts on."""
         return self._qubit_count
 
     @property

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -296,6 +296,14 @@ def test_gate_to_matrix(testclass, subroutine_name, irclass, irsubclasses, kwarg
     assert gate1.matrix_equivalence(gate2)
 
 
+@pytest.mark.parametrize("testclass,subroutine_name,irclass,irsubclasses,kwargs", testdata)
+def test_fixed_qubit_count(testclass, subroutine_name, irclass, irsubclasses, kwargs):
+    fixed_qubit_count = testclass.fixed_qubit_count()
+    if fixed_qubit_count is not NotImplemented:
+        gate = testclass(**create_valid_gate_class_input(irsubclasses, **kwargs))
+        assert gate.qubit_count == fixed_qubit_count
+
+
 # Additional Unitary gate tests
 
 

--- a/test/unit_tests/braket/circuits/test_noise_helpers.py
+++ b/test/unit_tests/braket/circuits/test_noise_helpers.py
@@ -23,7 +23,7 @@ from braket.circuits.noise_helpers import apply_noise_to_gates, apply_noise_to_m
 from braket.circuits.qubit_set import QubitSet
 
 invalid_data_noise_type = [Gate.X(), None, 1.5]
-invalid_data_target_gates_type = [([-1, "foo"]), ([1.5, None, -1]), "X", ([Gate.X, "CNot"])]
+invalid_data_target_gates_type = [[-1, "foo"], [1.5, None, -1], "X", [Gate.X, "CNot"]]
 invalid_data_target_qubits_value = [-1]
 invalid_data_target_qubits_type = [1.5, "foo", ["foo", 1]]
 invalid_data_target_unitary_value = [np.array([[0, 0], [1, 0]])]
@@ -180,6 +180,12 @@ def test_apply_readout_noise_invalid_target_qubits_type(
     circuit_2qubit, noise_1qubit, target_qubits
 ):
     circuit_2qubit.apply_readout_noise(noise_1qubit, target_qubits=target_qubits)
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_apply_gate_noise_fixed_qubit_count_not_implemented(noise_2qubit):
+    circ = Circuit().unitary([0, 1], matrix=np.eye(4))
+    circ.apply_gate_noise(noise_2qubit, target_gates=Gate.Unitary)
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/test/unit_tests/braket/circuits/test_noises.py
+++ b/test/unit_tests/braket/circuits/test_noises.py
@@ -372,6 +372,14 @@ def test_noise_to_matrix(testclass, subroutine_name, irclass, irsubclasses, kwar
     assert all(np.allclose(m1, m2) for m1, m2 in zip(noise1.to_matrix(), noise2.to_matrix()))
 
 
+@pytest.mark.parametrize("testclass,subroutine_name,irclass,irsubclasses,kwargs", testdata)
+def test_fixed_qubit_count(testclass, subroutine_name, irclass, irsubclasses, kwargs):
+    fixed_qubit_count = testclass.fixed_qubit_count()
+    if fixed_qubit_count is not NotImplemented:
+        noise = testclass(**create_valid_noise_class_input(irsubclasses, **kwargs))
+        assert noise.qubit_count == fixed_qubit_count
+
+
 # Additional Unitary noise tests
 
 

--- a/test/unit_tests/braket/circuits/test_quantum_operator.py
+++ b/test/unit_tests/braket/circuits/test_quantum_operator.py
@@ -26,6 +26,21 @@ def test_is_operator(quantum_operator):
     assert isinstance(quantum_operator, Operator)
 
 
+def test_fixed_qubit_count_implemented():
+    class DummyQuantumOperator(QuantumOperator):
+        @staticmethod
+        def fixed_qubit_count():
+            return 2
+
+    operator = DummyQuantumOperator(qubit_count=None, ascii_symbols=["foo", "bar"])
+    assert operator.qubit_count == DummyQuantumOperator.fixed_qubit_count()
+
+
+@pytest.mark.xfail(raises=TypeError)
+def test_qubit_count_not_int():
+    QuantumOperator(qubit_count="hello", ascii_symbols=[])
+
+
 @pytest.mark.xfail(raises=ValueError)
 def test_qubit_count_lt_one():
     QuantumOperator(qubit_count=0, ascii_symbols=[])

--- a/test/unit_tests/braket/circuits/test_quantum_operator.py
+++ b/test/unit_tests/braket/circuits/test_quantum_operator.py
@@ -17,6 +17,12 @@ import pytest
 from braket.circuits import Operator, QuantumOperator
 
 
+class _DummyQuantumOperator(QuantumOperator):
+    @staticmethod
+    def fixed_qubit_count():
+        return 2
+
+
 @pytest.fixture
 def quantum_operator():
     return QuantumOperator(qubit_count=1, ascii_symbols=["foo"])
@@ -27,13 +33,13 @@ def test_is_operator(quantum_operator):
 
 
 def test_fixed_qubit_count_implemented():
-    class DummyQuantumOperator(QuantumOperator):
-        @staticmethod
-        def fixed_qubit_count():
-            return 2
+    operator = _DummyQuantumOperator(qubit_count=None, ascii_symbols=["foo", "bar"])
+    assert operator.qubit_count == _DummyQuantumOperator.fixed_qubit_count()
 
-    operator = DummyQuantumOperator(qubit_count=None, ascii_symbols=["foo", "bar"])
-    assert operator.qubit_count == DummyQuantumOperator.fixed_qubit_count()
+
+@pytest.mark.xfail(raises=ValueError)
+def test_qubit_count_fixed_qubit_count_unequal():
+    _DummyQuantumOperator(qubit_count=1, ascii_symbols=["foo", "bar"])
 
 
 @pytest.mark.xfail(raises=TypeError)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Introduced `fixed_qubit_count` so customers don't need to instantiate a gate or noise operation to see its qubit count. Also fixed a bug when checking compatibility of gate and noise qubit counts, where the gate could always be instantiated with no arguments, which obviously fails for parametrized gates.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
