### PR TITLE
fix: Result Type syntax in repr

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -905,7 +905,7 @@ the number of qubits in target_qubits must be the same as defined by the multi-q
         else:
             return (
                 f"Circuit('instructions': {list(self.instructions)}"
-                + f"result_types': {self.result_types})"
+                + f", 'result_types': {self.result_types})"
             )
 
     def __str__(self):


### PR DESCRIPTION
*Issue #, if available:*
252

*Description of changes:*
The issue was that repr() output has a syntax error: `...]result_types': ...`. The fix was to add `, '` so it would read `...], 'result_types': ...`.

*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
