### PR TITLE
allow integer valued non-int type for qubit index

### DIFF
--- a/src/braket/circuits/qubit.py
+++ b/src/braket/circuits/qubit.py
@@ -36,7 +36,9 @@ class Qubit(int):
             >>> Qubit(0)
             >>> Qubit(1)
         """
-        if not isinstance(index, int):
+        try:
+            assert int(index) == index
+        except (ValueError, AssertionError):
             raise TypeError(f"Supplied qubit index, {index}, must be an integer.")
         if index < 0:
             raise ValueError(f"Supplied qubit index, {index}, cannot be less than zero.")

--- a/src/braket/circuits/qubit.py
+++ b/src/braket/circuits/qubit.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import numbers
 from typing import Union
 
 QubitInput = Union["Qubit", int]
@@ -36,9 +37,7 @@ class Qubit(int):
             >>> Qubit(0)
             >>> Qubit(1)
         """
-        try:
-            assert int(index) == index
-        except (ValueError, AssertionError):
+        if not isinstance(index, numbers.Integral):
             raise TypeError(f"Supplied qubit index, {index}, must be an integer.")
         if index < 0:
             raise ValueError(f"Supplied qubit index, {index}, cannot be less than zero.")

--- a/test/unit_tests/braket/circuits/test_qubit.py
+++ b/test/unit_tests/braket/circuits/test_qubit.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import numpy as np
 import pytest
 
 from braket.circuits import Qubit
@@ -32,7 +33,7 @@ def test_index_non_int(qubit_arg):
     Qubit(qubit_arg)
 
 
-@pytest.mark.parametrize("qubit_index", (0, 5, float(0)))
+@pytest.mark.parametrize("qubit_index", (0, 5, np.int64(5)))
 def test_index_gte_zero(qubit_index):
     Qubit(qubit_index)
 

--- a/test/unit_tests/braket/circuits/test_qubit.py
+++ b/test/unit_tests/braket/circuits/test_qubit.py
@@ -32,9 +32,9 @@ def test_index_non_int(qubit_arg):
     Qubit(qubit_arg)
 
 
-def test_index_gte_zero():
-    Qubit(0)
-    Qubit(5)
+@pytest.mark.parametrize("qubit_index", (0, 5, float(0)))
+def test_index_gte_zero(qubit_index):
+    Qubit(qubit_index)
 
 
 def test_str(qubit):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Check value rather than type to make sure qubit index is an int.

*Testing done:*

unit test added

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
