### PR TITLE
fix: Pass along endpoint url when copying an AwsSession

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -325,6 +325,7 @@ class AwsDevice(Device):
         session_region = aws_session.boto_session.region_name
         new_region = region or session_region
         creds = aws_session.boto_session.get_credentials()
+        client = aws_session.braket_client
         if creds.method == "explicit":
             boto_session = boto3.Session(
                 aws_access_key_id=creds.access_key,
@@ -334,7 +335,8 @@ class AwsDevice(Device):
             )
         else:
             boto_session = boto3.Session(region_name=new_region)
-        return AwsSession(boto_session=boto_session, config=config)
+        braket_client = boto_session.client('braket', endpoint_url=client._endpoint.host)
+        return AwsSession(boto_session=boto_session, braket_client=braket_client, config=config)
 
     def __repr__(self):
         return "Device('name': {}, 'arn': {})".format(self.name, self.arn)


### PR DESCRIPTION
Change `_copy_aws_session` to also track the endpoint URL of the original session to its clone. Need some help writing a nice test for this as my knowledge of `botocore` is rudimentary.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
