### PR TITLE
change: Add test for local simulator device names

### DIFF
--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -110,3 +110,16 @@ def test_result_types_all_selected(shots):
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_observable_not_in_instructions(shots):
     result_types_observable_not_in_instructions(DEVICE, {"shots": shots})
+
+
+@pytest.mark.parametrize(
+    "backend, device_name",
+    [
+        ("default", "StateVectorSimulator"),
+        ("braket_sv", "StateVectorSimulator"),
+        ("braket_dm", "DensityMatrixSimulator"),
+    ],
+)
+def test_local_simulator_device_names(backend, device_name):
+    local_simulator_device = LocalSimulator(backend)
+    assert local_simulator_device.name == device_name


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added a test for catching changes to device names. The local simulator class renaming caused one of the example notebooks to break. This test would ensure that we detect such changes in the future.

*Testing done:*
* `tox -e integ-tests -- -k 'test_local_simulator_device_names'` succeeded.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
