### PR TITLE
feature: Calculate arbitrary observables when `shots=0`

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -123,8 +123,9 @@ class Circuit:
         self._moments: Moments = Moments()
         self._result_types: Dict[ResultType] = {}
         self._qubit_observable_mapping: Dict[Union[int, Circuit._ALL_QUBITS], Observable] = {}
-        self._qubit_target_mapping: Dict[int, Tuple[int]] = {}
+        self._qubit_observable_target_mapping: Dict[int, Tuple[int]] = {}
         self._qubit_observable_set = set()
+        self._noncommuting_observables = False
 
         if addable is not None:
             self.add(addable, *args, **kwargs)
@@ -150,6 +151,9 @@ class Circuit:
         """List[Instruction]: Get a list of basis rotation instructions in the circuit.
         These basis rotation instructions are added if result types are requested for
         an observable other than Pauli-Z.
+
+        This only makes sense if all observables mutually commute; if noncommuting observables
+        are attached to the circuit, this method will return an empty list.
         """
         # Note that basis_rotation_instructions can change each time a new instruction
         # is added to the circuit because `self._moments.qubits` would change
@@ -162,7 +166,7 @@ class Circuit:
                 )
             return basis_rotation_instructions
 
-        target_lists = sorted(list(set(self._qubit_target_mapping.values())))
+        target_lists = sorted(set(self._qubit_observable_target_mapping.values()))
         for target_list in target_lists:
             observable = self._qubit_observable_mapping[target_list[0]]
             basis_rotation_instructions += Circuit._observable_to_instruction(
@@ -194,7 +198,7 @@ class Circuit:
         self,
         result_type: ResultType,
         target: QubitSetInput = None,
-        target_mapping: Dict[QubitInput, QubitInput] = {},
+        target_mapping: Dict[QubitInput, QubitInput] = None,
     ) -> Circuit:
         """
         Add a requested result type to `self`, returns `self` for chaining ability.
@@ -207,7 +211,7 @@ class Circuit:
             target_mapping (dictionary[int or Qubit, int or Qubit], optional): A dictionary of
                 qubit mappings to apply to the `result_type.target`. Key is the qubit in
                 `result_type.target` and the value is what the key will be changed to.
-                Default = `{}`.
+                Default = `None`.
 
 
         Note: target and target_mapping will only be applied to those requested result types with
@@ -219,9 +223,6 @@ class Circuit:
 
         Raises:
             TypeError: If both `target_mapping` and `target` are supplied.
-            ValueError: If the observable specified for a qubit is different from what is
-                specified by the result types already added to the circuit. Only one observable
-                is allowed for a qubit.
 
         Examples:
             >>> result_type = ResultType.Probability(target=[0, 1])
@@ -258,87 +259,74 @@ class Circuit:
             result_type_to_add = result_type.copy(target=target)
 
         if result_type_to_add not in self._result_types:
-            self._add_to_qubit_observable_mapping(result_type_to_add)
+            observable = Circuit._extract_observable(result_type_to_add)
+            if observable and not self._noncommuting_observables:
+                # Only check if all observables can be simultaneously diagonalized,
+                # i.e. there are no noncommuting observables
+                self._add_to_qubit_observable_mapping(observable, result_type_to_add.target)
             self._add_to_qubit_observable_set(result_type_to_add)
             # using dict as an ordered set, value is arbitrary
             self._result_types[result_type_to_add] = None
         return self
 
-    def _add_to_qubit_observable_mapping(self, result_type: ResultType) -> None:
+    @staticmethod
+    def _extract_observable(result_type: ResultType) -> Optional[Observable]:
         if isinstance(result_type, ResultType.Probability):
-            observable = Observable.Z()  # computational basis
+            return Observable.Z()  # computational basis
         elif isinstance(result_type, ObservableResultType):
-            observable = result_type.observable
+            return result_type.observable
         else:
-            return
+            return None
 
-        targets = result_type.target or list(self._qubit_observable_set)
+    def _add_to_qubit_observable_mapping(
+        self, observable: Observable, observable_target: QubitSet
+    ) -> None:
+        targets = observable_target or list(self._qubit_observable_set)
         all_qubits_observable = self._qubit_observable_mapping.get(Circuit._ALL_QUBITS)
+        tensor_product_dict = (
+            Circuit._tensor_product_index_dict(observable, observable_target)
+            if isinstance(observable, TensorProduct)
+            else None
+        )
+        identity = Observable.I()
         for i in range(len(targets)):
             target = targets[i]
-            tensor_product_dict = (
-                Circuit._tensor_product_index_dict(observable)
-                if isinstance(observable, TensorProduct)
-                else None
-            )
             new_observable = tensor_product_dict[i][0] if tensor_product_dict else observable
             current_observable = all_qubits_observable or self._qubit_observable_mapping.get(target)
 
-            add_observable = Circuit._validate_observable_to_add_for_qubit(
-                current_observable, new_observable, target
+            add_observable = not current_observable or (
+                current_observable == identity and new_observable != identity
             )
+            if (
+                not add_observable
+                and current_observable != identity
+                and new_observable != identity
+                and current_observable != new_observable
+            ):
+                return self._encounter_noncommuting_observable()
 
-            if result_type.target:
+            if observable_target:
                 new_targets = (
-                    tuple(
-                        result_type.target[
-                            tensor_product_dict[i][1][0] : tensor_product_dict[i][1][1]
-                        ]
-                    )
-                    if tensor_product_dict
-                    else tuple(result_type.target)
+                    tensor_product_dict[i][1] if tensor_product_dict else tuple(observable_target)
                 )
+
                 if add_observable:
-                    self._qubit_target_mapping[target] = new_targets
+                    self._qubit_observable_target_mapping[target] = new_targets
                     self._qubit_observable_mapping[target] = new_observable
                 elif new_observable.qubit_count > 1:
-                    current_target = self._qubit_target_mapping.get(target)
+                    current_target = self._qubit_observable_target_mapping.get(target)
                     if current_target and current_target != new_targets:
-                        raise ValueError(
-                            f"Target order {current_target} of existing result type with"
-                            f" observable {current_observable} conflicts with order {targets}"
-                            " of new result type"
-                        )
+                        return self._encounter_noncommuting_observable()
 
-        if not result_type.target:
+        if not observable_target:
             if all_qubits_observable and all_qubits_observable != observable:
-                raise ValueError(
-                    f"Existing result type for observable {all_qubits_observable} for all qubits"
-                    f" conflicts with observable {observable} for new result type"
-                )
+                return self._encounter_noncommuting_observable()
             self._qubit_observable_mapping[Circuit._ALL_QUBITS] = observable
 
     @staticmethod
-    def _validate_observable_to_add_for_qubit(current_observable, new_observable, target):
-        identity = Observable.I()
-        add_observable = False
-        if not current_observable or (
-            current_observable == identity and new_observable != identity
-        ):
-            add_observable = True
-        elif (
-            current_observable != identity
-            and new_observable != identity
-            and current_observable != new_observable
-        ):
-            raise ValueError(
-                f"Observable {new_observable} specified for target {target} conflicts with"
-                + f" existing observable {current_observable} on this target."
-            )
-        return add_observable
-
-    @staticmethod
-    def _tensor_product_index_dict(observable: TensorProduct) -> Dict[int, Observable]:
+    def _tensor_product_index_dict(
+        observable: TensorProduct, observable_target: QubitSet
+    ) -> Dict[int, Tuple[Observable, Tuple[int, ...]]]:
         obj_dict = {}
         i = 0
         factors = list(observable.factors)
@@ -349,7 +337,8 @@ class Circuit:
                 if factors:
                     total += factors[0].qubit_count
             if factors:
-                obj_dict[i] = (factors[0], (total - factors[0].qubit_count, total))
+                first = total - factors[0].qubit_count
+                obj_dict[i] = (factors[0], tuple(observable_target[first:total]))
             i += 1
         return obj_dict
 
@@ -911,6 +900,20 @@ the number of qubits in target_qubits must be the same as defined by the multi-q
         qubit_count = max(qubits) + 1
 
         return calculate_unitary(qubit_count, self.instructions)
+
+    @property
+    def has_noncommuting_observables(self) -> bool:
+        """bool: Whether the circuit has noncommuting observables
+
+        If this is True, then the circuit can only be run for shots = 0, as noncommuting observables
+        cannot be simultaneously diagonalized for sample measurements.
+        """
+        return self._noncommuting_observables
+
+    def _encounter_noncommuting_observable(self):
+        self._noncommuting_observables = True
+        self._qubit_observable_mapping.clear()
+        self._qubit_observable_target_mapping.clear()
 
     def _copy(self) -> Circuit:
         copy = Circuit().add(self.instructions)

--- a/src/braket/circuits/circuit_helpers.py
+++ b/src/braket/circuits/circuit_helpers.py
@@ -25,8 +25,8 @@ def validate_circuit_and_shots(circuit: Circuit, shots: int) -> None:
     Raises:
         ValueError: If circuit has no instructions; if no result types
             specified for circuit and `shots=0`. See `braket.circuit.result_types`;
-            if circuit has noncommuting observables when shots > 0;
-            or, if `StateVector` or `Amplitude` are specified as result types when `shots > 0`.
+            if circuit has observables that cannot be simultaneously measured and `shots>0`;
+            or, if `StateVector` or `Amplitude` are specified as result types when `shots>0`.
     """
     if not circuit.instructions:
         raise ValueError("Circuit must have instructions to run on a device")
@@ -35,8 +35,8 @@ def validate_circuit_and_shots(circuit: Circuit, shots: int) -> None:
             "No result types specified for circuit and shots=0. See `braket.circuit.result_types`"
         )
     elif shots and circuit.result_types:
-        if circuit.has_noncommuting_observables:
-            raise ValueError("Noncommuting observables cannot be sampled simultaneously")
+        if not circuit.observables_simultaneously_measurable:
+            raise ValueError("Observables cannot be sampled simultaneously")
         for rt in circuit.result_types:
             if isinstance(rt, ResultType.StateVector) or isinstance(rt, ResultType.Amplitude):
                 raise ValueError("StateVector or Amplitude cannot be specified when shots>0")

--- a/src/braket/circuits/circuit_helpers.py
+++ b/src/braket/circuits/circuit_helpers.py
@@ -23,9 +23,10 @@ def validate_circuit_and_shots(circuit: Circuit, shots: int) -> None:
         shots (int): shots to validate
 
     Raises:
-        ValueError: If circuit has no instructions. Also, if no result types
-            specified for circuit and `shots=0`. See `braket.circuit.result_types`.
-            Or, if `StateVector` or `Amplitude` are specified as result types when `shots > 0`.
+        ValueError: If circuit has no instructions; if no result types
+            specified for circuit and `shots=0`. See `braket.circuit.result_types`;
+            if circuit has noncommuting observables when shots > 0;
+            or, if `StateVector` or `Amplitude` are specified as result types when `shots > 0`.
     """
     if not circuit.instructions:
         raise ValueError("Circuit must have instructions to run on a device")
@@ -34,6 +35,8 @@ def validate_circuit_and_shots(circuit: Circuit, shots: int) -> None:
             "No result types specified for circuit and shots=0. See `braket.circuit.result_types`"
         )
     elif shots and circuit.result_types:
+        if circuit.has_noncommuting_observables:
+            raise ValueError("Noncommuting observables cannot be sampled simultaneously")
         for rt in circuit.result_types:
             if isinstance(rt, ResultType.StateVector) or isinstance(rt, ResultType.Amplitude):
                 raise ValueError("StateVector or Amplitude cannot be specified when shots>0")

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -214,7 +214,7 @@ def get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, s
         .expectation(obs, obs_targets)
     )
     if shots:
-        circuit.add_result_type(ResultType.Sample(obs, obs_targets))
+        circuit.sample(obs, obs_targets)
     return circuit
 
 
@@ -423,6 +423,77 @@ def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str
     assert_variance_expectation_sample_result(
         result, shots, expected_var, expected_mean, expected_eigs
     )
+
+
+def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any]):
+    shots = 0
+    theta = 0.432
+    phi = 0.123
+    varphi = -0.543
+    array = np.array(
+        [
+            [-6, 2 + 1j, -3, -5 + 2j],
+            [2 - 1j, 0, 2 - 1j, -5 + 4j],
+            [-3, 2 + 1j, 0, -4 + 3j],
+            [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+        ]
+    )
+    obs1 = Observable.X() @ Observable.Y()
+    obs1_targets = [0, 2]
+    obs2 = Observable.Z() @ Observable.Z()
+    obs2_targets = [0, 2]
+    obs3 = Observable.Y() @ Observable.Hermitian(array)
+    obs3_targets = [0, 1, 2]
+    circuit = (
+        get_result_types_three_qubit_circuit(theta, phi, varphi, obs1, obs1_targets, shots)
+        .expectation(obs2, obs2_targets)
+        .expectation(obs3, obs3_targets)
+    )
+    result = device.run(circuit, **run_kwargs).result()
+
+    expected_mean1 = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+    expected_var1 = (
+        8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+        - np.cos(2 * (theta - phi))
+        - np.cos(2 * (theta + phi))
+        + 2 * np.cos(2 * theta)
+        + 2 * np.cos(2 * phi)
+        + 14
+    ) / 16
+
+    expected_mean2 = 0.849694136476246
+    expected_mean3 = 1.4499810303182408
+    assert np.allclose(result.values[0], expected_var1)
+    assert np.allclose(result.values[1], expected_mean1)
+    assert np.allclose(result.values[2], expected_mean2)
+    assert np.allclose(result.values[3], expected_mean3)
+
+
+def result_types_noncommuting_flipped_targets_testing(device: Device, run_kwargs: Dict[str, Any]):
+    circuit = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
+        .expectation(observable=Observable.H() @ Observable.X(), target=[1, 0])
+    )
+    result = device.run(circuit, shots=0, **run_kwargs).result()
+    assert np.allclose(result.values[0], np.sqrt(2) / 2)
+    assert np.allclose(result.values[1], np.sqrt(2) / 2)
+
+
+def result_types_noncommuting_all(device: Device, run_kwargs: Dict[str, Any]):
+    array = np.array([[1, 2j], [-2j, 0]])
+    circuit = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .expectation(observable=Observable.Hermitian(array))
+        .expectation(observable=Observable.X())
+    )
+    result = device.run(circuit, shots=0, **run_kwargs).result()
+    assert np.allclose(result.values[0], [0.5, 0.5])
+    assert np.allclose(result.values[1], [0, 0])
 
 
 def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -20,6 +20,9 @@ from gate_model_device_testing_utils import (
     result_types_bell_pair_full_probability_testing,
     result_types_bell_pair_marginal_probability_testing,
     result_types_hermitian_testing,
+    result_types_noncommuting_all,
+    result_types_noncommuting_flipped_targets_testing,
+    result_types_noncommuting_testing,
     result_types_nonzero_shots_bell_pair_testing,
     result_types_observable_not_in_instructions,
     result_types_tensor_hermitian_hermitian_testing,
@@ -105,6 +108,18 @@ def test_result_types_tensor_y_hermitian(shots):
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_all_selected(shots):
     result_types_all_selected_testing(DEVICE, {"shots": shots})
+
+
+def test_result_types_noncommuting():
+    result_types_noncommuting_testing(DEVICE, {})
+
+
+def test_result_types_noncommuting_flipped_targets():
+    result_types_noncommuting_flipped_targets_testing(DEVICE, {})
+
+
+def test_result_types_noncommuting_all():
+    result_types_noncommuting_all(DEVICE, {})
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])

--- a/test/integ_tests/test_local_noise_simulator.py
+++ b/test/integ_tests/test_local_noise_simulator.py
@@ -21,6 +21,9 @@ from gate_model_device_testing_utils import (
     result_types_bell_pair_full_probability_testing,
     result_types_bell_pair_marginal_probability_testing,
     result_types_hermitian_testing,
+    result_types_noncommuting_all,
+    result_types_noncommuting_flipped_targets_testing,
+    result_types_noncommuting_testing,
     result_types_nonzero_shots_bell_pair_testing,
     result_types_tensor_hermitian_hermitian_testing,
     result_types_tensor_x_y_testing,
@@ -96,6 +99,18 @@ def test_result_types_tensor_y_hermitian(shots):
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_all_selected(shots):
     result_types_all_selected_testing(DEVICE, {"shots": shots})
+
+
+def test_result_types_noncommuting():
+    result_types_noncommuting_testing(DEVICE, {})
+
+
+def test_result_types_noncommuting_flipped_targets():
+    result_types_noncommuting_flipped_targets_testing(DEVICE, {})
+
+
+def test_result_types_noncommuting_all():
+    result_types_noncommuting_all(DEVICE, {})
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -21,6 +21,9 @@ from gate_model_device_testing_utils import (
     result_types_bell_pair_full_probability_testing,
     result_types_bell_pair_marginal_probability_testing,
     result_types_hermitian_testing,
+    result_types_noncommuting_all,
+    result_types_noncommuting_flipped_targets_testing,
+    result_types_noncommuting_testing,
     result_types_nonzero_shots_bell_pair_testing,
     result_types_observable_not_in_instructions,
     result_types_tensor_hermitian_hermitian_testing,
@@ -152,6 +155,28 @@ def test_result_types_all_selected(simulator_arn, shots, aws_session, s3_destina
     result_types_all_selected_testing(
         device, {"shots": shots, "s3_destination_folder": s3_destination_folder}
     )
+
+
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
+def test_result_types_noncommuting(simulator_arn, aws_session, s3_destination_folder):
+    device = AwsDevice(simulator_arn, aws_session)
+    result_types_noncommuting_testing(device, {"s3_destination_folder": s3_destination_folder})
+
+
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
+def test_result_types_noncommuting_flipped_targets(
+    simulator_arn, aws_session, s3_destination_folder
+):
+    device = AwsDevice(simulator_arn, aws_session)
+    result_types_noncommuting_flipped_targets_testing(
+        device, {"s3_destination_folder": s3_destination_folder}
+    )
+
+
+@pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
+def test_result_types_noncommuting_all(simulator_arn, aws_session, s3_destination_folder):
+    device = AwsDevice(simulator_arn, aws_session)
+    result_types_noncommuting_all(device, {"s3_destination_folder": s3_destination_folder})
 
 
 @pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -105,49 +105,49 @@ def test_equality():
 
 def test_add_result_type_default(prob):
     circ = Circuit().add_result_type(prob)
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert list(circ.result_types) == [prob]
 
 
 def test_add_result_type_with_mapping(prob):
     expected = [ResultType.Probability([10, 11])]
     circ = Circuit().add_result_type(prob, target_mapping={0: 10, 1: 11})
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert list(circ.result_types) == expected
 
 
 def test_add_result_type_with_target(prob):
     expected = [ResultType.Probability([10, 11])]
     circ = Circuit().add_result_type(prob, target=[10, 11])
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert list(circ.result_types) == expected
 
 
 def test_add_result_type_already_exists():
     expected = [ResultType.StateVector()]
     circ = Circuit(expected).add_result_type(expected[0])
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert list(circ.result_types) == expected
 
 
 def test_add_result_type_observable_conflict_target():
     circ = Circuit().add_result_type(ResultType.Probability([0, 1]))
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=0))
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 
 def test_add_result_type_observable_conflict_all():
     circ = Circuit().add_result_type(ResultType.Probability())
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y()))
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 
 def test_add_result_type_observable_conflict_all_target_then_selected_target():
     circ = Circuit().add_result_type(ResultType.Probability())
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[0]))
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 
@@ -155,14 +155,14 @@ def test_add_result_type_observable_conflict_different_selected_targets_then_all
     circ = Circuit().add_result_type(ResultType.Expectation(observable=Observable.Z(), target=[0]))
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[1]))
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y()))
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 
 def test_add_result_type_observable_conflict_selected_target_then_all_target():
     circ = Circuit().add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[1]))
     circ.add_result_type(ResultType.Probability())
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 
@@ -172,7 +172,7 @@ def test_add_result_type_observable_no_conflict_all_target():
         ResultType.Expectation(observable=Observable.Z(), target=[0]),
     ]
     circ = Circuit(expected)
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert circ.result_types == expected
 
 
@@ -182,7 +182,7 @@ def test_add_result_type_observable_no_conflict_target_all():
         ResultType.Probability(),
     ]
     circ = Circuit(expected)
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert circ.result_types == expected
 
 
@@ -192,7 +192,7 @@ def test_add_result_type_observable_no_conflict_all():
         ResultType.Expectation(observable=Observable.Y()),
     ]
     circ = Circuit(expected)
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert circ.result_types == expected
 
 
@@ -202,7 +202,7 @@ def test_add_result_type_observable_no_conflict_state_vector_obs_return_value():
         ResultType.Expectation(observable=Observable.Y()),
     ]
     circ = Circuit(expected)
-    assert not circ.has_noncommuting_observables
+    assert circ.observables_simultaneously_measurable
     assert circ.result_types == expected
 
 
@@ -216,7 +216,7 @@ def test_add_result_type_same_observable_wrong_target_order_tensor_product():
             ResultType.Variance(observable=Observable.Y() @ Observable.X(), target=[1, 0])
         )
     )
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 
@@ -231,7 +231,7 @@ def test_add_result_type_same_observable_wrong_target_order_hermitian():
             ResultType.Variance(observable=Observable.Hermitian(matrix=array), target=[1, 0])
         )
     )
-    assert circ.has_noncommuting_observables
+    assert not circ.observables_simultaneously_measurable
     assert not circ.basis_rotation_instructions
 
 

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -105,58 +105,65 @@ def test_equality():
 
 def test_add_result_type_default(prob):
     circ = Circuit().add_result_type(prob)
+    assert not circ.has_noncommuting_observables
     assert list(circ.result_types) == [prob]
 
 
 def test_add_result_type_with_mapping(prob):
     expected = [ResultType.Probability([10, 11])]
     circ = Circuit().add_result_type(prob, target_mapping={0: 10, 1: 11})
+    assert not circ.has_noncommuting_observables
     assert list(circ.result_types) == expected
 
 
 def test_add_result_type_with_target(prob):
     expected = [ResultType.Probability([10, 11])]
     circ = Circuit().add_result_type(prob, target=[10, 11])
+    assert not circ.has_noncommuting_observables
     assert list(circ.result_types) == expected
 
 
 def test_add_result_type_already_exists():
     expected = [ResultType.StateVector()]
     circ = Circuit(expected).add_result_type(expected[0])
+    assert not circ.has_noncommuting_observables
     assert list(circ.result_types) == expected
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_observable_conflict_target():
     circ = Circuit().add_result_type(ResultType.Probability([0, 1]))
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=0))
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_observable_conflict_all():
     circ = Circuit().add_result_type(ResultType.Probability())
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y()))
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_observable_conflict_all_target_then_selected_target():
     circ = Circuit().add_result_type(ResultType.Probability())
-    circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[0, 1]))
+    circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[0]))
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_observable_conflict_different_selected_targets_then_all_target():
     circ = Circuit().add_result_type(ResultType.Expectation(observable=Observable.Z(), target=[0]))
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[1]))
     circ.add_result_type(ResultType.Expectation(observable=Observable.Y()))
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_observable_conflict_selected_target_then_all_target():
-    circ = Circuit().add_result_type(
-        ResultType.Expectation(observable=Observable.Y(), target=[0, 1])
-    )
+    circ = Circuit().add_result_type(ResultType.Expectation(observable=Observable.Y(), target=[1]))
     circ.add_result_type(ResultType.Probability())
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
 def test_add_result_type_observable_no_conflict_all_target():
@@ -165,6 +172,7 @@ def test_add_result_type_observable_no_conflict_all_target():
         ResultType.Expectation(observable=Observable.Z(), target=[0]),
     ]
     circ = Circuit(expected)
+    assert not circ.has_noncommuting_observables
     assert circ.result_types == expected
 
 
@@ -174,6 +182,7 @@ def test_add_result_type_observable_no_conflict_target_all():
         ResultType.Probability(),
     ]
     circ = Circuit(expected)
+    assert not circ.has_noncommuting_observables
     assert circ.result_types == expected
 
 
@@ -183,6 +192,7 @@ def test_add_result_type_observable_no_conflict_all():
         ResultType.Expectation(observable=Observable.Y()),
     ]
     circ = Circuit(expected)
+    assert not circ.has_noncommuting_observables
     assert circ.result_types == expected
 
 
@@ -192,26 +202,37 @@ def test_add_result_type_observable_no_conflict_state_vector_obs_return_value():
         ResultType.Expectation(observable=Observable.Y()),
     ]
     circ = Circuit(expected)
+    assert not circ.has_noncommuting_observables
     assert circ.result_types == expected
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_same_observable_wrong_target_order_tensor_product():
-    Circuit().add_result_type(
-        ResultType.Expectation(observable=Observable.Y() @ Observable.X(), target=[0, 1])
-    ).add_result_type(
-        ResultType.Variance(observable=Observable.Y() @ Observable.X(), target=[1, 0])
+    circ = (
+        Circuit()
+        .add_result_type(
+            ResultType.Expectation(observable=Observable.Y() @ Observable.X(), target=[0, 1])
+        )
+        .add_result_type(
+            ResultType.Variance(observable=Observable.Y() @ Observable.X(), target=[1, 0])
+        )
     )
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_add_result_type_same_observable_wrong_target_order_hermitian():
     array = np.eye(4)
-    Circuit().add_result_type(
-        ResultType.Expectation(observable=Observable.Hermitian(matrix=array), target=[0, 1])
-    ).add_result_type(
-        ResultType.Variance(observable=Observable.Hermitian(matrix=array), target=[1, 0])
+    circ = (
+        Circuit()
+        .add_result_type(
+            ResultType.Expectation(observable=Observable.Hermitian(matrix=array), target=[0, 1])
+        )
+        .add_result_type(
+            ResultType.Variance(observable=Observable.Hermitian(matrix=array), target=[1, 0])
+        )
     )
+    assert circ.has_noncommuting_observables
+    assert not circ.basis_rotation_instructions
 
 
 @pytest.mark.xfail(raises=TypeError)

--- a/test/unit_tests/braket/circuits/test_circuit_helpers.py
+++ b/test/unit_tests/braket/circuits/test_circuit_helpers.py
@@ -13,7 +13,7 @@
 
 import pytest
 
-from braket.circuits import Circuit
+from braket.circuits import Circuit, observables
 from braket.circuits.circuit_helpers import validate_circuit_and_shots
 
 
@@ -52,3 +52,24 @@ def test_validate_circuit_and_shots_100_result_state_vector():
 @pytest.mark.xfail(raises=ValueError)
 def test_validate_circuit_and_shots_100_result_amplitude():
     validate_circuit_and_shots(Circuit().h(0).amplitude(state=["0"]), 100)
+
+
+def test_validate_circuit_and_shots_0_noncommuting():
+    validate_circuit_and_shots(
+        Circuit()
+        .h(0)
+        .expectation(observables.X() @ observables.Y(), [0, 1])
+        .expectation(observables.Y() @ observables.X(), [0, 1]),
+        0,
+    )
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_validate_circuit_and_shots_100_noncommuting():
+    validate_circuit_and_shots(
+        Circuit()
+        .h(0)
+        .expectation(observables.X() @ observables.Y(), [0, 1])
+        .expectation(observables.Y() @ observables.X(), [0, 1]),
+        100,
+    )


### PR DESCRIPTION
Allows arbitrary observables to be attached to a circuit, allowing, for example, the simultaneous calculation of all terms of a qubit Hamiltonian when `shots=0`. However, running such a circuit with `shots>0`, will throw an exception, as observables must commute to be measured (sampled) simultaneously; in fact, here the observables must be either identical or the identity.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
