### PR TITLE
fix: Remove immutable default args

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -349,7 +349,7 @@ class Circuit:
         self,
         instruction: Instruction,
         target: QubitSetInput = None,
-        target_mapping: Dict[QubitInput, QubitInput] = {},
+        target_mapping: Dict[QubitInput, QubitInput] = None,
     ) -> Circuit:
         """
         Add an instruction to `self`, returns `self` for chaining ability.
@@ -363,7 +363,7 @@ class Circuit:
             target_mapping (dictionary[int or Qubit, int or Qubit], optional): A dictionary of
                 qubit mappings to apply to the `instruction.target`. Key is the qubit in
                 `instruction.target` and the value is what the key will be changed to.
-                Default = `{}`.
+                Default = `None`.
 
         Returns:
             Circuit: self
@@ -418,7 +418,7 @@ class Circuit:
         self,
         circuit: Circuit,
         target: QubitSetInput = None,
-        target_mapping: Dict[QubitInput, QubitInput] = {},
+        target_mapping: Dict[QubitInput, QubitInput] = None,
     ) -> Circuit:
         """
         Add a `circuit` to self, returns self for chaining ability.
@@ -431,7 +431,7 @@ class Circuit:
                 Default = `None`.
             target_mapping (dictionary[int or Qubit, int or Qubit], optional): A dictionary of
                 qubit mappings to apply to the qubits of `circuit.instructions`. Key is the qubit
-                to map, and the value is what to change it to. Default = `{}`.
+                to map, and the value is what to change it to. Default = `None`.
 
         Returns:
             Circuit: self

--- a/src/braket/circuits/instruction.py
+++ b/src/braket/circuits/instruction.py
@@ -90,7 +90,7 @@ class Instruction:
         return self._operator.to_ir([int(qubit) for qubit in self._target])
 
     def copy(
-        self, target_mapping: Dict[QubitInput, QubitInput] = {}, target: QubitSetInput = None
+        self, target_mapping: Dict[QubitInput, QubitInput] = None, target: QubitSetInput = None
     ) -> Instruction:
         """
         Return a shallow copy of the instruction.
@@ -102,7 +102,7 @@ class Instruction:
         Args:
             target_mapping (dictionary[int or Qubit, int or Qubit], optional): A dictionary of
                 qubit mappings to apply to the target. Key is the qubit in this `target` and the
-                value is what the key is changed to. Default = `{}`.
+                value is what the key is changed to. Default = `None`.
             target (int, Qubit, or iterable of int / Qubit, optional): Target qubits for the new
                 instruction.
 
@@ -129,7 +129,7 @@ class Instruction:
         elif target is not None:
             return Instruction(self._operator, target)
         else:
-            return Instruction(self._operator, self._target.map(target_mapping))
+            return Instruction(self._operator, self._target.map(target_mapping or {}))
 
     def __repr__(self):
         return f"Instruction('operator': {self._operator}, 'target': {self._target})"

--- a/src/braket/circuits/moments.py
+++ b/src/braket/circuits/moments.py
@@ -81,7 +81,7 @@ class Moments(Mapping[MomentsKey, Instruction]):
 
     Args:
         instructions (Iterable[Instruction], optional): Instructions to initialize self.
-            Default = [].
+            Default = None.
 
     Examples:
         >>> moments = Moments()
@@ -106,13 +106,13 @@ class Moments(Mapping[MomentsKey, Instruction]):
             Value: Instruction('operator': H, 'target': QubitSet([Qubit(1)]))
     """
 
-    def __init__(self, instructions: Iterable[Instruction] = []):
+    def __init__(self, instructions: Iterable[Instruction] = None):
         self._moments: OrderedDict[MomentsKey, Instruction] = OrderedDict()
         self._max_times: Dict[Qubit, int] = {}
         self._qubits = QubitSet()
         self._depth = 0
 
-        self.add(instructions)
+        self.add(instructions or [])
 
     @property
     def depth(self) -> int:

--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -69,7 +69,9 @@ class ResultType:
         """
         raise NotImplementedError("to_ir has not been implemented yet.")
 
-    def copy(self, target_mapping: Dict[QubitInput, QubitInput] = {}, target: QubitSetInput = None):
+    def copy(
+        self, target_mapping: Dict[QubitInput, QubitInput] = None, target: QubitSetInput = None
+    ):
         """
         Return a shallow copy of the result type.
 
@@ -80,7 +82,7 @@ class ResultType:
         Args:
             target_mapping (dictionary[int or Qubit, int or Qubit], optional): A dictionary of
                 qubit mappings to apply to the target. Key is the qubit in this `target` and the
-                value is what the key is changed to. Default = `{}`.
+                value is what the key is changed to. Default = `None`.
             target (int, Qubit, or iterable of int / Qubit, optional): Target qubits for the new
                 instruction.
 
@@ -108,9 +110,8 @@ class ResultType:
         elif target is not None:
             if hasattr(copy, "target"):
                 copy.target = target
-        else:
-            if hasattr(copy, "target"):
-                copy.target = self._target.map(target_mapping)
+        elif hasattr(copy, "target"):
+            copy.target = self._target.map(target_mapping or {})
         return copy
 
     @classmethod


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed mutable default arguments (i.e. `def func(a={})`) to immutable ones (`def func(a=None)`) to avoid [unexpected bugs](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments) down the line.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
