### PR TITLE
infra: Pin docutils<0.18 in doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+docutils<0.18
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-apidoc


### PR DESCRIPTION
docutils 0.18 was released on October 26, 2021, and with it came some [breaking changes](https://github.com/readthedocs/readthedocs.org/issues/8616) for sphinx, and in turn [readthedocs builds](https://readthedocs.org/projects/amazon-braket-sdk-python/builds/15168485/). To keep doc builds working, docutils will be constrained to versions below 0.18.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
