### PR TITLE
feature: added controlled-sqrt-not gate

### DIFF
--- a/src/braket/_sdk/_version.py
+++ b/src/braket/_sdk/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.11.1"
+__version__ = "1.11.2.dev0"

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -1055,14 +1055,13 @@ class CV(Gate):
     def to_ir(self, target: QubitSet):
         return ir.CV.construct(control=target[0], target=target[1])
 
-
     def to_matrix(self) -> np.ndarray:
         return np.array(
             [
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 0.5 + 0.5j, 0.5 - 0.5j], # if the control bit, then apply the V gate
-                [0.0, 0.0, 0.5 - 0.5j, 0.5 + 0.5j], # which is the sqrt(NOT) gate.
+                [0.0, 0.0, 0.5 + 0.5j, 0.5 - 0.5j],  # if the control bit, then apply the V gate
+                [0.0, 0.0, 0.5 - 0.5j, 0.5 + 0.5j],  # which is the sqrt(NOT) gate.
             ],
             dtype=complex,
         )
@@ -1087,6 +1086,7 @@ class CV(Gate):
             >>> circ = Circuit().cv(0, 1)
         """
         return Instruction(CV(), target=[control, target])
+
 
 Gate.register_gate(CV)
 

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -1046,6 +1046,51 @@ class CPhaseShift10(AngledGate):
 Gate.register_gate(CPhaseShift10)
 
 
+class CV(Gate):
+    """Controlled Sqrt of NOT gate."""
+
+    def __init__(self):
+        super().__init__(qubit_count=None, ascii_symbols=["C", "V"])
+
+    def to_ir(self, target: QubitSet):
+        return ir.CV.construct(control=target[0], target=target[1])
+
+
+    def to_matrix(self) -> np.ndarray:
+        return np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.5 + 0.5j, 0.5 - 0.5j], # if the control bit, then apply the V gate
+                [0.0, 0.0, 0.5 - 0.5j, 0.5 + 0.5j], # which is the sqrt(NOT) gate.
+            ],
+            dtype=complex,
+        )
+
+    @staticmethod
+    def fixed_qubit_count() -> int:
+        return 2
+
+    @staticmethod
+    @circuit.subroutine(register=True)
+    def cv(control: QubitInput, target: QubitInput) -> Instruction:
+        """Registers this function into the circuit class.
+
+        Args:
+            control (Qubit or int): Control qubit index.
+            target (Qubit or int): Target qubit index.
+
+        Returns:
+            Instruction: CV instruction.
+
+        Examples:
+            >>> circ = Circuit().cv(0, 1)
+        """
+        return Instruction(CV(), target=[control, target])
+
+Gate.register_gate(CV)
+
+
 class CY(Gate):
     """Controlled Pauli-Y gate."""
 

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -42,6 +42,7 @@ testdata = [
     (Gate.Ry, "ry", ir.Ry, [SingleTarget, Angle], {}),
     (Gate.Rz, "rz", ir.Rz, [SingleTarget, Angle], {}),
     (Gate.CNot, "cnot", ir.CNot, [SingleTarget, SingleControl], {}),
+    (Gate.CV, "cv", ir.CV, [SingleTarget, SingleControl], {}),
     (Gate.CCNot, "ccnot", ir.CCNot, [SingleTarget, DoubleControl], {}),
     (Gate.Swap, "swap", ir.Swap, [DoubleTarget], {}),
     (Gate.CSwap, "cswap", ir.CSwap, [SingleControl, DoubleTarget], {}),

--- a/tox.ini
+++ b/tox.ini
@@ -88,5 +88,5 @@ commands =
 [test-deps]
 deps =
     # If you need to test on a certain branch, add @<branch-name> after .git
-    git+https://github.com/unprovable/amazon-braket-schemas-python.git@ctrl-v-gate
-    git+https://github.com/unprovable/amazon-braket-default-simulator-python.git@ctrl-v-gate
+    git+https://github.com/aws/amazon-braket-schemas-python.git
+    git+https://github.com/aws/amazon-braket-default-simulator-python.git

--- a/tox.ini
+++ b/tox.ini
@@ -88,5 +88,5 @@ commands =
 [test-deps]
 deps =
     # If you need to test on a certain branch, add @<branch-name> after .git
-    git+https://github.com/aws/amazon-braket-schemas-python.git
-    git+https://github.com/aws/amazon-braket-default-simulator-python.git
+    git+https://github.com/unprovable/amazon-braket-schemas-python.git@ctrl-v-gate
+    git+https://github.com/unprovable/amazon-braket-default-simulator-python.git@ctrl-v-gate


### PR DESCRIPTION
This makes certain circuits, like CHSH, more straightforward. This commit works in line with the following branches (also committed, separately):
https://github.com/unprovable/amazon-braket-schemas-python.git@ctrl-v-gate
https://github.com/unprovable/amazon-braket-default-simulator-python.git@ctrl-v-gate

*Issue #, if available:*

*Description of changes:*

Added the controlled version of the sqrt(NOT) gate, in Braket's parlance this is the V-gate, and so it is named the 'CV-gate' in this PR. I have also made the relevant changes on similarly named branches in the `schemas` and `default-simulator` repos. These are located:

* https://github.com/unprovable/amazon-braket-schemas-python.git@ctrl-v-gate
* https://github.com/unprovable/amazon-braket-default-simulator-python.git@ctrl-v-gate

(I'll include this PR number in the PRs for those repositories). 

The main motivation for this change is to make circuits a little easier to construct in the simulator, and hopefully later on devices. For example, the CHSH form of the Bell inequality test has a very straightforward form using this gate. (See the 'testing' section for the code that demonstrates this). 
 
*Testing done:*

I wrote some unit tests and included them in the PR. Also, to check this point the following code was used, based on section 16.2 in https://arxiv.org/abs/1907.09415 - 

```
from braket.circuits import circuit, Circuit, Gate, Moments
from braket.circuits.instruction import Instruction
from braket.devices import LocalSimulator
import numpy as np

def chsh_circuit():
    """
    function to perform CHSH form of Bell Inequality Test.
    Based on material in 1907.09415, Section 16.2 (arXiv)
    """

    # instantiate circuit object
    circuit = Circuit()
    
    # put referees in superposition
    circuit.h(2)
    circuit.h(3)
    
    #entangle Alice and Bob
    circuit.h(0)
    circuit.cnot(0, 1)
    
    # spin Alice
    circuit.rx(0, -(3*np.pi)/16)
    
    # apply sqrt(NOT) based on referees flip
    circuit.cv(2,0)
    circuit.cv(3,1)

    return circuit

device = LocalSimulator()
cq = chsh_circuit()
my_task = device.run(cq, shots=1000)
my_task.result()

# check win percentage - should be around 85%, and certainly over 75%.
wins = 0
for i in my_task.result().measurements:
    if i[0] ^ i[1] == i[2] & i[3]:
        wins += 1

print((wins/len(my_task.result().measurements))*100)
```
This circuit produces the correct results using a modified version of the `amazon-braket-sdk` library. The code has been copied into this (and related) PR's to enable these simulations in the main AWS braket repo. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
