### PR TITLE
documentation: fix documentation on environment variable to match the…

### DIFF
--- a/src/braket/jobs/data_persistence.py
+++ b/src/braket/jobs/data_persistence.py
@@ -110,8 +110,8 @@ def save_job_result(
 ) -> None:
     """
     Saves the `result_data` to the local output directory that is specified by the container
-    environment variable `OUTPUT_DIR`, with the filename 'results.json'. The `result_data`
-    values are serialized to the specified `data_format`.
+    environment variable `AMZN_BRAKET_JOB_RESULTS_DIR`, with the filename 'results.json'.
+    The `result_data` values are serialized to the specified `data_format`.
 
     Note: This function for storing the results is only for use inside the job container
           as it writes data to directories and references env variables set in the containers.


### PR DESCRIPTION
*Issue #, if available:* fix mismatching documentation in save_job_result

*Description of changes:* Changing the environment variable in the comment from OUTPUT_DIR to AMZN_BRAKET_JOB_RESULTS_DIR. This is to correctly reflect the code content.

*Testing done:* Unit tests done.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
