### PR TITLE
change: pin coverage dependency only for test extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "backoff",
         "boltons",
         "boto3",
-        "coverage==5.5",
         "nest-asyncio",
         "networkx",
         "numpy",
@@ -40,6 +39,7 @@ setup(
         "test": [
             "black",
             "botocore",
+            "coverage==5.5",
             "flake8",
             "isort",
             "jsonschema==3.2.0",


### PR DESCRIPTION
*Description of changes:*

Remove the coverage dependency from the install dependencies to allow
better coexistence with other libraries.
The dependency is still pinned in the test extra so that it can be used
during the SDK testing process.

*Testing done:*

Executed the unit tests using:
```bash
pip install -U pip setuptools wheel
pip install tox
pip install '.[test]'
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.