### PR TITLE
fix: add device arn error handling for badly formed ARNs

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -231,7 +231,7 @@ class AwsDevice(Device):
         self._populate_properties(self._aws_session)
 
     def _get_session_and_initialize(self, session):
-        device_region = self._arn.split(":")[3]
+        device_region = AwsDevice.get_device_region(self._arn)
         return (
             self._get_regional_device_session(session)
             if device_region
@@ -239,7 +239,7 @@ class AwsDevice(Device):
         )
 
     def _get_regional_device_session(self, session):
-        device_region = self._arn.split(":")[3]
+        device_region = AwsDevice.get_device_region(self._arn)
         region_session = (
             session
             if session.region == device_region
@@ -509,3 +509,13 @@ class AwsDevice(Device):
         devices = list(device_map.values())
         devices.sort(key=lambda x: getattr(x, order_by))
         return devices
+
+    @staticmethod
+    def get_device_region(device_arn: str) -> str:
+        try:
+            return device_arn.split(":")[3]
+        except IndexError:
+            raise ValueError(
+                f"Device ARN is not a valid format: {device_arn}. For valid Braket ARNs, "
+                "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
+            )

--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -516,6 +516,6 @@ class AwsDevice(Device):
             return device_arn.split(":")[3]
         except IndexError:
             raise ValueError(
-                f"Device ARN is not a valid format: {device_arn}. For valid Braket ARNs, "
+                f"Device ARN is not a valid format. For valid Braket ARNs, "
                 "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
             )

--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -516,6 +516,6 @@ class AwsDevice(Device):
             return device_arn.split(":")[3]
         except IndexError:
             raise ValueError(
-                f"Device ARN is not a valid format. For valid Braket ARNs, "
+                "Device ARN is not a valid format. For valid Braket ARNs, "
                 "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
             )

--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -516,6 +516,6 @@ class AwsDevice(Device):
             return device_arn.split(":")[3]
         except IndexError:
             raise ValueError(
-                "Device ARN is not a valid format. For valid Braket ARNs, "
+                f"Device ARN is not a valid format: {device_arn}. For valid Braket ARNs, "
                 "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
             )

--- a/src/braket/aws/aws_quantum_job.py
+++ b/src/braket/aws/aws_quantum_job.py
@@ -529,9 +529,16 @@ class AwsQuantumJob(QuantumJob):
         return hash(self.arn)
 
     @staticmethod
+    def _get_device_region(device_arn: str) -> str:
+        try:
+            return device_arn.split(":")[3]
+        except IndexError:
+            raise ValueError(f"Device arn is not a valid format: {device_arn}")
+
+    @staticmethod
     def _initialize_session(session_value, device, logger):
         aws_session = session_value or AwsSession()
-        device_region = device.split(":")[3]
+        device_region = AwsQuantumJob._get_device_region(device)
         return (
             AwsQuantumJob._initialize_regional_device_session(aws_session, device, logger)
             if device_region
@@ -540,7 +547,7 @@ class AwsQuantumJob(QuantumJob):
 
     @staticmethod
     def _initialize_regional_device_session(aws_session, device, logger):
-        device_region = device.split(":")[3]
+        device_region = AwsQuantumJob._get_device_region(device)
         current_region = aws_session.region
         if current_region != device_region:
             aws_session = aws_session.copy_session(region=device_region)

--- a/src/braket/aws/aws_quantum_job.py
+++ b/src/braket/aws/aws_quantum_job.py
@@ -529,20 +529,9 @@ class AwsQuantumJob(QuantumJob):
         return hash(self.arn)
 
     @staticmethod
-    def _get_device_region(device_arn: str) -> str:
-        try:
-            return device_arn.split(":")[3]
-        except IndexError:
-            raise ValueError(
-                f"Device arn is not a valid format: {device_arn}. Examples of correct arns are: "
-                "arn:aws:braket:::device/quantum-simulator/amazon/sv1 or "
-                "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-1."
-            )
-
-    @staticmethod
     def _initialize_session(session_value, device, logger):
         aws_session = session_value or AwsSession()
-        device_region = AwsQuantumJob._get_device_region(device)
+        device_region = AwsDevice.get_device_region(device)
         return (
             AwsQuantumJob._initialize_regional_device_session(aws_session, device, logger)
             if device_region
@@ -551,7 +540,7 @@ class AwsQuantumJob(QuantumJob):
 
     @staticmethod
     def _initialize_regional_device_session(aws_session, device, logger):
-        device_region = AwsQuantumJob._get_device_region(device)
+        device_region = AwsDevice.get_device_region(device)
         current_region = aws_session.region
         if current_region != device_region:
             aws_session = aws_session.copy_session(region=device_region)

--- a/src/braket/aws/aws_quantum_job.py
+++ b/src/braket/aws/aws_quantum_job.py
@@ -533,7 +533,11 @@ class AwsQuantumJob(QuantumJob):
         try:
             return device_arn.split(":")[3]
         except IndexError:
-            raise ValueError(f"Device arn is not a valid format: {device_arn}")
+            raise ValueError(
+                f"Device arn is not a valid format: {device_arn}. Examples of correct arns are: "
+                "arn:aws:braket:::device/quantum-simulator/amazon/sv1 or "
+                "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-1."
+            )
 
     @staticmethod
     def _initialize_session(session_value, device, logger):

--- a/test/unit_tests/braket/aws/test_aws_quantum_job.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_job.py
@@ -985,3 +985,10 @@ def test_exceptions_in_all_device_regions(aws_session):
     )
     with pytest.raises(ClientError, match=error_message):
         AwsQuantumJob._initialize_session(aws_session, device_arn, logger)
+
+
+def test_bad_arn_format(aws_session):
+    logger = logging.getLogger(__name__)
+    device_not_found = "Device arn is not a valid format: bad-arn-format"
+    with pytest.raises(ValueError, match=device_not_found):
+        AwsQuantumJob._initialize_session(aws_session, "bad-arn-format", logger)

--- a/test/unit_tests/braket/aws/test_aws_quantum_job.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_job.py
@@ -990,7 +990,7 @@ def test_exceptions_in_all_device_regions(aws_session):
 def test_bad_arn_format(aws_session):
     logger = logging.getLogger(__name__)
     device_not_found = (
-        "Device ARN is not a valid format: bad-arn-format. For valid Braket ARNs, "
+        "Device ARN is not a valid format. For valid Braket ARNs, "
         "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
     )
 

--- a/test/unit_tests/braket/aws/test_aws_quantum_job.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_job.py
@@ -989,6 +989,10 @@ def test_exceptions_in_all_device_regions(aws_session):
 
 def test_bad_arn_format(aws_session):
     logger = logging.getLogger(__name__)
-    device_not_found = "Device arn is not a valid format: bad-arn-format"
+    device_not_found = (
+        "Device arn is not a valid format: bad-arn-format. Examples of correct arns are: "
+        "arn:aws:braket:::device/quantum-simulator/amazon/sv1 or "
+        "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-1."
+    )
     with pytest.raises(ValueError, match=device_not_found):
         AwsQuantumJob._initialize_session(aws_session, "bad-arn-format", logger)

--- a/test/unit_tests/braket/aws/test_aws_quantum_job.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_job.py
@@ -990,9 +990,9 @@ def test_exceptions_in_all_device_regions(aws_session):
 def test_bad_arn_format(aws_session):
     logger = logging.getLogger(__name__)
     device_not_found = (
-        "Device arn is not a valid format: bad-arn-format. Examples of correct arns are: "
-        "arn:aws:braket:::device/quantum-simulator/amazon/sv1 or "
-        "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-1."
+        "Device ARN is not a valid format: bad-arn-format. For valid Braket ARNs, "
+        "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
     )
+
     with pytest.raises(ValueError, match=device_not_found):
         AwsQuantumJob._initialize_session(aws_session, "bad-arn-format", logger)

--- a/test/unit_tests/braket/aws/test_aws_quantum_job.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_job.py
@@ -990,7 +990,7 @@ def test_exceptions_in_all_device_regions(aws_session):
 def test_bad_arn_format(aws_session):
     logger = logging.getLogger(__name__)
     device_not_found = (
-        "Device ARN is not a valid format. For valid Braket ARNs, "
+        "Device ARN is not a valid format: bad-arn-format. For valid Braket ARNs, "
         "see 'https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html'"
     )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While device ARN validation is handled by the service, we do some basic preprocessing that assumes the ARN will be of a certain format (ie. having at least 3 :'s). Previously, an ARN that doesn't meet this requirement would cause a crash in the BDK; now this throws an error gracefully.

*Testing done:*

Added a unit test.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
