### PR TITLE
fix: stringify hyperparameters automatically

### DIFF
--- a/src/braket/aws/aws_quantum_job.py
+++ b/src/braket/aws/aws_quantum_job.py
@@ -165,7 +165,6 @@ class AwsQuantumJob(QuantumJob):
         Raises:
             ValueError: Raises ValueError if the parameters are not valid.
         """
-
         aws_session = AwsQuantumJob._initialize_session(aws_session, device, logger)
 
         create_job_kwargs = prepare_quantum_job(

--- a/src/braket/aws/aws_quantum_job.py
+++ b/src/braket/aws/aws_quantum_job.py
@@ -166,10 +166,6 @@ class AwsQuantumJob(QuantumJob):
             ValueError: Raises ValueError if the parameters are not valid.
         """
 
-        if(type(hyperparameters) is dict):
-            keys_values = hyperparameters.items()
-            hyperparameters = {str(key): str(value) for key, value in keys_values}
-
         aws_session = AwsQuantumJob._initialize_session(aws_session, device, logger)
 
         create_job_kwargs = prepare_quantum_job(

--- a/src/braket/aws/aws_quantum_job.py
+++ b/src/braket/aws/aws_quantum_job.py
@@ -165,6 +165,11 @@ class AwsQuantumJob(QuantumJob):
         Raises:
             ValueError: Raises ValueError if the parameters are not valid.
         """
+
+        if(type(hyperparameters) is dict):
+            keys_values = hyperparameters.items()
+            hyperparameters = {str(key): str(value) for key, value in keys_values}
+
         aws_session = AwsQuantumJob._initialize_session(aws_session, device, logger)
 
         create_job_kwargs = prepare_quantum_job(

--- a/src/braket/jobs/quantum_job_creation.py
+++ b/src/braket/jobs/quantum_job_creation.py
@@ -142,6 +142,7 @@ def prepare_quantum_job(
     job_name = job_name or _generate_default_job_name(image_uri)
     role_arn = role_arn or aws_session.get_default_jobs_role()
     hyperparameters = hyperparameters or {}
+    hyperparameters = {str(key): str(value) for key, value in hyperparameters.items()}
     input_data = input_data or {}
     tags = tags or {}
     default_bucket = aws_session.default_bucket()

--- a/test/unit_tests/braket/jobs/test_quantum_job_creation.py
+++ b/test/unit_tests/braket/jobs/test_quantum_job_creation.py
@@ -305,6 +305,7 @@ def _translate_creation_args(create_job_args):
     role_arn = create_job_args["role_arn"] or aws_session.get_default_jobs_role()
     device = create_job_args["device"]
     hyperparameters = create_job_args["hyperparameters"] or {}
+    hyperparameters = {str(key): str(value) for key, value in hyperparameters.items()}
     input_data = create_job_args["input_data"] or {}
     instance_config = create_job_args["instance_config"] or InstanceConfig()
     output_data_config = create_job_args["output_data_config"] or OutputDataConfig(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Currently our docs say we automatically stringify hyperparameters passed in but we do not. This is a fix to do that.

*Testing done:*
- tox integ and unit tests run successfully
- I manually tested creating a job with and without non-string values

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
