### PR TITLE
Fix: remove instanceCount field from InstanceConfig class.

### DIFF
--- a/src/braket/jobs/config.py
+++ b/src/braket/jobs/config.py
@@ -29,7 +29,6 @@ class InstanceConfig:
 
     instanceType: str = "ml.m5.large"
     volumeSizeInGb: int = 30
-    instanceCount: int = 1
 
 
 @dataclass


### PR DESCRIPTION
*Issue #, if available:* No issue # available. Bug located during test: the change to remove instanceCount from InstanceConfig has not been synced to local-sim-jobs branch. This leads to a validation error when using embedded simulator. 

*Description of changes:* remove instanceCount field from InstanceConfig class.

*Testing done:* confirmed that one can successfully create AwsQuantumJob jobs with the updated InstanceConfig.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
