### PR TITLE
feat: Support jobs metrics with multiple nodes

### DIFF
--- a/src/braket/jobs/metrics_data/cwl_insights_metrics_fetcher.py
+++ b/src/braket/jobs/metrics_data/cwl_insights_metrics_fetcher.py
@@ -167,7 +167,7 @@ class CwlInsightsMetricsFetcher(object):
         query = (
             f"fields @timestamp, @message "
             f"| filter @logStream like /^{job_name}\\// "
-            f"| filter @message like /^Metrics - /"
+            f"| filter @message like /Metrics - /"
         )
 
         response = self._logs_client.start_query(

--- a/src/braket/jobs/metrics_data/log_metrics_parser.py
+++ b/src/braket/jobs/metrics_data/log_metrics_parser.py
@@ -132,7 +132,7 @@ class LogMetricsParser(object):
         for metric in self.all_metrics:
             if pivot in metric:
                 # If no node_id is present, pair pivot value with None for the key.
-                metric_pivot = (metric[pivot], metric.get("node_id"))
+                metric_pivot = (metric[pivot], metric.get(self.NODE_ID))
                 if metric_pivot not in pivot_indices:
                     pivot_indices[metric_pivot] = row_count
                     row_count += 1
@@ -174,7 +174,7 @@ class LogMetricsParser(object):
         table, pivot_indices = self.get_columns_and_pivot_indices(pivot)
         for metric in self.all_metrics:
             if pivot in metric:
-                metric_pivot = (metric[pivot], metric.get("node_id"))
+                metric_pivot = (metric[pivot], metric.get(self.NODE_ID))
                 row = pivot_indices[metric_pivot]
                 for column_name in metric:
                     table[column_name][row] = self._get_value(

--- a/src/braket/jobs/metrics_data/log_metrics_parser.py
+++ b/src/braket/jobs/metrics_data/log_metrics_parser.py
@@ -121,7 +121,7 @@ class LogMetricsParser(object):
 
         Returns:
             Tuple[Dict[str, List[Any]], Dict[Tuple[int, str], int]]:
-                The Dict[str, List[Any]] the result table with all the metrics values initialized
+                The Dict[str, List[Any]] is the result table with all the metrics values initialized
                     to None
                 The Dict[Tuple[int, str], int] is the list of pivot indices, where the value of a
                     pivot column and node_id is mapped to a row index.

--- a/test/unit_tests/braket/jobs/metrics_data/test_cwl_insights_metrics_fetcher.py
+++ b/test/unit_tests/braket/jobs/metrics_data/test_cwl_insights_metrics_fetcher.py
@@ -73,7 +73,7 @@ def test_get_all_metrics_complete_results(mock_add_metrics, mock_get_metrics, aw
         startTime=1,
         endTime=2,
         queryString="fields @timestamp, @message | filter @logStream like /^test_job\\//"
-        " | filter @message like /^Metrics - /",
+        " | filter @message like /Metrics - /",
         limit=10000,
     )
     assert mock_add_metrics.call_args_list == EXPECTED_CALL_LIST

--- a/test/unit_tests/braket/jobs/metrics_data/test_log_metrics_parser.py
+++ b/test/unit_tests/braket/jobs/metrics_data/test_log_metrics_parser.py
@@ -63,6 +63,40 @@ SIMPLE_METRICS_RESULT = {
     "metric3": [None, None, 0.2, None],
 }
 
+MULTINODE_METRICS_LOG_LINES = [
+    {
+        "timestamp": "Test timestamp 0",
+        "message": "[nodeA]<stdout>:Metrics - metric0=1.0;",
+    },
+    # This line logs the same metric from a different node.
+    {
+        "timestamp": "Test timestamp 0",
+        "message": "[nodeB]<stdout>:Metrics - metric0=2.0;",
+    },
+    # This line also logs a metric unique to one node.
+    {
+        "timestamp": "Test timestamp 1",
+        "message": "[nodeA]<stdout>:Metrics - metricA=3.0;",
+    },
+    # This line logs a metric without a node tag.
+    {
+        "timestamp": "Test timestamp 1",
+        "message": "Metrics - metric0=0.0;",
+    },
+]
+
+MULTINODES_METRICS_RESULT = {
+    "timestamp": ["Test timestamp 0", "Test timestamp 0", "Test timestamp 1", "Test timestamp 1"],
+    "node_id": [
+        "nodeA",
+        "nodeB",
+        "nodeA",
+        None,
+    ],
+    "metric0": [1.0, 2.0, None, 0.0],
+    "metricA": [None, None, 3.0, None],
+}
+
 # This will test how metrics are combined when the multiple metrics have the same timestamp
 SINGLE_TIMESTAMP_METRICS_LOG_LINES = [
     {"timestamp": "Test timestamp 0", "message": "Metrics - metric0=0.0;"},
@@ -134,6 +168,12 @@ ITERATION_NUMBER_MAX_RESULTS = {
             MetricType.TIMESTAMP,
             MetricStatistic.MAX,
             SIMPLE_METRICS_RESULT,
+        ),
+        (
+            MULTINODE_METRICS_LOG_LINES,
+            MetricType.TIMESTAMP,
+            MetricStatistic.MAX,
+            MULTINODES_METRICS_RESULT,
         ),
         (
             SINGLE_TIMESTAMP_METRICS_LOG_LINES,


### PR DESCRIPTION
*Description of changes:*
Metrics logged from distributed jobs are additionally tagged with a node id like, `[1,mpirank:4,algo-1]<stdout>:Metrics - cost=5;...`. This change is to also read logs with this tag on the metrics and to use this tag as an additional pivot so that two nodes do not overwrite each other's metrics.

*Testing done:*
unit-tests, integ-tests, local testing with a job with multinode metric logs.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
