### PR TITLE
add implementation for translating arbitrary 1-qubit unitary gates to…

### DIFF
--- a/src/braket/circuits/quantum_operator_helpers.py
+++ b/src/braket/circuits/quantum_operator_helpers.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
 from functools import lru_cache
 from typing import Iterable
 
@@ -129,3 +128,29 @@ def get_pauli_eigenvalues(num_qubits: int) -> np.ndarray:
     )
     eigs.setflags(write=False)
     return eigs
+
+
+def solve_unitary_parameterization(unitary, verify_unitary=False):
+    ((a, b), (c, d)) = unitary
+    theta = abs(2 * np.arccos(a))
+    sin_theta_over_2 = np.sin(theta / 2)
+    phi = np.angle(c / sin_theta_over_2) if sin_theta_over_2 else 0
+    lambda_ = np.angle(-b / sin_theta_over_2) if sin_theta_over_2 else np.angle(d / a) - phi
+
+    if verify_unitary:
+        regenerated = np.array(
+            [
+                [np.cos(theta / 2), -np.exp(1j * lambda_) * np.sin(theta / 2)],
+                [
+                    np.exp(1j * phi) * np.sin(theta / 2),
+                    np.exp(1j * (phi + lambda_)) * np.cos(theta / 2),
+                ],
+            ]
+        )
+        if not np.allclose(
+            unitary,
+            regenerated,
+        ):
+            raise ValueError("Argument is not unitary")
+
+    return theta, phi, lambda_

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -295,6 +295,25 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
             "rx(0.17) $4;",
         ),
+        (
+            Gate.Unitary(matrix=Gate.Rx(angle=0.17).to_matrix()),
+            [4],
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
+            "U(0.17000000000000087, -1.5707963267948966, 1.5707963267948966) q[4];",
+        ),
+        (
+            Gate.Unitary(matrix=Gate.Rx(angle=0.17).to_matrix()),
+            [4],
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
+            "U(0.17000000000000087, -1.5707963267948966, 1.5707963267948966) $4;",
+        ),
+        pytest.param(
+            Gate.Unitary(matrix=np.eye(4)),
+            [4],
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
+            "",
+            marks=pytest.mark.xfail(raises=NotImplementedError, strict=True),
+        ),
     ],
 )
 def test_gate_to_ir_openqasm(gate, target, serialization_properties, expected_ir):

--- a/test/unit_tests/braket/circuits/test_quantum_operator_helpers.py
+++ b/test/unit_tests/braket/circuits/test_quantum_operator_helpers.py
@@ -22,6 +22,7 @@ from braket.circuits.quantum_operator_helpers import (
     is_hermitian,
     is_square_matrix,
     is_unitary,
+    solve_unitary_parameterization,
     verify_quantum_operator_matrix_dimensions,
 )
 
@@ -137,3 +138,15 @@ def test_get_pauli_eigenvalues_cache_usage(depth):
 @pytest.mark.parametrize("num_qubits", [1, 2])
 def test_get_pauli_eigenvalues_immutable(num_qubits):
     get_pauli_eigenvalues(num_qubits)[0] = 100
+
+
+@pytest.mark.parametrize("non_unitary", invalid_unitary_matrices_false)
+def test_solve_unitary_parameterization_invalid_unitary(non_unitary):
+    not_unitary = "Argument is not unitary"
+    with pytest.raises(ValueError, match=not_unitary):
+        solve_unitary_parameterization(non_unitary, verify_unitary=True)
+
+
+@pytest.mark.parametrize("unitary", (valid_unitary_hermitian_matrix, z_matrix))
+def test_solve_unitary_parameterization_valid_unitary(unitary):
+    solve_unitary_parameterization(unitary, verify_unitary=True)


### PR DESCRIPTION
… openqasm

*Issue #, if available:*

https://github.com/aws/amazon-braket-sdk-python/issues/329

*Description of changes:*

Add implementation for converting arbitrary 1-qubit unitary gates into OQ3's parameterized U gate, as described in the [specification](https://qiskit.github.io/openqasm/language/gates.html).

*Testing done:*

Unit testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
