### PR TITLE
feature: support openQASM serialization of ry gate

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -538,6 +538,12 @@ class Ry(AngledGate):
     def _to_jaqcd(self, target: QubitSet):
         return ir.Ry.construct(target=target[0], angle=self.angle)
 
+    def _to_openqasm(
+        self, target: QubitSet, serialization_properties: OpenQASMSerializationProperties, **kwargs
+    ):
+        target_qubit = serialization_properties.format_target(int(target[0]))
+        return f"ry({self.angle}) {target_qubit};"
+
     def to_matrix(self) -> np.ndarray:
         cos = np.cos(self.angle / 2)
         sin = np.sin(self.angle / 2)

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -307,7 +307,6 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
             "ry(0.17) $4;",
         ),
-
     ],
 )
 def test_gate_to_ir_openqasm(gate, target, serialization_properties, expected_ir):

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -295,6 +295,19 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
             "rx(0.17) $4;",
         ),
+        (
+            Gate.Ry(angle=0.17),
+            [4],
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
+            "ry(0.17) q[4];",
+        ),
+        (
+            Gate.Ry(angle=0.17),
+            [4],
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
+            "ry(0.17) $4;",
+        ),
+
     ],
 )
 def test_gate_to_ir_openqasm(gate, target, serialization_properties, expected_ir):


### PR DESCRIPTION
*Issue #, if available:*
329

*Description of changes:*
Added support for openQasm serializzation of ry gate.

*Testing done:*
Ran/added unit tests with 100% coverage.
Ran this test script as an integration test.
```
circuit = Circuit().ry(0, 0.0)
print(f"{circuit.to_ir(ir_type=IRType.OPENQASM).source}")

d = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
res = d.run(circuit.to_ir(ir_type=IRType.OPENQASM), shots=10).result()
print(res)
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
