### PR TITLE
feat: allow user to set region+endpoint through env variables

### DIFF
--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -61,7 +61,7 @@ class AwsSession(object):
             self.braket_client = braket_client
         else:
             self.boto_session = boto_session or boto3.Session(
-                region_name=os.environ.get("BRAKET_REGION")
+                region_name=os.environ.get("AWS_REGION")
             )
             self.braket_client = self.boto_session.client(
                 "braket", config=self._config, endpoint_url=os.environ.get("BRAKET_ENDPOINT")

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -60,8 +60,12 @@ class AwsSession(object):
             )
             self.braket_client = braket_client
         else:
-            self.boto_session = boto_session or boto3.Session()
-            self.braket_client = self.boto_session.client("braket", config=self._config)
+            self.boto_session = boto_session or boto3.Session(
+                region_name=os.environ.get("BRAKET_REGION")
+            )
+            self.braket_client = self.boto_session.client(
+                "braket", config=self._config, endpoint_url=os.environ.get("BRAKET_ENDPOINT")
+            )
 
         self._update_user_agent()
         self._custom_default_bucket = bool(default_bucket)

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -146,7 +146,7 @@ def throttling_response():
 
 def test_initializes_boto_client_if_required(boto_session):
     AwsSession(boto_session=boto_session)
-    boto_session.client.assert_any_call("braket", config=None)
+    boto_session.client.assert_any_call("braket", config=None, endpoint_url=None)
 
 
 def test_user_supplied_braket_client():
@@ -158,10 +158,15 @@ def test_user_supplied_braket_client():
     assert aws_session.braket_client == braket_client
 
 
+@patch.dict("os.environ", {"BRAKET_ENDPOINT": "some-endpoint"})
 def test_config(boto_session):
     config = Mock()
     AwsSession(boto_session=boto_session, config=config)
-    boto_session.client.assert_any_call("braket", config=config)
+    boto_session.client.assert_any_call(
+        "braket",
+        config=config,
+        endpoint_url="some-endpoint",
+    )
 
 
 def test_region():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Run the exact same code in prod/pre-prod just by setting an environment variable for region/stage

### Before
```python
import boto3
from braket.aws import AwsDevice, AwsSession
from braket.circuits import Circuit

endpoint = "https://some-endpoint.com"
braket_client = boto3.client("braket", region_name="us-west-2", endpoint_url=endpoint)
aws_session = AwsSession(braket_client=braket_client)

device = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1", aws_session=aws_session)

bell = Circuit().h(0).cnot(0, 1)
task = device.run(bell, shots=100)
```
### After
```bash
export BRAKET_ENDPOINT="https://some-endpoint.com" && export AWS_REGION=us-west-2
```
```python
from braket.aws import AwsDevice
from braket.circuits import Circuit

device = AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")

bell = Circuit().h(0).cnot(0, 1)
task = device.run(bell, shots=100)
```

This is a simplification for users wishing to provide endpoint/region arguments to their braket client

*Testing done:*

manual, unit

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
