### PR TITLE
feat: allow job role to be set via env variable

### DIFF
--- a/src/braket/jobs/quantum_job_creation.py
+++ b/src/braket/jobs/quantum_job_creation.py
@@ -146,9 +146,7 @@ def prepare_quantum_job(
     aws_session = aws_session or AwsSession()
     device_config = DeviceConfig(device)
     job_name = job_name or _generate_default_job_name(image_uri)
-    role_arn = (
-        role_arn or os.os.getenv("BRAKET_JOBS_ROLE_ARN", aws_session.get_default_jobs_role())
-    )
+    role_arn = role_arn or os.getenv("BRAKET_JOBS_ROLE_ARN", aws_session.get_default_jobs_role())
     hyperparameters = hyperparameters or {}
     hyperparameters = {str(key): str(value) for key, value in hyperparameters.items()}
     input_data = input_data or {}

--- a/src/braket/jobs/quantum_job_creation.py
+++ b/src/braket/jobs/quantum_job_creation.py
@@ -147,7 +147,7 @@ def prepare_quantum_job(
     device_config = DeviceConfig(device)
     job_name = job_name or _generate_default_job_name(image_uri)
     role_arn = (
-        role_arn or os.environ.get("BRAKET_JOBS_ROLE_ARN") or aws_session.get_default_jobs_role()
+        role_arn or os.os.getenv("BRAKET_JOBS_ROLE_ARN", aws_session.get_default_jobs_role())
     )
     hyperparameters = hyperparameters or {}
     hyperparameters = {str(key): str(value) for key, value in hyperparameters.items()}

--- a/src/braket/jobs/quantum_job_creation.py
+++ b/src/braket/jobs/quantum_job_creation.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
 import sys
 import tarfile
@@ -145,7 +146,9 @@ def prepare_quantum_job(
     aws_session = aws_session or AwsSession()
     device_config = DeviceConfig(device)
     job_name = job_name or _generate_default_job_name(image_uri)
-    role_arn = role_arn or aws_session.get_default_jobs_role()
+    role_arn = (
+        role_arn or os.environ.get("BRAKET_JOBS_ROLE_ARN") or aws_session.get_default_jobs_role()
+    )
     hyperparameters = hyperparameters or {}
     hyperparameters = {str(key): str(value) for key, value in hyperparameters.items()}
     input_data = input_data or {}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow role_arn parameter for jobs to be set via an environment variable

*Testing done:*

Verified that jobs the role arn will be parsed from the env variable and existing functionality still works.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
