### PR TITLE
fix: removing validation for disable_qubit_rewiring

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -446,11 +446,6 @@ def _(
     **kwargs,
 ) -> AwsQuantumTask:
     validate_circuit_and_shots(circuit, create_task_kwargs["shots"])
-    if circuit.qubits_frozen and not disable_qubit_rewiring:
-        raise ValueError(
-            "disable_qubit_rewiring must be True to run circuit with compiler directives"
-        )
-
     # TODO: Update this to use `deviceCapabilities` from Amazon Braket's GetDevice operation
     # in order to decide what parameters to build.
     paradigm_parameters = GateModelParameters(

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -102,8 +102,6 @@ class AwsQuantumTask(QuantumTask):
                 without any rewiring downstream, if this is supported by the device.
                 Only applies to digital, gate-based circuits (as opposed to annealing problems).
                 If ``True``, no qubit rewiring is allowed; if ``False``, qubit rewiring is allowed.
-                If the circuit has frozen qubits (``circuit.has_frozen_qubits==True``), then this
-                must be True, or running will throw an exception.
                 Default: False
 
             tags (Dict[str, str]): Tags, which are Key-Value pairs to add to this quantum task.

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -432,9 +432,12 @@ def test_from_circuit_with_disabled_rewiring(
 
 
 @pytest.mark.parametrize(
-    "device_arn,device_parameters_class", [(RIGETTI_ARN, RigettiDeviceParameters)]
+    "device_arn,device_parameters_class, disable_qubit_rewiring",
+    [(RIGETTI_ARN, RigettiDeviceParameters, True), (RIGETTI_ARN, RigettiDeviceParameters, False)],
 )
-def test_from_circuit_with_verbatim(device_arn, device_parameters_class, aws_session):
+def test_from_circuit_with_verbatim(
+    device_arn, device_parameters_class, disable_qubit_rewiring, aws_session
+):
     circ = Circuit().add_verbatim_box(Circuit().h(0))
     mocked_task_arn = "task-arn-1"
     aws_session.create_quantum_task.return_value = mocked_task_arn
@@ -446,7 +449,7 @@ def test_from_circuit_with_verbatim(device_arn, device_parameters_class, aws_ses
         circ,
         S3_TARGET,
         shots,
-        disable_qubit_rewiring=True,
+        disable_qubit_rewiring=disable_qubit_rewiring,
     )
     assert task == AwsQuantumTask(mocked_task_arn, aws_session)
 
@@ -458,17 +461,10 @@ def test_from_circuit_with_verbatim(device_arn, device_parameters_class, aws_ses
         shots,
         device_parameters_class(
             paradigmParameters=GateModelParameters(
-                qubitCount=circ.qubit_count, disableQubitRewiring=True
+                qubitCount=circ.qubit_count, disableQubitRewiring=disable_qubit_rewiring
             )
         ),
     )
-
-
-@pytest.mark.xfail(raises=ValueError)
-def test_from_circuit_with_verbatim_qubit_rewiring_not_disabled(aws_session):
-    circ = Circuit().add_verbatim_box(Circuit().h(0))
-    shots = 57
-    AwsQuantumTask.create(aws_session, RIGETTI_ARN, circ, S3_TARGET, shots)
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
*Issue #, if available:*
This fix will unblock the customer from validating the suggestion in this issue : https://github.com/aws/amazon-braket-sdk-python/issues/348 

*Description of changes:*
Removing validation for disable_qubit_rewiring and letting the service handle it.

It seems like this check was done as an optimization, since the values should be validated service-side. I'm removing this because different devices handle verbatim differently and some don't require disable_qubit_rewiring for verbatim (in fact, they don't support the flag at all). Rather than trying to handle these differences client side (especially in AwsTask, rather than AwsDevice), I think we can remove the check and let the service handle it.

***Note:*** As a result of this change, customers will no longer get a ValueError when providing the incorrect verbatim/disable_qubit_rewiring combination - instead they will get a ValidationException from the service call. 

*Testing done:*
Ran tox.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
