### PR TITLE
feat: Add method for updating the user agent for braket client

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -297,6 +297,10 @@ class AwsDevice(Device):
         return self._provider_name
 
     @property
+    def aws_session(self) -> AwsSession:
+        return self._aws_session
+
+    @property
     def arn(self) -> str:
         """str: Return the ARN of the device"""
         return self._arn

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -140,8 +140,9 @@ class AwsSession(object):
 
     def add_braket_user_agent(self, user_agent: str) -> None:
         """
-        Appends the `user-agent` value to the User-Agent header, if it does not yet exist in the header.
-        This method is typically only relevant for libraries integrating with the Amazon Braket SDK.
+        Appends the `user-agent` value to the User-Agent header, if it does not yet exist in the
+        header. This method is typically only relevant for libraries integrating with the
+        Amazon Braket SDK.
 
         Args:
             user_agent (str): The user_agent value to append to the header.
@@ -149,7 +150,6 @@ class AwsSession(object):
         existing_user_agent = self.braket_client._client_config.user_agent
         if user_agent not in existing_user_agent:
             self.braket_client._client_config.user_agent = f"{existing_user_agent} {user_agent}"
-
 
     #
     # Quantum Tasks
@@ -746,7 +746,11 @@ class AwsSession(object):
             )
         else:
             boto_session = boto3.Session(region_name=new_region)
-        copied_session = AwsSession(boto_session=boto_session, config=config, default_bucket=default_bucket)
+        copied_session = AwsSession(
+            boto_session=boto_session, config=config, default_bucket=default_bucket
+        )
         # Preserve user_agent information
-        copied_session.braket_client._client_config.user_agent = self.braket_client._client_config.user_agent
+        copied_session.braket_client._client_config.user_agent = (
+            self.braket_client._client_config.user_agent
+        )
         return copied_session

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -138,6 +138,19 @@ class AwsSession(object):
             f"{self.braket_client._client_config.user_agent} {additional_user_agent_fields}"
         )
 
+    def add_braket_user_agent(self, user_agent: str) -> None:
+        """
+        Appends the `user-agent` value to the User-Agent header, if it does not yet exist in the header.
+        This method is typically only relevant for libraries integrating with the Amazon Braket SDK.
+
+        Args:
+            user_agent (str): The user_agent value to append to the header.
+        """
+        existing_user_agent = self.braket_client._client_config.user_agent
+        if user_agent not in existing_user_agent:
+            self.braket_client._client_config.user_agent = f"{existing_user_agent} {user_agent}"
+
+
     #
     # Quantum Tasks
     #
@@ -733,4 +746,7 @@ class AwsSession(object):
             )
         else:
             boto_session = boto3.Session(region_name=new_region)
-        return AwsSession(boto_session=boto_session, config=config, default_bucket=default_bucket)
+        copied_session = AwsSession(boto_session=boto_session, config=config, default_bucket=default_bucket)
+        # Preserve user_agent information
+        copied_session.braket_client._client_config.user_agent = self.braket_client._client_config.user_agent
+        return copied_session

--- a/test/unit_tests/braket/aws/test_aws_device.py
+++ b/test/unit_tests/braket/aws/test_aws_device.py
@@ -355,6 +355,7 @@ def test_device_aws_session(device_capabilities, get_device_data, arn):
     mock_session.region = RIGETTI_REGION
     device = AwsDevice(arn, mock_session)
     _assert_device_fields(device, device_capabilities, get_device_data)
+    assert device.aws_session == mock_session
 
 
 @patch("braket.aws.aws_device.AwsSession")

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -1232,8 +1232,10 @@ def test_get_log_events(aws_session, next_token):
 @patch("boto3.Session")
 def test_copy_session(boto_session_init, aws_session):
     boto_session_init.return_value = Mock()
+    aws_session.braket_client._client_config.user_agent = "foo/bar"
     copied_session = AwsSession.copy_session(aws_session, "us-west-2")
     boto_session_init.assert_called_with(region_name="us-west-2")
+    assert copied_session.braket_client._client_config.user_agent == "foo/bar"
     assert copied_session._default_bucket is None
 
 
@@ -1256,3 +1258,10 @@ def test_copy_session_custom_default_bucket(mock_boto, aws_session):
     aws_session._custom_default_bucket = True
     copied_session = AwsSession.copy_session(aws_session)
     assert copied_session._default_bucket == "my-own-default"
+
+
+def test_add_braket_user_agent(aws_session):
+    user_agent = "newAgent/1.0"
+    aws_session.add_braket_user_agent(user_agent)
+    aws_session.add_braket_user_agent(user_agent)
+    assert aws_session.braket_client._client_config.user_agent.count(user_agent) == 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Exposed the `aws_session` for an AwsDevice as a property.
* Added a method `add_braket_user_agent` for updating the UserAgent header for the Braket client. 

*Testing done:*
* `tox -e unit-tests` succeeded.
* Updated Pennylane plugin and verified that the corresponding headers are being set correctly.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
