### PR TITLE
fix: Set the range for amazon-braket-schemas to >= 1.10.0 for the lat…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-default-simulator",
+        "amazon-braket-schemas>=1.10.0",
         "backoff",
         "boltons",
         "boto3",


### PR DESCRIPTION
…est device schemas needed.

*Issue #, if available:*

*Description of changes:*
Set the range for amazon-braket-schemas to >= 1.10.0 as it is required for the blackbird devices.

*Testing done:*
`tox`
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
