### PR TITLE
fix: Lazily parse schemas for devices so getDevice calls do not rely …

### DIFF
--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -282,8 +282,7 @@ class AwsDevice(Device):
         self._status = metadata.get("deviceStatus")
         self._type = AwsDeviceType(metadata.get("deviceType"))
         self._provider_name = metadata.get("providerName")
-        qpu_properties = metadata.get("deviceCapabilities")
-        self._properties = BraketSchemaBase.parse_raw_schema(qpu_properties)
+        self._properties = metadata.get("deviceCapabilities")
         self._topology_graph = self._construct_topology_graph()
 
     @property
@@ -370,7 +369,7 @@ class AwsDevice(Device):
         Please see `braket.device_schema` in amazon-braket-schemas-python_
 
         .. _amazon-braket-schemas-python: https://github.com/aws/amazon-braket-schemas-python"""
-        return self._properties
+        return BraketSchemaBase.parse_raw_schema(self._properties)
 
     @property
     def topology_graph(self) -> DiGraph:

--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -283,7 +283,6 @@ class AwsDevice(Device):
         self._type = AwsDeviceType(metadata.get("deviceType"))
         self._provider_name = metadata.get("providerName")
         self._properties = metadata.get("deviceCapabilities")
-        self._topology_graph = self._construct_topology_graph()
 
     @property
     def type(self) -> str:
@@ -386,7 +385,7 @@ class AwsDevice(Device):
 
             >>> print(device.topology_graph.edges)
         """
-        return self._topology_graph
+        return self._construct_topology_graph()
 
     def _construct_topology_graph(self) -> DiGraph:
         """

--- a/test/unit_tests/braket/aws/test_aws_device.py
+++ b/test/unit_tests/braket/aws/test_aws_device.py
@@ -13,7 +13,7 @@
 import json
 import os
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import networkx as nx
 import pytest
@@ -1145,6 +1145,11 @@ def test_get_device_availability(mock_utc_now):
             for i in range(len(test_item[1])):
                 device_name = test_set["test_devices"][i][0]
                 device = test_set["test_devices"][i][1]
+                type(device).properties = PropertyMock(return_value=Expando())
+                type(device).properties.service = PropertyMock(return_value=Expando())
+                device.properties.service.executionWindows = (
+                    device._properties.service.executionWindows
+                )
                 expected = bool(test_item[1][i])
                 actual = device.is_available
                 assert (


### PR DESCRIPTION
…on the device.

*Issue #, if available:*

*Description of changes:*
Lazily parse schemas for device properties

*Testing done:*
`tox`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
