### PR TITLE
fix: format a - bi when negative imaginary component

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -2011,7 +2011,8 @@ def format_complex(number: complex) -> str:
     """
     if number.real:
         if number.imag:
-            return f"{number.real} + {number.imag}im"
+            imag_sign = "+" if number.imag > 0 else "-"
+            return f"{number.real} {imag_sign} {abs(number.imag)}im"
         else:
             return f"{number.real}"
     else:

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -742,6 +742,12 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
             "#pragma braket unitary([[1.0, 0], [0, 0.70710678 + 0.70710678im]]) $4",
         ),
+        (
+            Gate.Unitary(np.array([[1.0, 0], [0, 0.70710678 - 0.70710678j]])),
+            [4],
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
+            "#pragma braket unitary([[1.0, 0], [0, 0.70710678 - 0.70710678im]]) q[4]",
+        ),
     ],
 )
 def test_gate_to_ir_openqasm(gate, target, serialization_properties, expected_ir):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

a - bi instead of a + -bi

*Testing done:*

tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
