### PR TITLE
add generation step to openqasm integ tests

### DIFF
--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -254,14 +254,21 @@ class TensorProduct(Observable):
     def _to_openqasm(
         self, serialization_properties: OpenQASMSerializationProperties, target: QubitSet = None
     ) -> str:
-        return " @ ".join(
-            obs.to_ir(
-                target=QubitSet(targ),
-                ir_type=IRType.OPENQASM,
-                serialization_properties=serialization_properties,
+        factors = []
+        use_qubits = iter(target)
+        for obs in self._factors:
+            obs_target = QubitSet()
+            num_qubits = int(np.log2(obs.to_matrix().shape[0]))
+            for _ in range(num_qubits):
+                obs_target.add(next(use_qubits))
+            factors.append(
+                obs.to_ir(
+                    target=obs_target,
+                    ir_type=IRType.OPENQASM,
+                    serialization_properties=serialization_properties,
+                )
             )
-            for obs, targ in zip(self._factors, target)
-        )
+        return " @ ".join(factors)
 
     @property
     def factors(self) -> Tuple[Observable, ...]:

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -277,7 +277,7 @@ class Probability(ResultType):
 
     def _to_openqasm(self, serialization_properties: OpenQASMSerializationProperties) -> str:
         if not self.target:
-            return "#pragma braket result probability"
+            return "#pragma braket result probability all"
         targets = ", ".join(
             serialization_properties.format_target(int(target)) for target in self.target
         )

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -66,7 +66,9 @@ def no_result_types_testing(
     assert len(result.measurements) == shots
 
 
-def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def no_result_types_bell_pair_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     bell = Circuit().h(0).cnot(0, 1)
     no_result_types_testing(bell, device, run_kwargs, {"00": 0.5, "11": 0.5})
 
@@ -75,7 +77,9 @@ def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]
         no_result_types_testing(bell_qasm, device, run_kwargs, {"00": 0.5, "11": 0.5})
 
 
-def result_types_observable_not_in_instructions(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_observable_not_in_instructions(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     bell = (
@@ -113,11 +117,7 @@ def result_types_zero_shots_bell_pair_testing(
         circuit.amplitude(["01", "10", "00", "11"])
     if include_state_vector:
         circuit.state_vector()
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
         assert len(result.result_types) == 3 if include_state_vector else 2
@@ -133,7 +133,9 @@ def result_types_zero_shots_bell_pair_testing(
                 np.array([1, 0, 0, 1]) / np.sqrt(2),
             )
         if include_amplitude:
-            assert result.get_value_by_result_type(ResultType.Amplitude(["01", "10", "00", "11"])) == {
+            assert result.get_value_by_result_type(
+                ResultType.Amplitude(["01", "10", "00", "11"])
+            ) == {
                 "01": 0j,
                 "10": 0j,
                 "00": (1 / np.sqrt(2)),
@@ -141,32 +143,30 @@ def result_types_zero_shots_bell_pair_testing(
             }
 
 
-def result_types_bell_pair_full_probability_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_bell_pair_full_probability_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuit = Circuit().h(0).cnot(0, 1).probability()
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
         assert len(result.result_types) == 1
         assert np.allclose(
-            result.get_value_by_result_type(ResultType.Probability()), np.array([0.5, 0, 0, 0.5]), **tol
+            result.get_value_by_result_type(ResultType.Probability()),
+            np.array([0.5, 0, 0, 0.5]),
+            **tol
         )
 
 
-def result_types_bell_pair_marginal_probability_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_bell_pair_marginal_probability_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuit = Circuit().h(0).cnot(0, 1).probability(0)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
         assert len(result.result_types) == 1
@@ -177,7 +177,9 @@ def result_types_bell_pair_marginal_probability_testing(device: Device, run_kwar
         )
 
 
-def result_types_nonzero_shots_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_nonzero_shots_bell_pair_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     circuit = (
         Circuit()
         .h(0)
@@ -185,11 +187,7 @@ def result_types_nonzero_shots_bell_pair_testing(device: Device, run_kwargs: Dic
         .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
         .sample(observable=Observable.H() @ Observable.X(), target=[0, 1])
     )
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
         assert len(result.result_types) == 2
@@ -210,7 +208,9 @@ def result_types_nonzero_shots_bell_pair_testing(device: Device, run_kwargs: Dic
         )
 
 
-def result_types_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_hermitian_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.543
     array = np.array([[1, 2j], [-2j, 0]])
@@ -223,11 +223,7 @@ def result_types_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], t
     )
     if shots:
         circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 0))
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     print(circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
@@ -240,7 +236,9 @@ def result_types_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], t
         )
 
 
-def result_types_all_selected_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_all_selected_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.543
     array = np.array([[1, 2j], [-2j, 0]])
@@ -252,11 +250,7 @@ def result_types_all_selected_testing(device: Device, run_kwargs: Dict[str, Any]
         .variance(Observable.Hermitian(array))
         .expectation(Observable.Hermitian(array), 0)
     )
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         if shots:
             circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 1))
@@ -306,7 +300,9 @@ def assert_variance_expectation_sample_result(
     assert np.allclose(variance, expected_var, **tol)
 
 
-def result_types_tensor_x_y_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_tensor_x_y_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -314,11 +310,7 @@ def result_types_tensor_x_y_testing(device: Device, run_kwargs: Dict[str, Any], 
     obs = Observable.X() @ Observable.Y()
     obs_targets = [0, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
@@ -338,7 +330,9 @@ def result_types_tensor_x_y_testing(device: Device, run_kwargs: Dict[str, Any], 
         )
 
 
-def result_types_tensor_z_z_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_tensor_z_z_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -346,11 +340,7 @@ def result_types_tensor_z_z_testing(device: Device, run_kwargs: Dict[str, Any], 
     obs = Observable.Z() @ Observable.Z()
     obs_targets = [0, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
@@ -363,7 +353,9 @@ def result_types_tensor_z_z_testing(device: Device, run_kwargs: Dict[str, Any], 
         )
 
 
-def result_types_tensor_hermitian_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_tensor_hermitian_hermitian_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -380,11 +372,7 @@ def result_types_tensor_hermitian_hermitian_testing(device: Device, run_kwargs: 
     obs = Observable.Hermitian(matrix1) @ Observable.Hermitian(matrix2)
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
@@ -397,7 +385,9 @@ def result_types_tensor_hermitian_hermitian_testing(device: Device, run_kwargs: 
         )
 
 
-def result_types_tensor_z_h_y_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_tensor_z_h_y_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -405,15 +395,13 @@ def result_types_tensor_z_h_y_testing(device: Device, run_kwargs: Dict[str, Any]
     obs = Observable.Z() @ Observable.H() @ Observable.Y()
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
-        expected_mean = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
+        expected_mean = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(
+            2
+        )
         expected_var = (
             3
             + np.cos(2 * phi) * np.cos(varphi) ** 2
@@ -426,7 +414,9 @@ def result_types_tensor_z_h_y_testing(device: Device, run_kwargs: Dict[str, Any]
         )
 
 
-def result_types_tensor_z_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_tensor_z_hermitian_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -442,11 +432,7 @@ def result_types_tensor_z_hermitian_testing(device: Device, run_kwargs: Dict[str
     obs = Observable.Z() @ Observable.Hermitian(array)
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
@@ -494,7 +480,9 @@ def result_types_tensor_z_hermitian_testing(device: Device, run_kwargs: Dict[str
         )
 
 
-def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_tensor_y_hermitian_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -510,11 +498,7 @@ def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str
     obs = Observable.Y() @ Observable.Hermitian(array)
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
@@ -527,7 +511,9 @@ def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str
         )
 
 
-def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_noncommuting_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = 0
     theta = 0.432
     phi = 0.123
@@ -551,11 +537,7 @@ def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any]
         .expectation(obs2, obs2_targets)
         .expectation(obs3, obs3_targets)
     )
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 
@@ -577,7 +559,9 @@ def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any]
         assert np.allclose(result.values[3], expected_mean3)
 
 
-def result_types_noncommuting_flipped_targets_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_noncommuting_flipped_targets_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     circuit = (
         Circuit()
         .h(0)
@@ -585,18 +569,16 @@ def result_types_noncommuting_flipped_targets_testing(device: Device, run_kwargs
         .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
         .expectation(observable=Observable.H() @ Observable.X(), target=[1, 0])
     )
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, shots=0, **run_kwargs).result()
         assert np.allclose(result.values[0], np.sqrt(2) / 2)
         assert np.allclose(result.values[1], np.sqrt(2) / 2)
 
 
-def result_types_noncommuting_all(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def result_types_noncommuting_all(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     array = np.array([[1, 2j], [-2j, 0]])
     circuit = (
         Circuit()
@@ -605,18 +587,16 @@ def result_types_noncommuting_all(device: Device, run_kwargs: Dict[str, Any], te
         .expectation(observable=Observable.Hermitian(array))
         .expectation(observable=Observable.X())
     )
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, shots=0, **run_kwargs).result()
         assert np.allclose(result.values[0], [0.5, 0.5])
         assert np.allclose(result.values[1], [0, 0])
 
 
-def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def multithreaded_bell_pair_testing(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     bell = Circuit().h(0).cnot(0, 1)
@@ -628,11 +608,7 @@ def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], 
     futures = []
     num_threads = 2
 
-    tasks = (
-        (bell,)
-        if not test_program
-        else (bell, bell.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (bell,) if not test_program else (bell, bell.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             for _ in range(num_threads):
@@ -645,15 +621,13 @@ def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], 
             assert len(result.measurements) == shots
 
 
-def noisy_circuit_1qubit_noise_full_probability(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def noisy_circuit_1qubit_noise_full_probability(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuit = Circuit().x(0).x(1).bit_flip(0, 0.1).probability()
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
         assert len(result.result_types) == 1
@@ -664,7 +638,9 @@ def noisy_circuit_1qubit_noise_full_probability(device: Device, run_kwargs: Dict
         )
 
 
-def noisy_circuit_2qubit_noise_full_probability(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+def noisy_circuit_2qubit_noise_full_probability(
+    device: Device, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     K0 = np.eye(4) * np.sqrt(0.9)
@@ -672,11 +648,7 @@ def noisy_circuit_2qubit_noise_full_probability(device: Device, run_kwargs: Dict
         0.1
     )
     circuit = Circuit().x(0).x(1).kraus((0, 1), [K0, K1]).probability()
-    tasks = (
-        (circuit,)
-        if not test_program
-        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    )
+    tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
         assert len(result.result_types) == 1
@@ -687,7 +659,9 @@ def noisy_circuit_2qubit_noise_full_probability(device: Device, run_kwargs: Dict
         )
 
 
-def batch_bell_pair_testing(device: AwsDevice, run_kwargs: Dict[str, Any], test_program: bool = True):
+def batch_bell_pair_testing(
+    device: AwsDevice, run_kwargs: Dict[str, Any], test_program: bool = True
+):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuits = [Circuit().h(0).cnot(0, 1) for _ in range(10)]

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -30,7 +30,7 @@ def get_tol(shots: int) -> Dict[str, float]:
     return {"atol": 0.1, "rtol": 0.15} if shots else {"atol": 0.01, "rtol": 0}
 
 
-def qubit_ordering_testing(device: Device, run_kwargs: Dict[str, Any]):
+def qubit_ordering_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     # |110> should get back value of "110"
     state_110 = Circuit().x(0).x(1).i(2)
     result = device.run(state_110, **run_kwargs).result()
@@ -40,6 +40,15 @@ def qubit_ordering_testing(device: Device, run_kwargs: Dict[str, Any]):
     state_001 = Circuit().i(0).i(1).x(2)
     result = device.run(state_001, **run_kwargs).result()
     assert result.measurement_counts.most_common(1)[0][0] == "001"
+
+    if test_program:
+        state_110_qasm = state_110.to_ir(ir_type=IRType.OPENQASM)
+        result = device.run(state_110_qasm, **run_kwargs).result()
+        assert result.measurement_counts.most_common(1)[0][0] == "110"
+
+        state_001_qasm = state_001.to_ir(ir_type=IRType.OPENQASM)
+        result = device.run(state_001_qasm, **run_kwargs).result()
+        assert result.measurement_counts.most_common(1)[0][0] == "001"
 
 
 def no_result_types_testing(
@@ -57,11 +66,16 @@ def no_result_types_testing(
     assert len(result.measurements) == shots
 
 
-def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
-    no_result_types_testing(Circuit().h(0).cnot(0, 1), device, run_kwargs, {"00": 0.5, "11": 0.5})
+def no_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
+    bell = Circuit().h(0).cnot(0, 1)
+    no_result_types_testing(bell, device, run_kwargs, {"00": 0.5, "11": 0.5})
+
+    if test_program:
+        bell_qasm = bell.to_ir(ir_type=IRType.OPENQASM)
+        no_result_types_testing(bell_qasm, device, run_kwargs, {"00": 0.5, "11": 0.5})
 
 
-def result_types_observable_not_in_instructions(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_observable_not_in_instructions(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     bell = (
@@ -75,12 +89,19 @@ def result_types_observable_not_in_instructions(device: Device, run_kwargs: Dict
     assert np.allclose(result.values[0], 0, **tol)
     assert np.allclose(result.values[1], 1, **tol)
 
+    if test_program:
+        bell_qasm = bell.to_ir(ir_type=IRType.OPENQASM)
+        result = device.run(bell_qasm, **run_kwargs).result()
+        assert np.allclose(result.values[0], 0, **tol)
+        assert np.allclose(result.values[1], 1, **tol)
+
 
 def result_types_zero_shots_bell_pair_testing(
     device: Device,
     include_state_vector: bool,
     run_kwargs: Dict[str, Any],
     include_amplitude: bool = True,
+    test_program: bool = True,
 ):
     circuit = (
         Circuit()
@@ -92,53 +113,71 @@ def result_types_zero_shots_bell_pair_testing(
         circuit.amplitude(["01", "10", "00", "11"])
     if include_state_vector:
         circuit.state_vector()
-    result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 3 if include_state_vector else 2
-    assert np.allclose(
-        result.get_value_by_result_type(
-            ResultType.Expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
-        ),
-        1 / np.sqrt(2),
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
-    if include_state_vector:
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+        assert len(result.result_types) == 3 if include_state_vector else 2
         assert np.allclose(
-            result.get_value_by_result_type(ResultType.StateVector()),
-            np.array([1, 0, 0, 1]) / np.sqrt(2),
+            result.get_value_by_result_type(
+                ResultType.Expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
+            ),
+            1 / np.sqrt(2),
         )
-    if include_amplitude:
-        assert result.get_value_by_result_type(ResultType.Amplitude(["01", "10", "00", "11"])) == {
-            "01": 0j,
-            "10": 0j,
-            "00": (1 / np.sqrt(2)),
-            "11": (1 / np.sqrt(2)),
-        }
+        if include_state_vector:
+            assert np.allclose(
+                result.get_value_by_result_type(ResultType.StateVector()),
+                np.array([1, 0, 0, 1]) / np.sqrt(2),
+            )
+        if include_amplitude:
+            assert result.get_value_by_result_type(ResultType.Amplitude(["01", "10", "00", "11"])) == {
+                "01": 0j,
+                "10": 0j,
+                "00": (1 / np.sqrt(2)),
+                "11": (1 / np.sqrt(2)),
+            }
 
 
-def result_types_bell_pair_full_probability_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_bell_pair_full_probability_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuit = Circuit().h(0).cnot(0, 1).probability()
-    result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 1
-    assert np.allclose(
-        result.get_value_by_result_type(ResultType.Probability()), np.array([0.5, 0, 0, 0.5]), **tol
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+        assert len(result.result_types) == 1
+        assert np.allclose(
+            result.get_value_by_result_type(ResultType.Probability()), np.array([0.5, 0, 0, 0.5]), **tol
+        )
 
 
-def result_types_bell_pair_marginal_probability_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_bell_pair_marginal_probability_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuit = Circuit().h(0).cnot(0, 1).probability(0)
-    result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 1
-    assert np.allclose(
-        result.get_value_by_result_type(ResultType.Probability(target=0)),
-        np.array([0.5, 0.5]),
-        **tol
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+        assert len(result.result_types) == 1
+        assert np.allclose(
+            result.get_value_by_result_type(ResultType.Probability(target=0)),
+            np.array([0.5, 0.5]),
+            **tol
+        )
 
 
-def result_types_nonzero_shots_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_nonzero_shots_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     circuit = (
         Circuit()
         .h(0)
@@ -146,26 +185,32 @@ def result_types_nonzero_shots_bell_pair_testing(device: Device, run_kwargs: Dic
         .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
         .sample(observable=Observable.H() @ Observable.X(), target=[0, 1])
     )
-    result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 2
-    assert (
-        0.6
-        < result.get_value_by_result_type(
-            ResultType.Expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
-        )
-        < 0.8
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
-    assert (
-        len(
-            result.get_value_by_result_type(
-                ResultType.Sample(observable=Observable.H() @ Observable.X(), target=[0, 1])
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+        assert len(result.result_types) == 2
+        assert (
+            0.6
+            < result.get_value_by_result_type(
+                ResultType.Expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
             )
+            < 0.8
         )
-        == run_kwargs["shots"]
-    )
+        assert (
+            len(
+                result.get_value_by_result_type(
+                    ResultType.Sample(observable=Observable.H() @ Observable.X(), target=[0, 1])
+                )
+            )
+            == run_kwargs["shots"]
+        )
 
 
-def result_types_hermitian_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.543
     array = np.array([[1, 2j], [-2j, 0]])
@@ -178,17 +223,24 @@ def result_types_hermitian_testing(device: Device, run_kwargs: Dict[str, Any]):
     )
     if shots:
         circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 0))
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5
-    expected_var = 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2
-    expected_eigs = np.linalg.eigvalsh(array)
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    print(circuit.to_ir(ir_type=IRType.OPENQASM))
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5
+        expected_var = 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2
+        expected_eigs = np.linalg.eigvalsh(array)
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
-def result_types_all_selected_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_all_selected_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.543
     array = np.array([[1, 2j], [-2j, 0]])
@@ -200,17 +252,23 @@ def result_types_all_selected_testing(device: Device, run_kwargs: Dict[str, Any]
         .variance(Observable.Hermitian(array))
         .expectation(Observable.Hermitian(array), 0)
     )
-    if shots:
-        circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 1))
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5
-    var = 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2
-    expected_var = [var, var]
-    expected_eigs = np.linalg.eigvalsh(array)
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        if shots:
+            circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 1))
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5
+        var = 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2
+        expected_var = [var, var]
+        expected_eigs = np.linalg.eigvalsh(array)
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
 def get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots) -> Circuit:
@@ -248,7 +306,7 @@ def assert_variance_expectation_sample_result(
     assert np.allclose(variance, expected_var, **tol)
 
 
-def result_types_tensor_x_y_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_tensor_x_y_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -256,25 +314,31 @@ def result_types_tensor_x_y_testing(device: Device, run_kwargs: Dict[str, Any]):
     obs = Observable.X() @ Observable.Y()
     obs_targets = [0, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-    expected_var = (
-        8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
-        - np.cos(2 * (theta - phi))
-        - np.cos(2 * (theta + phi))
-        + 2 * np.cos(2 * theta)
-        + 2 * np.cos(2 * phi)
-        + 14
-    ) / 16
-    expected_eigs = get_pauli_eigenvalues(1)
-
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+        expected_var = (
+            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+            - np.cos(2 * (theta - phi))
+            - np.cos(2 * (theta + phi))
+            + 2 * np.cos(2 * theta)
+            + 2 * np.cos(2 * phi)
+            + 14
+        ) / 16
+        expected_eigs = get_pauli_eigenvalues(1)
+
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
-def result_types_tensor_z_z_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_tensor_z_z_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -282,18 +346,24 @@ def result_types_tensor_z_z_testing(device: Device, run_kwargs: Dict[str, Any]):
     obs = Observable.Z() @ Observable.Z()
     obs_targets = [0, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = 0.849694136476246
-    expected_var = 0.27801987443788634
-    expected_eigs = get_pauli_eigenvalues(1)
-
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = 0.849694136476246
+        expected_var = 0.27801987443788634
+        expected_eigs = get_pauli_eigenvalues(1)
+
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
-def result_types_tensor_hermitian_hermitian_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_tensor_hermitian_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -310,18 +380,24 @@ def result_types_tensor_hermitian_hermitian_testing(device: Device, run_kwargs: 
     obs = Observable.Hermitian(matrix1) @ Observable.Hermitian(matrix2)
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = -4.30215023196904
-    expected_var = 370.71292282796804
-    expected_eigs = np.array([-70.90875406, -31.04969387, 0, 3.26468993, 38.693758])
-
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = -4.30215023196904
+        expected_var = 370.71292282796804
+        expected_eigs = np.array([-70.90875406, -31.04969387, 0, 3.26468993, 38.693758])
+
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
-def result_types_tensor_z_h_y_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_tensor_z_h_y_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -329,23 +405,28 @@ def result_types_tensor_z_h_y_testing(device: Device, run_kwargs: Dict[str, Any]
     obs = Observable.Z() @ Observable.H() @ Observable.Y()
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
-    expected_var = (
-        3
-        + np.cos(2 * phi) * np.cos(varphi) ** 2
-        - np.cos(2 * theta) * np.sin(varphi) ** 2
-        - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
-    ) / 4
-    expected_eigs = get_pauli_eigenvalues(1)
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
+        expected_var = (
+            3
+            + np.cos(2 * phi) * np.cos(varphi) ** 2
+            - np.cos(2 * theta) * np.sin(varphi) ** 2
+            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+        ) / 4
+        expected_eigs = get_pauli_eigenvalues(1)
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
-def result_types_tensor_z_hermitian_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_tensor_z_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -361,54 +442,59 @@ def result_types_tensor_z_hermitian_testing(device: Device, run_kwargs: Dict[str
     obs = Observable.Z() @ Observable.Hermitian(array)
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = 0.5 * (
-        -6 * np.cos(theta) * (np.cos(varphi) + 1)
-        - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
-        + 3 * np.cos(varphi) * np.sin(phi)
-        + np.sin(phi)
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
-    expected_var = (
-        1057
-        - np.cos(2 * phi)
-        + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
-        - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
-        + 16 * np.sin(2 * phi)
-        - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
-        - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
-        - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
-        - 8
-        * np.cos(theta)
-        * (
-            4
-            * np.cos(phi)
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = 0.5 * (
+            -6 * np.cos(theta) * (np.cos(varphi) + 1)
+            - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
+            + 3 * np.cos(varphi) * np.sin(phi)
+            + np.sin(phi)
+        )
+        expected_var = (
+            1057
+            - np.cos(2 * phi)
+            + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
+            + 16 * np.sin(2 * phi)
+            - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
+            - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
+            - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+            - 8
+            * np.cos(theta)
             * (
                 4
-                + 8 * np.cos(varphi)
-                + np.cos(2 * varphi)
-                - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                * np.cos(phi)
+                * (
+                    4
+                    + 8 * np.cos(varphi)
+                    + np.cos(2 * varphi)
+                    - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                )
+                + np.sin(phi)
+                * (
+                    15
+                    + 8 * np.cos(varphi)
+                    - 11 * np.cos(2 * varphi)
+                    + 42 * np.sin(varphi)
+                    + 3 * np.sin(2 * varphi)
+                )
             )
-            + np.sin(phi)
-            * (
-                15
-                + 8 * np.cos(varphi)
-                - 11 * np.cos(2 * varphi)
-                + 42 * np.sin(varphi)
-                + 3 * np.sin(2 * varphi)
-            )
+        ) / 16
+
+        z_array = np.diag([1, -1])
+        expected_eigs = np.linalg.eigvalsh(np.kron(z_array, array))
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
         )
-    ) / 16
-
-    z_array = np.diag([1, -1])
-    expected_eigs = np.linalg.eigvalsh(np.kron(z_array, array))
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
-    )
 
 
-def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     theta = 0.432
     phi = 0.123
@@ -424,19 +510,24 @@ def result_types_tensor_y_hermitian_testing(device: Device, run_kwargs: Dict[str
     obs = Observable.Y() @ Observable.Hermitian(array)
     obs_targets = [0, 1, 2]
     circuit = get_result_types_three_qubit_circuit(theta, phi, varphi, obs, obs_targets, shots)
-
-    result = device.run(circuit, **run_kwargs).result()
-
-    expected_mean = 1.4499810303182408
-    expected_var = 74.03174647518193
-    y_array = np.array([[0, -1j], [1j, 0]])
-    expected_eigs = np.linalg.eigvalsh(np.kron(y_array, array))
-    assert_variance_expectation_sample_result(
-        result, shots, expected_var, expected_mean, expected_eigs
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+
+        expected_mean = 1.4499810303182408
+        expected_var = 74.03174647518193
+        y_array = np.array([[0, -1j], [1j, 0]])
+        expected_eigs = np.linalg.eigvalsh(np.kron(y_array, array))
+        assert_variance_expectation_sample_result(
+            result, shots, expected_var, expected_mean, expected_eigs
+        )
 
 
-def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = 0
     theta = 0.432
     phi = 0.123
@@ -460,27 +551,33 @@ def result_types_noncommuting_testing(device: Device, run_kwargs: Dict[str, Any]
         .expectation(obs2, obs2_targets)
         .expectation(obs3, obs3_targets)
     )
-    result = device.run(circuit, **run_kwargs).result()
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
+    )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
 
-    expected_mean1 = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-    expected_var1 = (
-        8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
-        - np.cos(2 * (theta - phi))
-        - np.cos(2 * (theta + phi))
-        + 2 * np.cos(2 * theta)
-        + 2 * np.cos(2 * phi)
-        + 14
-    ) / 16
+        expected_mean1 = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+        expected_var1 = (
+            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+            - np.cos(2 * (theta - phi))
+            - np.cos(2 * (theta + phi))
+            + 2 * np.cos(2 * theta)
+            + 2 * np.cos(2 * phi)
+            + 14
+        ) / 16
 
-    expected_mean2 = 0.849694136476246
-    expected_mean3 = 1.4499810303182408
-    assert np.allclose(result.values[0], expected_var1)
-    assert np.allclose(result.values[1], expected_mean1)
-    assert np.allclose(result.values[2], expected_mean2)
-    assert np.allclose(result.values[3], expected_mean3)
+        expected_mean2 = 0.849694136476246
+        expected_mean3 = 1.4499810303182408
+        assert np.allclose(result.values[0], expected_var1)
+        assert np.allclose(result.values[1], expected_mean1)
+        assert np.allclose(result.values[2], expected_mean2)
+        assert np.allclose(result.values[3], expected_mean3)
 
 
-def result_types_noncommuting_flipped_targets_testing(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_noncommuting_flipped_targets_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     circuit = (
         Circuit()
         .h(0)
@@ -488,12 +585,18 @@ def result_types_noncommuting_flipped_targets_testing(device: Device, run_kwargs
         .expectation(observable=Observable.H() @ Observable.X(), target=[0, 1])
         .expectation(observable=Observable.H() @ Observable.X(), target=[1, 0])
     )
-    result = device.run(circuit, shots=0, **run_kwargs).result()
-    assert np.allclose(result.values[0], np.sqrt(2) / 2)
-    assert np.allclose(result.values[1], np.sqrt(2) / 2)
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
+    )
+    for task in tasks:
+        result = device.run(task, shots=0, **run_kwargs).result()
+        assert np.allclose(result.values[0], np.sqrt(2) / 2)
+        assert np.allclose(result.values[1], np.sqrt(2) / 2)
 
 
-def result_types_noncommuting_all(device: Device, run_kwargs: Dict[str, Any]):
+def result_types_noncommuting_all(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     array = np.array([[1, 2j], [-2j, 0]])
     circuit = (
         Circuit()
@@ -502,12 +605,18 @@ def result_types_noncommuting_all(device: Device, run_kwargs: Dict[str, Any]):
         .expectation(observable=Observable.Hermitian(array))
         .expectation(observable=Observable.X())
     )
-    result = device.run(circuit, shots=0, **run_kwargs).result()
-    assert np.allclose(result.values[0], [0.5, 0.5])
-    assert np.allclose(result.values[1], [0, 0])
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
+    )
+    for task in tasks:
+        result = device.run(task, shots=0, **run_kwargs).result()
+        assert np.allclose(result.values[0], [0.5, 0.5])
+        assert np.allclose(result.values[1], [0, 0])
 
 
-def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
+def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     bell = Circuit().h(0).cnot(0, 1)
@@ -519,31 +628,43 @@ def multithreaded_bell_pair_testing(device: Device, run_kwargs: Dict[str, Any]):
     futures = []
     num_threads = 2
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        for _ in range(num_threads):
-            future = executor.submit(run_circuit, bell)
-            futures.append(future)
-    for future in futures:
-        result = future.result()
-        assert np.allclose(result.measurement_probabilities["00"], 0.5, **tol)
-        assert np.allclose(result.measurement_probabilities["11"], 0.5, **tol)
-        assert len(result.measurements) == shots
+    tasks = (
+        (bell,)
+        if not test_program
+        else (bell, bell.to_ir(ir_type=IRType.OPENQASM))
+    )
+    for task in tasks:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for _ in range(num_threads):
+                future = executor.submit(run_circuit, task)
+                futures.append(future)
+        for future in futures:
+            result = future.result()
+            assert np.allclose(result.measurement_probabilities["00"], 0.5, **tol)
+            assert np.allclose(result.measurement_probabilities["11"], 0.5, **tol)
+            assert len(result.measurements) == shots
 
 
-def noisy_circuit_1qubit_noise_full_probability(device: Device, run_kwargs: Dict[str, Any]):
+def noisy_circuit_1qubit_noise_full_probability(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuit = Circuit().x(0).x(1).bit_flip(0, 0.1).probability()
-    result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 1
-    assert np.allclose(
-        result.get_value_by_result_type(ResultType.Probability()),
-        np.array([0.0, 0.1, 0, 0.9]),
-        **tol
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+        assert len(result.result_types) == 1
+        assert np.allclose(
+            result.get_value_by_result_type(ResultType.Probability()),
+            np.array([0.0, 0.1, 0, 0.9]),
+            **tol
+        )
 
 
-def noisy_circuit_2qubit_noise_full_probability(device: Device, run_kwargs: Dict[str, Any]):
+def noisy_circuit_2qubit_noise_full_probability(device: Device, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     K0 = np.eye(4) * np.sqrt(0.9)
@@ -551,27 +672,38 @@ def noisy_circuit_2qubit_noise_full_probability(device: Device, run_kwargs: Dict
         0.1
     )
     circuit = Circuit().x(0).x(1).kraus((0, 1), [K0, K1]).probability()
-    result = device.run(circuit, **run_kwargs).result()
-    assert len(result.result_types) == 1
-    assert np.allclose(
-        result.get_value_by_result_type(ResultType.Probability()),
-        np.array([0.1, 0.0, 0, 0.9]),
-        **tol
+    tasks = (
+        (circuit,)
+        if not test_program
+        else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     )
+    for task in tasks:
+        result = device.run(task, **run_kwargs).result()
+        assert len(result.result_types) == 1
+        assert np.allclose(
+            result.get_value_by_result_type(ResultType.Probability()),
+            np.array([0.1, 0.0, 0, 0.9]),
+            **tol
+        )
 
 
-def batch_bell_pair_testing(device: AwsDevice, run_kwargs: Dict[str, Any]):
+def batch_bell_pair_testing(device: AwsDevice, run_kwargs: Dict[str, Any], test_program: bool = True):
     shots = run_kwargs["shots"]
     tol = get_tol(shots)
     circuits = [Circuit().h(0).cnot(0, 1) for _ in range(10)]
-
-    batch = device.run_batch(circuits, max_parallel=5, **run_kwargs)
-    results = batch.results()
-    for result in results:
-        assert np.allclose(result.measurement_probabilities["00"], 0.5, **tol)
-        assert np.allclose(result.measurement_probabilities["11"], 0.5, **tol)
-        assert len(result.measurements) == shots
-    assert [task.result() for task in batch.tasks] == results
+    tasks_list = (
+        (circuits,)
+        if not test_program
+        else (circuits, [circuit.to_ir(ir_type=IRType.OPENQASM) for circuit in circuits])
+    )
+    for tasks in tasks_list:
+        batch = device.run_batch(tasks, max_parallel=5, **run_kwargs)
+        results = batch.results()
+        for result in results:
+            assert np.allclose(result.measurement_probabilities["00"], 0.5, **tol)
+            assert np.allclose(result.measurement_probabilities["11"], 0.5, **tol)
+            assert len(result.measurements) == shots
+        assert [task.result() for task in batch.tasks] == results
 
 
 def bell_pair_openqasm_testing(device: AwsDevice, run_kwargs: Dict[str, Any]):

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -250,10 +250,11 @@ def result_types_all_selected_testing(
         .variance(Observable.Hermitian(array))
         .expectation(Observable.Hermitian(array), 0)
     )
+    if shots:
+        circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 1))
+
     tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
-        if shots:
-            circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 1))
         result = device.run(task, **run_kwargs).result()
 
         expected_mean = 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -589,9 +589,7 @@ def bell_pair_openqasm_testing(device: AwsDevice, run_kwargs: Dict[str, Any]):
     generated_openqasm = circuit.to_ir(ir_type=IRType.OPENQASM)
 
     for program in hardcoded_openqasm, generated_openqasm:
-        no_result_types_testing(
-            program, device, run_kwargs, {"00": 0.5, "11": 0.5}
-        )
+        no_result_types_testing(program, device, run_kwargs, {"00": 0.5, "11": 0.5})
 
 
 def openqasm_noisy_circuit_1qubit_noise_full_probability(
@@ -631,10 +629,12 @@ def openqasm_result_types_bell_pair_testing(device: Device, run_kwargs: Dict[str
         "#pragma braket result sample h(q[0]) @ x(q[1])"
     )
     hardcoded_openqasm = OpenQasmProgram(source=openqasm_string)
-    circuit = Circuit().h(0).cnot(0, 1).expectation(
-        Observable.H() @ Observable.X(), (0, 1)
-    ).sample(
-        Observable.H() @ Observable.X(), (0, 1)
+    circuit = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .expectation(Observable.H() @ Observable.X(), (0, 1))
+        .sample(Observable.H() @ Observable.X(), (0, 1))
     )
     generated_openqasm = circuit.to_ir(ir_type=IRType.OPENQASM)
 

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -224,7 +224,6 @@ def result_types_hermitian_testing(
     if shots:
         circuit.add_result_type(ResultType.Sample(Observable.Hermitian(array), 0))
     tasks = (circuit,) if not test_program else (circuit, circuit.to_ir(ir_type=IRType.OPENQASM))
-    print(circuit.to_ir(ir_type=IRType.OPENQASM))
     for task in tasks:
         result = device.run(task, **run_kwargs).result()
 

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -67,7 +67,9 @@ def test_result_types_bell_pair_full_probability(shots):
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_bell_pair_marginal_probability(shots):
-    result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots}, test_program=False)
+    result_types_bell_pair_marginal_probability_testing(
+        DEVICE, {"shots": shots}, test_program=False
+    )
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -41,90 +41,90 @@ SHOTS = 8000
 
 
 def test_multithreaded_bell_pair():
-    multithreaded_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    multithreaded_bell_pair_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 def test_no_result_types_bell_pair():
-    no_result_types_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    no_result_types_bell_pair_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 def test_qubit_ordering():
-    qubit_ordering_testing(DEVICE, {"shots": SHOTS})
+    qubit_ordering_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 def test_result_types_no_shots():
-    result_types_zero_shots_bell_pair_testing(DEVICE, True, {"shots": 0})
+    result_types_zero_shots_bell_pair_testing(DEVICE, True, {"shots": 0}, test_program=False)
 
 
 def test_result_types_nonzero_shots_bell_pair():
-    result_types_nonzero_shots_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    result_types_nonzero_shots_bell_pair_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_bell_pair_full_probability(shots):
-    result_types_bell_pair_full_probability_testing(DEVICE, {"shots": shots})
+    result_types_bell_pair_full_probability_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_bell_pair_marginal_probability(shots):
-    result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots})
+    result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_hermitian(shots):
-    result_types_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_x_y(shots):
-    result_types_tensor_x_y_testing(DEVICE, {"shots": shots})
+    result_types_tensor_x_y_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_z_z(shots):
-    result_types_tensor_z_z_testing(DEVICE, {"shots": shots})
+    result_types_tensor_z_z_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_z_h_y(shots):
-    result_types_tensor_z_h_y_testing(DEVICE, {"shots": shots})
+    result_types_tensor_z_h_y_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_z_hermitian(shots):
-    result_types_tensor_z_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_tensor_z_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_hermitian_hermitian(shots):
-    result_types_tensor_hermitian_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_tensor_hermitian_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_y_hermitian(shots):
-    result_types_tensor_y_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_tensor_y_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_all_selected(shots):
-    result_types_all_selected_testing(DEVICE, {"shots": shots})
+    result_types_all_selected_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 def test_result_types_noncommuting():
-    result_types_noncommuting_testing(DEVICE, {})
+    result_types_noncommuting_testing(DEVICE, {}, test_program=False)
 
 
 def test_result_types_noncommuting_flipped_targets():
-    result_types_noncommuting_flipped_targets_testing(DEVICE, {})
+    result_types_noncommuting_flipped_targets_testing(DEVICE, {}, test_program=False)
 
 
 def test_result_types_noncommuting_all():
-    result_types_noncommuting_all(DEVICE, {})
+    result_types_noncommuting_all(DEVICE, {}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_observable_not_in_instructions(shots):
-    result_types_observable_not_in_instructions(DEVICE, {"shots": shots})
+    result_types_observable_not_in_instructions(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize(

--- a/test/integ_tests/test_local_noise_simulator.py
+++ b/test/integ_tests/test_local_noise_simulator.py
@@ -58,7 +58,9 @@ def test_result_types_bell_pair_full_probability(shots):
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_bell_pair_marginal_probability(shots):
-    result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots}, test_program=False)
+    result_types_bell_pair_marginal_probability_testing(
+        DEVICE, {"shots": shots}, test_program=False
+    )
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])

--- a/test/integ_tests/test_local_noise_simulator.py
+++ b/test/integ_tests/test_local_noise_simulator.py
@@ -40,84 +40,84 @@ SHOTS = 8000
 
 
 def test_no_result_types_bell_pair():
-    no_result_types_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    no_result_types_bell_pair_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 def test_qubit_ordering():
-    qubit_ordering_testing(DEVICE, {"shots": SHOTS})
+    qubit_ordering_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 def test_result_types_nonzero_shots_bell_pair():
-    result_types_nonzero_shots_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    result_types_nonzero_shots_bell_pair_testing(DEVICE, {"shots": SHOTS}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_bell_pair_full_probability(shots):
-    result_types_bell_pair_full_probability_testing(DEVICE, {"shots": shots})
+    result_types_bell_pair_full_probability_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_bell_pair_marginal_probability(shots):
-    result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots})
+    result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_hermitian(shots):
-    result_types_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_x_y(shots):
-    result_types_tensor_x_y_testing(DEVICE, {"shots": shots})
+    result_types_tensor_x_y_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_z_z(shots):
-    result_types_tensor_z_z_testing(DEVICE, {"shots": shots})
+    result_types_tensor_z_z_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_z_h_y(shots):
-    result_types_tensor_z_h_y_testing(DEVICE, {"shots": shots})
+    result_types_tensor_z_h_y_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_z_hermitian(shots):
-    result_types_tensor_z_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_tensor_z_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_hermitian_hermitian(shots):
-    result_types_tensor_hermitian_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_tensor_hermitian_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_tensor_y_hermitian(shots):
-    result_types_tensor_y_hermitian_testing(DEVICE, {"shots": shots})
+    result_types_tensor_y_hermitian_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_result_types_all_selected(shots):
-    result_types_all_selected_testing(DEVICE, {"shots": shots})
+    result_types_all_selected_testing(DEVICE, {"shots": shots}, test_program=False)
 
 
 def test_result_types_noncommuting():
-    result_types_noncommuting_testing(DEVICE, {})
+    result_types_noncommuting_testing(DEVICE, {}, test_program=False)
 
 
 def test_result_types_noncommuting_flipped_targets():
-    result_types_noncommuting_flipped_targets_testing(DEVICE, {})
+    result_types_noncommuting_flipped_targets_testing(DEVICE, {}, test_program=False)
 
 
 def test_result_types_noncommuting_all():
-    result_types_noncommuting_all(DEVICE, {})
+    result_types_noncommuting_all(DEVICE, {}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_noisy_circuit_1qubit_noise(shots):
-    noisy_circuit_1qubit_noise_full_probability(DEVICE, {"shots": shots})
+    noisy_circuit_1qubit_noise_full_probability(DEVICE, {"shots": shots}, test_program=False)
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
 def test_noisy_circuit_2qubit_noise(shots):
-    noisy_circuit_2qubit_noise_full_probability(DEVICE, {"shots": shots})
+    noisy_circuit_2qubit_noise_full_probability(DEVICE, {"shots": shots}, test_program=False)

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -164,6 +164,7 @@ def test_result_types_tensor_z_hermitian(simulator_arn, shots, aws_session, s3_d
     )
 
 
+@pytest.mark.xfail(reason="hermitian all service bug")
 @pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_all_selected(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
@@ -188,6 +189,7 @@ def test_result_types_noncommuting_flipped_targets(
     )
 
 
+@pytest.mark.xfail(reason="hermitian all, x all service bug")
 @pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_result_types_noncommuting_all(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)

--- a/test/integ_tests/test_simulator_quantum_task.py
+++ b/test/integ_tests/test_simulator_quantum_task.py
@@ -164,7 +164,6 @@ def test_result_types_tensor_z_hermitian(simulator_arn, shots, aws_session, s3_d
     )
 
 
-@pytest.mark.xfail(reason="hermitian all service bug")
 @pytest.mark.parametrize("simulator_arn,shots", ARNS_WITH_SHOTS)
 def test_result_types_all_selected(simulator_arn, shots, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)
@@ -189,7 +188,6 @@ def test_result_types_noncommuting_flipped_targets(
     )
 
 
-@pytest.mark.xfail(reason="hermitian all, x all service bug")
 @pytest.mark.parametrize("simulator_arn", SIMULATOR_ARNS)
 def test_result_types_noncommuting_all(simulator_arn, aws_session, s3_destination_folder):
     device = AwsDevice(simulator_arn, aws_session)

--- a/test/unit_tests/braket/circuits/test_observables.py
+++ b/test/unit_tests/braket/circuits/test_observables.py
@@ -196,6 +196,22 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             [3, 0, 1],
             "h($3) @ z($0) @ i($1)",
         ),
+        (
+            Observable.Hermitian(np.eye(4)) @ Observable.I(),
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
+            [3, 0, 1],
+            "hermitian([[1+0im, 0im, 0im, 0im], [0im, 1+0im, 0im, 0im], "
+            "[0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) q[3], q[0]"
+            " @ i(q[1])",
+        ),
+        (
+            Observable.I() @ Observable.Hermitian(np.eye(4)),
+            OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.PHYSICAL),
+            [3, 0, 1],
+            "i($3) @ "
+            "hermitian([[1+0im, 0im, 0im, 0im], [0im, 1+0im, 0im, 0im], "
+            "[0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) $0, $1",
+        ),
     ],
 )
 def test_observables_to_ir_openqasm(observable, serialization_properties, target, expected_ir):

--- a/test/unit_tests/braket/circuits/test_result_types.py
+++ b/test/unit_tests/braket/circuits/test_result_types.py
@@ -154,7 +154,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.Probability(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result probability",
+            "#pragma braket result probability all",
         ),
         (
             ResultType.Probability([0, 2]),

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     {[test-deps]deps}
 passenv =
     AWS_PROFILE
+    BRAKET_ENDPOINT
 commands =
     pytest test/integ_tests {posargs}
 extras = test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add openqasm generation step to openqasm integ tests.

*Testing done:*

tox -e integ-tests -- -k openqasm

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
