### PR TITLE
feature: raise error if user tries to use inputs for the service

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -458,6 +458,10 @@ def _(
     *args,
     **kwargs,
 ) -> AwsQuantumTask:
+    if open_qasm_program.inputs is not None:
+        raise ValueError(
+            "OpenQASM Program inputs are only currently supported in the LocalSimulator."
+        )
     create_task_kwargs.update({"action": open_qasm_program.json()})
     task_arn = aws_session.create_quantum_task(**create_task_kwargs)
     return AwsQuantumTask(task_arn, aws_session, *args, **kwargs)

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -870,3 +870,20 @@ def _mock_metadata(aws_session, state):
 
 def _mock_s3(aws_session, result):
     aws_session.retrieve_s3_object_body.return_value = result
+
+
+def test_no_program_inputs(aws_session):
+    openqasm_program = OpenQasmProgram(
+        source="""
+        qubit q;
+        h q;
+        """,
+        inputs={"x": 1},
+    )
+    aws_session.create_quantum_task.return_value = arn
+    shots = 21
+    only_for_local_sim = (
+        "OpenQASM Program inputs are only currently supported in the LocalSimulator."
+    )
+    with pytest.raises(ValueError, match=only_for_local_sim):
+        AwsQuantumTask.create(aws_session, SIMULATOR_ARN, openqasm_program, S3_TARGET, shots)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Raise an error when a user tries to use OpenQASM Program inputs for an AWS quantum task.

*Testing done:*

unit test added, manually tested

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
