### PR TITLE
assert no sim warning for integ tests

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -754,7 +754,8 @@ class Circuit:
         noise: Union[Type[Noise], Iterable[Type[Noise]]],
         target_qubits: Optional[QubitSetInput] = None,
     ) -> Circuit:
-        """Apply `noise` at the beginning of the circuit for every qubit (default) or target_qubits`.
+        """Apply `noise` at the beginning of the circuit for every qubit (default) or
+        target_qubits`.
 
         Only when `target_qubits` is given can the noise be applied to an empty circuit.
 

--- a/test/integ_tests/test_local_braket_simulator.py
+++ b/test/integ_tests/test_local_braket_simulator.py
@@ -40,91 +40,110 @@ DEVICE = LocalSimulator()
 SHOTS = 8000
 
 
-def test_multithreaded_bell_pair():
+def test_multithreaded_bell_pair(caplog):
     multithreaded_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
-def test_no_result_types_bell_pair():
+def test_no_result_types_bell_pair(caplog):
     no_result_types_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
-def test_qubit_ordering():
+def test_qubit_ordering(caplog):
     qubit_ordering_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
-def test_result_types_no_shots():
+def test_result_types_no_shots(caplog):
     result_types_zero_shots_bell_pair_testing(DEVICE, True, {"shots": 0})
+    assert not caplog.text
 
 
-def test_result_types_nonzero_shots_bell_pair():
+def test_result_types_nonzero_shots_bell_pair(caplog):
     result_types_nonzero_shots_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_bell_pair_full_probability(shots):
+def test_result_types_bell_pair_full_probability(shots, caplog):
     result_types_bell_pair_full_probability_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_bell_pair_marginal_probability(shots):
+def test_result_types_bell_pair_marginal_probability(shots, caplog):
     result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_hermitian(shots):
+def test_result_types_hermitian(shots, caplog):
     result_types_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_x_y(shots):
+def test_result_types_tensor_x_y(shots, caplog):
     result_types_tensor_x_y_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_z_z(shots):
+def test_result_types_tensor_z_z(shots, caplog):
     result_types_tensor_z_z_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_z_h_y(shots):
+def test_result_types_tensor_z_h_y(shots, caplog):
     result_types_tensor_z_h_y_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_z_hermitian(shots):
+def test_result_types_tensor_z_hermitian(shots, caplog):
     result_types_tensor_z_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_hermitian_hermitian(shots):
+def test_result_types_tensor_hermitian_hermitian(shots, caplog):
     result_types_tensor_hermitian_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_y_hermitian(shots):
+def test_result_types_tensor_y_hermitian(shots, caplog):
     result_types_tensor_y_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_all_selected(shots):
+def test_result_types_all_selected(shots, caplog):
     result_types_all_selected_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
-def test_result_types_noncommuting():
+def test_result_types_noncommuting(caplog):
     result_types_noncommuting_testing(DEVICE, {})
+    assert not caplog.text
 
 
-def test_result_types_noncommuting_flipped_targets():
+def test_result_types_noncommuting_flipped_targets(caplog):
     result_types_noncommuting_flipped_targets_testing(DEVICE, {})
+    assert not caplog.text
 
 
-def test_result_types_noncommuting_all():
+def test_result_types_noncommuting_all(caplog):
     result_types_noncommuting_all(DEVICE, {})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_observable_not_in_instructions(shots):
+def test_result_types_observable_not_in_instructions(shots, caplog):
     result_types_observable_not_in_instructions(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize(
@@ -135,6 +154,7 @@ def test_result_types_observable_not_in_instructions(shots):
         ("braket_dm", "DensityMatrixSimulator"),
     ],
 )
-def test_local_simulator_device_names(backend, device_name):
+def test_local_simulator_device_names(backend, device_name, caplog):
     local_simulator_device = LocalSimulator(backend)
     assert local_simulator_device.name == device_name
+    assert not caplog.text

--- a/test/integ_tests/test_local_noise_simulator.py
+++ b/test/integ_tests/test_local_noise_simulator.py
@@ -39,85 +39,103 @@ DEVICE = LocalSimulator("braket_dm")
 SHOTS = 8000
 
 
-def test_no_result_types_bell_pair():
+def test_no_result_types_bell_pair(caplog):
     no_result_types_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
-def test_qubit_ordering():
+def test_qubit_ordering(caplog):
     qubit_ordering_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
-def test_result_types_nonzero_shots_bell_pair():
+def test_result_types_nonzero_shots_bell_pair(caplog):
     result_types_nonzero_shots_bell_pair_testing(DEVICE, {"shots": SHOTS})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_bell_pair_full_probability(shots):
+def test_result_types_bell_pair_full_probability(shots, caplog):
     result_types_bell_pair_full_probability_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_bell_pair_marginal_probability(shots):
+def test_result_types_bell_pair_marginal_probability(shots, caplog):
     result_types_bell_pair_marginal_probability_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_hermitian(shots):
+def test_result_types_hermitian(shots, caplog):
     result_types_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_x_y(shots):
+def test_result_types_tensor_x_y(shots, caplog):
     result_types_tensor_x_y_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_z_z(shots):
+def test_result_types_tensor_z_z(shots, caplog):
     result_types_tensor_z_z_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_z_h_y(shots):
+def test_result_types_tensor_z_h_y(shots, caplog):
     result_types_tensor_z_h_y_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_z_hermitian(shots):
+def test_result_types_tensor_z_hermitian(shots, caplog):
     result_types_tensor_z_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_hermitian_hermitian(shots):
+def test_result_types_tensor_hermitian_hermitian(shots, caplog):
     result_types_tensor_hermitian_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_tensor_y_hermitian(shots):
+def test_result_types_tensor_y_hermitian(shots, caplog):
     result_types_tensor_y_hermitian_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_result_types_all_selected(shots):
+def test_result_types_all_selected(shots, caplog):
     result_types_all_selected_testing(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
-def test_result_types_noncommuting():
+def test_result_types_noncommuting(caplog):
     result_types_noncommuting_testing(DEVICE, {})
+    assert not caplog.text
 
 
-def test_result_types_noncommuting_flipped_targets():
+def test_result_types_noncommuting_flipped_targets(caplog):
     result_types_noncommuting_flipped_targets_testing(DEVICE, {})
+    assert not caplog.text
 
 
-def test_result_types_noncommuting_all():
+def test_result_types_noncommuting_all(caplog):
     result_types_noncommuting_all(DEVICE, {})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_noisy_circuit_1qubit_noise(shots):
+def test_noisy_circuit_1qubit_noise(shots, caplog):
     noisy_circuit_1qubit_noise_full_probability(DEVICE, {"shots": shots})
+    assert not caplog.text
 
 
 @pytest.mark.parametrize("shots", [0, SHOTS])
-def test_noisy_circuit_2qubit_noise(shots):
+def test_noisy_circuit_2qubit_noise(shots, caplog):
     noisy_circuit_2qubit_noise_full_probability(DEVICE, {"shots": shots})
+    assert not caplog.text


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make sure there is no local sim openqasm features warning for integ tests

*Testing done:*

integ

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
