### PR TITLE
fix: Avoid mutation of fixtures

### DIFF
--- a/test/unit_tests/braket/tasks/test_photonic_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_photonic_model_quantum_task_result.py
@@ -64,9 +64,10 @@ def result_1_str(result_1):
 
 @pytest.fixture
 def empty_result(task_metadata, additional_metadata):
-    task_metadata.id = "empty_arn"
+    updated_metadata = task_metadata.copy()
+    updated_metadata.id = "empty_arn"
     return PhotonicModelTaskResult(
-        taskMetadata=task_metadata, additionalMetadata=additional_metadata
+        taskMetadata=updated_metadata, additionalMetadata=additional_metadata
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Avoid mutation of a fixture which is being reused across multiple object. This was working earlier as Pydantic had inadvertently released a change for deep copying, but have now reverted to the old behavior of shallow copying.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
