### PR TITLE
fix: LocalQuantumJob.create() fails  on Windows

### DIFF
--- a/src/braket/jobs/local/local_job_container.py
+++ b/src/braket/jobs/local/local_job_container.py
@@ -14,7 +14,7 @@ import base64
 import re
 import subprocess
 from logging import Logger, getLogger
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, List
 
 from braket.aws.aws_session import AwsSession
@@ -193,7 +193,7 @@ class _LocalJobContainer(object):
         Raises:
             subprocess.CalledProcessError: If unable to copy.
         """
-        dirname = str(Path(destination).parent)
+        dirname = str(PurePosixPath(destination).parent)
         try:
             subprocess.check_output(
                 ["docker", "exec", self._container_name, "mkdir", "-p", dirname]

--- a/src/braket/jobs/local/local_job_container.py
+++ b/src/braket/jobs/local/local_job_container.py
@@ -14,7 +14,7 @@ import base64
 import re
 import subprocess
 from logging import Logger, getLogger
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Dict, List
 
 from braket.aws.aws_session import AwsSession

--- a/test/unit_tests/braket/jobs/local/test_local_job_container.py
+++ b/test/unit_tests/braket/jobs/local/test_local_job_container.py
@@ -13,7 +13,7 @@
 
 import base64
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest.mock import Mock, patch
 
 import pytest
@@ -321,7 +321,7 @@ def test_copy_to(mock_run, mock_check_output, repo_uri, image_uri, aws_session):
     local_image_name = "LocalImageName"
     running_container_name = "RunningContainer"
     source_path = str(Path("test", "source", "dir", "path", "srcfile.txt"))
-    dest_path = str(Path("test", "dest", "dir", "path", "dstfile.txt"))
+    dest_path = str(PurePosixPath("test", "dest", "dir", "path", "dstfile.txt"))
     mock_check_output.side_effect = [
         str.encode(local_image_name),
         str.encode(running_container_name),
@@ -341,7 +341,7 @@ def test_copy_to(mock_run, mock_check_output, repo_uri, image_uri, aws_session):
             running_container_name,
             "mkdir",
             "-p",
-            str(Path("test", "dest", "dir", "path")),
+            str(PurePosixPath("test", "dest", "dir", "path")),
         ]
     )
     mock_check_output.assert_any_call(


### PR DESCRIPTION
*Issue #440 *

*Description of changes:*
Updated Path calls to PurePosixPath for the destination directory.
*Testing done:*
Tested the fix as described in the issue in Windows and WSL.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
[integ-aws-win-20220916T1742.log](https://github.com/aws/amazon-braket-sdk-python/files/9590481/integ-aws-win-20220916T1742.log)
[integ-aws-wsl-20220916T1758.log](https://github.com/aws/amazon-braket-sdk-python/files/9590485/integ-aws-wsl-20220916T1758.log)
