### PR TITLE
fix: allow using numpy arrays as atom sites

### DIFF
--- a/src/braket/ahs/atom_arrangement.py
+++ b/src/braket/ahs/atom_arrangement.py
@@ -52,7 +52,7 @@ class AtomArrangement:
         Returns:
             AtomArrangement: returns self (to allow for chaining).
         """
-        self._sites.append(AtomArrangementItem(coord, site_type))
+        self._sites.append(AtomArrangementItem(tuple(coord), site_type))
         return self
 
     def coordinate_list(self, coordinate_index: Number) -> List[Number]:

--- a/src/braket/ahs/atom_arrangement.py
+++ b/src/braket/ahs/atom_arrangement.py
@@ -51,8 +51,8 @@ class AtomArrangement:
 
         Args:
             coord (Union[Tuple[Number, Number], np.ndarray]): The coordinate of the
-                atom (in meters). The coordinates can be a tuple of int, float,
-                Decimal, or a numpy array of shape (2,)
+                atom (in meters). The coordinates can be a numpy array of shape (2,)
+                or a tuple of int, float, Decimal
             site_type (SiteType): The type of site. Optional. Default is FILLED.
         Returns:
             AtomArrangement: returns self (to allow for chaining).

--- a/src/braket/ahs/atom_arrangement.py
+++ b/src/braket/ahs/atom_arrangement.py
@@ -13,11 +13,13 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from numbers import Number
-from typing import Iterator, List, Tuple
+from typing import Iterator, List, Tuple, Union
 
 from braket.ahs.discretization_types import DiscretizationError, DiscretizationProperties
 
@@ -41,13 +43,16 @@ class AtomArrangement:
         self._sites = []
 
     def add(
-        self, coord: Tuple[Number, Number], site_type: SiteType = SiteType.FILLED
+        self,
+        coord: Union[Tuple[Number, Number], np.ndarray],
+        site_type: SiteType = SiteType.FILLED
     ) -> AtomArrangement:
         """Add a coordinate to the atom arrangement.
 
         Args:
-            coord (Tuple[Number, Number]): The coordinate of the atom (in meters). The coordinates
-                can be int, float or Decimal.
+            coord (Union[Tuple[Number, Number], np.ndarray]): The coordinate of the
+                atom (in meters). The coordinates can be a tuple of int, float,
+                Decimal, or a numpy array of shape (2,)
             site_type (SiteType): The type of site. Optional. Default is FILLED.
         Returns:
             AtomArrangement: returns self (to allow for chaining).

--- a/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
+++ b/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
@@ -13,6 +13,7 @@
 
 import json
 from decimal import Decimal
+import numpy as np
 from unittest.mock import Mock
 
 import pytest
@@ -176,3 +177,26 @@ def test_discretize(register, driving_field, shifting_field):
         "pattern": [0.5, 1.0, 0.5, 0.5, 0.5, 0.5],
         "sequence": {"times": [0.0, 3e-06], "values": [-125664000.0, 125664000.0]},
     }
+
+
+def test_converting_numpy_array_sites_to_ir(register, driving_field):
+    hamiltonian = driving_field
+
+    sites = np.array([
+        [0.0, 0.0],
+        [0.0, 1.0e-6],
+        [1e-6, 2.0e-6],
+    ])
+    register = AtomArrangement()
+    for site in sites:
+        register.add(site)
+
+    ahs = AnalogHamiltonianSimulation(register=register, hamiltonian=hamiltonian)
+    sites_in_ir = ahs.to_ir().setup.atomArray.sites
+    expected_sites_in_ir = [
+        [Decimal("0.0"), Decimal("0.0")],
+        [Decimal("0.0"), Decimal("1e-6")],
+        [Decimal("1e-6"), Decimal("2e-6")],
+    ]
+
+    assert sites_in_ir == expected_sites_in_ir


### PR DESCRIPTION
*Description of changes:*

`AtomArrangement.add` converts the `coord` argument to a tuple before constructing an `AtomArrangementItem`. This enables passing numpy arrays of shape `(2,)` to to `add`. Without this conversion, the `add` would not fail, but calling `to_ir` on the `AnalogHamiltonianSimulation` object containing the atom arrangement in question would fail.

*Testing done:*

Yes. See `test_converting_numpy_array_sites_to_ir` in unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
