### PR TITLE
feature: validate site when adding to register

### DIFF
--- a/src/braket/ahs/atom_arrangement.py
+++ b/src/braket/ahs/atom_arrangement.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 from __future__ import annotations
-from multiprocessing.sharedctypes import Value
 
 import numpy as np
 

--- a/src/braket/ahs/atom_arrangement.py
+++ b/src/braket/ahs/atom_arrangement.py
@@ -52,7 +52,7 @@ class AtomArrangementItem:
        
     def _validate_site_type(self):
         allowed_site_types = {SiteType.FILLED, SiteType.VACANT}
-        if self.site_type not in {SiteType.FILLED, SiteType.VACANT}:
+        if self.site_type not in allowed_site_types:
             raise ValueError(
                     f"{self.site_type} must be one of {allowed_site_types}"
                 )

--- a/src/braket/ahs/atom_arrangement.py
+++ b/src/braket/ahs/atom_arrangement.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from __future__ import annotations
+from multiprocessing.sharedctypes import Value
 
 import numpy as np
 
@@ -33,6 +34,32 @@ class SiteType(Enum):
 class AtomArrangementItem:
     coordinate: Tuple[Number, Number]
     site_type: SiteType
+
+    def _validate_coordinate(self):
+        if (self.coordinate != tuple(self.coordinate)):
+            raise TypeError(
+                f"{self.coordinate} must be a tuple of numbers"
+            )
+        if len(self.coordinate) != 2:
+            raise ValueError(
+                f"{self.coordinate} must be of length 2"
+            )
+        for idx, num in enumerate(self.coordinate):
+            if not isinstance(num, Number):
+                raise TypeError(
+                    f"{num} at position {idx} must be a number"
+                )
+       
+    def _validate_site_type(self):
+        allowed_site_types = {SiteType.FILLED, SiteType.VACANT}
+        if self.site_type not in {SiteType.FILLED, SiteType.VACANT}:
+            raise ValueError(
+                    f"{self.site_type} must be one of {allowed_site_types}"
+                )
+
+    def __post_init__(self):
+        self._validate_coordinate()
+        self._validate_site_type()
 
 
 class AtomArrangement:

--- a/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
+++ b/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
@@ -26,6 +26,7 @@ from braket.ahs.analog_hamiltonian_simulation import (
     ShiftingField,
     SiteType,
 )
+from braket.ahs.atom_arrangement import AtomArrangementItem
 from braket.ahs.field import Field
 from braket.ahs.pattern import Pattern
 from braket.ahs.time_series import TimeSeries
@@ -179,7 +180,7 @@ def test_discretize(register, driving_field, shifting_field):
     }
 
 
-def test_converting_numpy_array_sites_to_ir(register, driving_field):
+def test_converting_numpy_array_sites_to_ir(driving_field):
     hamiltonian = driving_field
 
     sites = np.array([
@@ -190,7 +191,7 @@ def test_converting_numpy_array_sites_to_ir(register, driving_field):
     register = AtomArrangement()
     for site in sites:
         register.add(site)
-
+    
     ahs = AnalogHamiltonianSimulation(register=register, hamiltonian=hamiltonian)
     sites_in_ir = ahs.to_ir().setup.atomArray.sites
     expected_sites_in_ir = [
@@ -200,3 +201,26 @@ def test_converting_numpy_array_sites_to_ir(register, driving_field):
     ]
 
     assert sites_in_ir == expected_sites_in_ir
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_site_validation_wrong_length():
+    register = AtomArrangement()
+    register.add(np.array([0.0, 1e-6, -1e-6]))
+
+
+@pytest.mark.xfail(raises=TypeError)
+def test_site_validation_non_number():
+    register = AtomArrangement()
+    register.add(['not-a-number', ['also-not-a-number', ]])
+
+
+@pytest.mark.xfail(raises=TypeError)
+def test_site_validation_not_a_tuple():
+    AtomArrangementItem(None, SiteType.FILLED)
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_site_validation_invalid_site_type():
+    register = AtomArrangement()
+    register.add([0.0, 0.0], 'not-a-valid-site-type')

--- a/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
+++ b/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
@@ -191,7 +191,7 @@ def test_converting_numpy_array_sites_to_ir(driving_field):
     register = AtomArrangement()
     for site in sites:
         register.add(site)
-    
+
     ahs = AnalogHamiltonianSimulation(register=register, hamiltonian=hamiltonian)
     sites_in_ir = ahs.to_ir().setup.atomArray.sites
     expected_sites_in_ir = [


### PR DESCRIPTION
*Description of changes:*

When the caller is doing `AtomArrangement.add(coord, site_type)`, both `coord` and `site_type` get validated for type and value.

*Testing done:*

Yes, the following tests (in test_analog_hamiltonian_simulation.py) check the correct behavior of the validator:
* `test_site_validation_wrong_length`
* `test_site_validation_non_number`
* `test_site_validation_not_a_tuple`
* `test_site_validation_invalid_site_type`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
