### PR TITLE
feature: support inputs in the device interface

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1149,12 +1149,14 @@ class Circuit:
                 qubit_target = serialization_properties.format_target(int(qubit))
                 ir_instructions.append(f"b[{idx}] = measure {qubit_target};")
 
-        return OpenQasmProgram.construct(source="\n".join(ir_instructions))
+        return OpenQasmProgram.construct(source="\n".join(ir_instructions), inputs={})
 
     def _create_openqasm_header(
         self, serialization_properties: OpenQASMSerializationProperties
     ) -> List[str]:
         ir_instructions = ["OPENQASM 3.0;"]
+        for parameter in self.parameters:
+            ir_instructions.append(f"input float {parameter};")
         if not self.result_types:
             ir_instructions.append(f"bit[{self.qubit_count}] b;")
 

--- a/src/braket/devices/device.py
+++ b/src/braket/devices/device.py
@@ -35,8 +35,8 @@ class Device(ABC):
     def run(
         self,
         task_specification: Union[Circuit, Problem],
-        shots: Optional[int],
-        inputs: Optional[Dict[str, float]],
+        shots: Optional[int] = 0,
+        inputs: Optional[Dict[str, float]] = None,
         *args,
         **kwargs
     ) -> QuantumTask:

--- a/src/braket/devices/device.py
+++ b/src/braket/devices/device.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from braket.annealing.problem import Problem
 from braket.circuits import Circuit
@@ -33,7 +33,12 @@ class Device(ABC):
 
     @abstractmethod
     def run(
-        self, task_specification: Union[Circuit, Problem], shots: Optional[int], *args, **kwargs
+        self,
+        task_specification: Union[Circuit, Problem],
+        shots: Optional[int],
+        inputs: Optional[Dict[str, float]],
+        *args,
+        **kwargs
     ) -> QuantumTask:
         """Run a quantum task specification on this quantum device. A task can be a circuit
         or an annealing problem.
@@ -43,6 +48,9 @@ class Device(ABC):
                 to run on device.
             shots (Optional[int]): The number of times to run the task on the device.
                 Default is `None`.
+            inputs (Optional[Dict[str, float]]): Inputs to be passed along with the
+                IR. If IR is an OpenQASM Program, the inputs will be updated with this value.
+                Not all devices and IR formats support inputs. Default: {}.
 
         Returns:
             QuantumTask: The QuantumTask tracking task execution on this device

--- a/src/braket/devices/device.py
+++ b/src/braket/devices/device.py
@@ -35,8 +35,8 @@ class Device(ABC):
     def run(
         self,
         task_specification: Union[Circuit, Problem],
-        shots: Optional[int] = 0,
-        inputs: Optional[Dict[str, float]] = None,
+        shots: Optional[int],
+        inputs: Optional[Dict[str, float]],
         *args,
         **kwargs
     ) -> QuantumTask:

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -659,7 +659,8 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                         "b[0] = measure q[0];",
                         "b[1] = measure q[1];",
                     ]
-                )
+                ),
+                inputs={},
             ),
         ),
         (
@@ -675,7 +676,8 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                         "b[0] = measure $0;",
                         "b[1] = measure $4;",
                     ]
-                )
+                ),
+                inputs={},
             ),
         ),
         (
@@ -695,7 +697,8 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                         "}",
                         "#pragma braket result expectation i all",
                     ]
-                )
+                ),
+                inputs={},
             ),
         ),
         (
@@ -715,7 +718,27 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                         "#pragma braket noise bit_flip(0.2) q[3]",
                         "#pragma braket result expectation i(q[0])",
                     ]
-                )
+                ),
+                inputs={},
+            ),
+        ),
+        (
+            Circuit().rx(0, 0.15).rx(1, FreeParameter("theta")),
+            OpenQASMSerializationProperties(QubitReferenceType.VIRTUAL),
+            OpenQasmProgram(
+                source="\n".join(
+                    [
+                        "OPENQASM 3.0;",
+                        "input float theta;",
+                        "bit[2] b;",
+                        "qubit[2] q;",
+                        "rx(0.15) q[0];",
+                        "rx(theta) q[1];",
+                        "b[0] = measure q[0];",
+                        "b[1] = measure q[1];",
+                    ]
+                ),
+                inputs={},
             ),
         ),
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Support specifying inputs from `device.run` for the local simulator. A circuit with free parameters, when passed along with correct input, will run successfully on the local simulator. The AwsDevice class does not at this moment have an option for inputs added, so the behavior is unchanged.

*Testing done:*

Unit tests and manual e2e verification.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
