### PR TITLE
Plot the phase between 0 and 2*pi

### DIFF
--- a/test/unit_tests/braket/pulse/ast/test_approximation_parser.py
+++ b/test/unit_tests/braket/pulse/ast/test_approximation_parser.py
@@ -115,7 +115,7 @@ def test_set_shift_phase_beyond_2_pi(port):
     frame = Frame(frame_id="frame1", port=port, frequency=1e8, phase=0, is_predefined=False)
     pulse_seq = (
         PulseSequence()
-        .set_phase(frame, 5*np.pi/2)
+        .set_phase(frame, 5 * np.pi / 2)
         .delay(frame, 2e-9)
         .shift_phase(frame, -np.pi)
         .delay(frame, 5e-9)
@@ -129,17 +129,18 @@ def test_set_shift_phase_beyond_2_pi(port):
     # 5pi/2 is reduced to pi/2
     expected_amplitudes["frame1"].put(0, 0).put(1e-9, 0)
     expected_frequencies["frame1"].put(0, 1e8).put(1e-9, 1e8)
-    expected_phases["frame1"].put(0, np.pi/2).put(1e-9, np.pi/2)
+    expected_phases["frame1"].put(0, np.pi / 2).put(1e-9, np.pi / 2)
 
     # set_shift_phase should be instantaneous (result on current or next datapoint?)
     # shift_phase adds -pi to the phase of the last point -> 3pi/2
     expected_amplitudes["frame1"].put(2e-9, 0).put(6e-9, 0)
     expected_frequencies["frame1"].put(2e-9, 1e8).put(6e-9, 1e8)
-    expected_phases["frame1"].put(2e-9, 3*np.pi/2).put(6e-9, 3*np.pi/2)
+    expected_phases["frame1"].put(2e-9, 3 * np.pi / 2).put(6e-9, 3 * np.pi / 2)
 
     parser = _ApproximationParser(program=pulse_seq._program, frames=to_dict(frame))
 
     verify_results(parser, expected_amplitudes, expected_frequencies, expected_phases)
+
 
 def test_set_shift_frequency(port):
     frame = Frame(frame_id="frame1", port=port, frequency=1e8, phase=0, is_predefined=False)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We change the way the phase of frames is displayed by bounding it between 0 and 2pi.

*Testing done:* 
We add a new test that checks specifically for the case where the phase is initially set above 2pi and shifting out of the 0-2pi range.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
