### PR TITLE
bump oqpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "amazon-braket-schemas>=1.12.0",
         "amazon-braket-default-simulator>=1.10.0",
-        "oqpy==0.1.0",
+        "oqpy==0.1.1",
         "backoff",
         "boltons",
         "boto3>=1.22.3",


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Bump [`oqpy`](https://github.com/openqasm/oqpy) version. The [0.1.1 release](https://github.com/openqasm/oqpy/releases/tag/v0.1.1) loosens the bounds on numpy and openpulse, making it easier to use with other projects. We ran into this on [mitiq](https://github.com/unitaryfund/mitiq) since the 1.32 release of `amazon-braket-sdk` which added oqpy as a dependency.

*Testing done:* None. The changes in the latest oqpy release look small. Hoping CI should be enough, but let me know if there is other testing I should try.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
