### PR TITLE
loosen oqpy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "amazon-braket-schemas>=1.12.0",
         "amazon-braket-default-simulator>=1.10.0",
-        "oqpy",
+        "oqpy~=0.1.1",
         "backoff",
         "boltons",
         "boto3>=1.22.3",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "amazon-braket-schemas>=1.12.0",
         "amazon-braket-default-simulator>=1.10.0",
-        "oqpy==0.1.1",
+        "oqpy",
         "backoff",
         "boltons",
         "boto3>=1.22.3",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             "black",
             "botocore",
             "coverage==5.5",
-            "flake8",
+            "flake8<=5.0.4",
             "isort",
             "jsonschema==3.2.0",
             "pre-commit",


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* `oqpy` [released version 0.1.2](https://github.com/openqasm/oqpy/releases/tag/v0.1.2) which is python 3.11 compatible. We'd like to support python 3.11 over on Mitiq as well, but are blocked by the pinned version of oqpy here. I've gone ahead and removed the version specifier completely since many other dependencies are also unspecified, but let me know if having some range would be better.

*Testing done:* None

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
