### PR TITLE
fix: Hamiltonian ascii simplification

### DIFF
--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -431,7 +431,7 @@ Observable.register_observable(TensorProduct)
 class Sum(Observable):
     """Sum of observables"""
 
-    def __init__(self, observables: List[Observable]):
+    def __init__(self, observables: List[Observable], display_name: str = "Hamiltonian"):
         """
         Args:
             observables (List[Observable]): List of observables for Sum
@@ -451,8 +451,7 @@ class Sum(Observable):
                 flattened_observables.append(obs)
 
         self._summands = tuple(flattened_observables)
-        qubit_count = sum(obs.qubit_count for obs in flattened_observables)
-        display_name = "+".join([obs.ascii_symbols[0] for obs in flattened_observables])
+        qubit_count = max(flattened_observables, key=lambda obs: obs.qubit_count).qubit_count
         super().__init__(qubit_count=qubit_count, ascii_symbols=[display_name] * qubit_count)
 
     @property

--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -232,7 +232,7 @@ class ObservableResultType(ResultType):
                     f"Observable's qubit count {self._observable.qubit_count} and "
                     f"the size of the target qubit set {self._target} must be equal"
                 )
-            if self._observable.qubit_count != len(self.ascii_symbols):
+            elif self._observable.qubit_count != len(self.ascii_symbols):
                 raise ValueError(
                     "Observable's qubit count and the number of ASCII symbols must be equal"
                 )

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -14,12 +14,14 @@
 from __future__ import annotations
 
 import re
+from functools import reduce
 from typing import List, Union
 
 import braket.ir.jaqcd as ir
 from braket.circuits import circuit
 from braket.circuits.free_parameter import FreeParameter
 from braket.circuits.observable import Observable
+from braket.circuits.observables import Sum
 from braket.circuits.qubit_set import QubitSet, QubitSetInput
 from braket.circuits.result_type import (
     ObservableParameterResultType,
@@ -208,10 +210,13 @@ class AdjointGradient(ObservableParameterResultType):
             >>> )
         """
 
+        if isinstance(observable, Sum):
+            target_qubits = reduce(QubitSet.union, map(QubitSet, target), QubitSet())
+        else:
+            target_qubits = QubitSet(target)
+
         super().__init__(
-            ascii_symbols=[
-                f"AdjointGradient({obs_ascii})" for obs_ascii in observable.ascii_symbols
-            ],
+            ascii_symbols=[f"AdjointGradient({observable.ascii_symbols[0]})"] * len(target_qubits),
             observable=observable,
             target=target,
             parameters=parameters,

--- a/test/unit_tests/braket/circuits/test_observable.py
+++ b/test/unit_tests/braket/circuits/test_observable.py
@@ -212,5 +212,5 @@ def test_sum_observable_with_subtraction():
     obs2 = -4 * Observable.Y()
     result = obs1 - obs2
     assert isinstance(result, Observable.Sum)
-    assert result.qubit_count == 2
-    assert result.ascii_symbols == ("6X+4Y", "6X+4Y")
+    assert result.qubit_count == 1
+    assert result.ascii_symbols == ("6X+4Y",)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Default ASCII representation of Hamiltonians (Sum observables) to "Hamiltonian".

Opt to underestimate qubit count for Sum observables rather than overestimate

*Testing done:*

unit testing, manual performance testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
