### PR TITLE
fix: add DoubleAngledGate as exported symbol

### DIFF
--- a/src/braket/circuits/__init__.py
+++ b/src/braket/circuits/__init__.py
@@ -19,7 +19,7 @@ from braket.circuits import (  # noqa: F401
     observables,
     result_types,
 )
-from braket.circuits.angled_gate import AngledGate  # noqa: F401
+from braket.circuits.angled_gate import AngledGate, DoubleAngledGate  # noqa: F401
 from braket.circuits.ascii_circuit_diagram import AsciiCircuitDiagram  # noqa: F401
 from braket.circuits.circuit import Circuit  # noqa: F401
 from braket.circuits.circuit_diagram import CircuitDiagram  # noqa: F401


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Exports the `DoubleAngledGate` symbol, which was not accessible from outside the package. The `AngledGate` symbol was already exported, so this is for consistency.

*Testing done:*
Verified that I can access the `DoubleAngledGate` symbol from outside the package. No tests added for this change. (The `DoubleAngledGate` class already has unit tests, and I'm not sure how to test this change otherwise.)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
