### PR TITLE
fix: ignore CompilerDirective when calculating unitary

### DIFF
--- a/src/braket/circuits/unitary_calculation.py
+++ b/src/braket/circuits/unitary_calculation.py
@@ -15,6 +15,7 @@ from typing import Iterable
 
 import numpy as np
 
+from braket.circuits.compiler_directive import CompilerDirective
 from braket.circuits.gate import Gate
 from braket.circuits.instruction import Instruction
 from braket.circuits.qubit_set import QubitSet
@@ -60,11 +61,16 @@ def calculate_unitary(qubit_count: int, instructions: Iterable[Instruction]) -> 
     Raises:
         TypeError: If `instructions` is not composed only of `Gate` instances,
             i.e. a circuit with `Noise` operators will raise this error.
+            Any `CompilerDirective` instructions will be ignored, as these should
+            not affect the unitary representation of the circuit.
     """
     unitary = np.eye(2**qubit_count, dtype=complex)
     un_tensor = np.reshape(unitary, qubit_count * [2, 2])
 
     for instr in instructions:
+        if isinstance(instr.operator, CompilerDirective):
+            continue
+
         if not isinstance(instr.operator, Gate):
             raise TypeError("Only Gate operators are supported to build the unitary")
 
@@ -109,6 +115,8 @@ def calculate_unitary_big_endian(
     Raises:
         TypeError: If `instructions` is not composed only of `Gate` instances,
             i.e. a circuit with `Noise` operators will raise this error.
+            Any `CompilerDirective` instructions will be ignored, as these should
+            not affect the unitary representation of the circuit.
     """
     qubits_sorted = sorted(qubits)
     qubit_count = len(qubits_sorted)
@@ -119,6 +127,8 @@ def calculate_unitary_big_endian(
     unitary = np.eye(rank).reshape([2] * 2 * qubit_count)
 
     for instruction in instructions:
+        if isinstance(instruction.operator, CompilerDirective):
+            continue
         if not isinstance(instruction.operator, Gate):
             raise TypeError("Only Gate operators are supported to build the unitary")
         unitary = multiply_matrix(

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -1296,6 +1296,18 @@ def test_to_unitary_noise_not_apply_returns_expected_unitary(recwarn):
     )
 
 
+def test_to_unitary_with_compiler_directives_returns_expected_unitary():
+    circuit = Circuit().add_verbatim_box(
+        Circuit()
+        .cphaseshift(1, 2, 0.15)
+        .si(3)
+    )
+    assert np.allclose(
+        circuit.to_unitary(),
+        np.kron(gates.CPhaseShift(0.15).to_matrix(), gates.Si().to_matrix()),
+    )
+
+
 @pytest.mark.parametrize(
     "circuit,expected_unitary",
     [

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -1297,11 +1297,7 @@ def test_to_unitary_noise_not_apply_returns_expected_unitary(recwarn):
 
 
 def test_to_unitary_with_compiler_directives_returns_expected_unitary():
-    circuit = Circuit().add_verbatim_box(
-        Circuit()
-        .cphaseshift(1, 2, 0.15)
-        .si(3)
-    )
+    circuit = Circuit().add_verbatim_box(Circuit().cphaseshift(1, 2, 0.15).si(3))
     assert np.allclose(
         circuit.to_unitary(),
         np.kron(gates.CPhaseShift(0.15).to_matrix(), gates.Si().to_matrix()),

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -891,6 +891,14 @@ def test_as_unitary_noise_not_apply_returns_expected_unitary(recwarn):
     )
 
 
+def test_as_unitary_with_compiler_directives_returns_expected_unitary():
+    circuit = Circuit().add_verbatim_box(Circuit().cphaseshift(2, 1, 0.15).si(3))
+    assert np.allclose(
+        circuit.as_unitary(),
+        np.kron(gates.Si().to_matrix(), np.kron(gates.CPhaseShift(0.15).to_matrix(), np.eye(2))),
+    )
+
+
 @pytest.mark.parametrize(
     "circuit,expected_unitary",
     [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ignores `CompilerDirective` instructions when calculating the unitary representation for a circuit. Without this change, it is impossible to get the unitary of a circuit that contains a verbatim box. My understanding is that `CompilerDirective` instructions should never change the unitary representation of a circuit, so these are safe to ignore in this context.

*Testing done:*
Added a unit test to ensure this case works properly.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
