### PR TITLE
infra: speed up unit testing by automatically parallelizing the CPU workers for test runs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,12 @@ test=pytest
 [tool:pytest]
 xfail_strict = true
 addopts =
+    --cov-report term-missing
+    --cov-report html
+    --cov-report xml
+    --cov=braket
     --verbose
+    -n auto
 testpaths = test/unit_tests
 
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "test": [
             "black",
             "botocore",
-            "coverage==5.5",
             "flake8<=5.0.4",
             "isort",
             "jsonschema==3.2.0",

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,7 @@ basepython = python3
 deps =
     {[test-deps]deps}
 commands =
-    coverage run -m pytest {posargs}
-    coverage combine
-    coverage report
-    coverage html
-    coverage xml
+    pytest {posargs}
 extras = test
 
 [testenv:integ-tests]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I got annoyed of waiting for tests to run so I wanted to do something to speed them up.

Performance tested using `time tox -e unit-tests` on main and the new branch.

Before:
```
tox -e unit-tests  94.95s user 12.11s system 62% cpu 2:50.52 total
```

After:
```
tox -e unit-tests  74.72s user 13.27s system 111% cpu 1:19.01 total
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
