### PR TITLE
feat: add optional third angle to MS gate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-schemas>=1.17.0",
-        "amazon-braket-default-simulator>=1.14.0",
+        "amazon-braket-default-simulator>=1.15.0",
         "oqpy~=0.1.1",
         "setuptools",
         "backoff",

--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -401,13 +401,11 @@ def _multi_angled_ascii_characters(
         str: Returns the ascii representation for an angled gate.
 
     """
-    return (
-        f"{gate}("
-        + ", ".join(
-            f'{angle:{".2f" if isinstance(angle, (float, Float)) else ""}}' for angle in angles
-        )
-        + ")"
-    )
+
+    def format_string(angle):
+        return ".2f" if isinstance(angle, (float, Float)) else ""
+
+    return f"{gate}({', '.join(f'{angle:{format_string(angle)}}' for angle in angles)})"
 
 
 def get_angle(gate: AngledGate, **kwargs) -> AngledGate:

--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -232,6 +232,133 @@ class DoubleAngledGate(Gate, Parameterizable):
         )
 
 
+class TripleAngledGate(Gate, Parameterizable):
+    """
+    Class `TripleAngledGate` represents a quantum gate that operates on N qubits and three angles.
+    """
+
+    def __init__(
+        self,
+        angle_1: Union[FreeParameterExpression, float],
+        angle_2: Union[FreeParameterExpression, float],
+        angle_3: Union[FreeParameterExpression, float],
+        qubit_count: Optional[int],
+        ascii_symbols: Sequence[str],
+    ):
+        """
+        Args:
+            angle_1 (Union[FreeParameterExpression, float]): The first angle of the gate in
+                radians or expression representation.
+            angle_2 (Union[FreeParameterExpression, float]): The second angle of the gate in
+                radians or expression representation.
+            angle_3 (Union[FreeParameterExpression, float]): The third angle of the gate in
+                radians or expression representation.
+            qubit_count (Optional[int]): The number of qubits that this gate interacts with.
+            ascii_symbols (Sequence[str]): ASCII string symbols for the gate. These are used when
+                printing a diagram of a circuit. The length must be the same as `qubit_count`, and
+                index ordering is expected to correlate with the target ordering on the instruction.
+                For instance, if a CNOT instruction has the control qubit on the first index and
+                target qubit on the second index, the ASCII symbols should have `["C", "X"]` to
+                correlate a symbol with that index.
+
+        Raises:
+            ValueError: If `qubit_count` is less than 1, `ascii_symbols` are `None`, or
+                `ascii_symbols` length != `qubit_count`, or `angle_1` or `angle_2` or `angle_3`
+                 is `None`
+        """
+        super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
+        if angle_1 is None or angle_2 is None or angle_3 is None:
+            raise ValueError("angles must not be None")
+        self._parameters = [
+            (
+                angle
+                if isinstance(angle, FreeParameterExpression)
+                else float(angle)  # explicit casting in case angle is e.g. np.float32
+            )
+            for angle in (angle_1, angle_2, angle_3)
+        ]
+
+    @property
+    def parameters(self) -> List[Union[FreeParameterExpression, float]]:
+        """
+        Returns the parameters associated with the object, either unbound free parameters or
+        bound values.
+
+        Returns:
+            List[Union[FreeParameterExpression, float]]: The free parameters or fixed value
+            associated with the object.
+        """
+        return self._parameters
+
+    @property
+    def angle_1(self) -> Union[FreeParameterExpression, float]:
+        """
+        Returns the first angle for the gate
+
+        Returns:
+            Union[FreeParameterExpression, float]: The first angle of the gate in radians
+        """
+        return self._parameters[0]
+
+    @property
+    def angle_2(self) -> Union[FreeParameterExpression, float]:
+        """
+        Returns the second angle for the gate
+
+        Returns:
+            Union[FreeParameterExpression, float]: The second angle of the gate in radians
+        """
+        return self._parameters[1]
+
+    @property
+    def angle_3(self) -> Union[FreeParameterExpression, float]:
+        """
+        Returns the second angle for the gate
+
+        Returns:
+            Union[FreeParameterExpression, float]: The third angle of the gate in radians
+        """
+        return self._parameters[2]
+
+    def bind_values(self, **kwargs) -> AngledGate:
+        """
+        Takes in parameters and attempts to assign them to values.
+
+        Args:
+            ``**kwargs``: The parameters that are being assigned.
+
+        Returns:
+            AngledGate: A new Gate of the same type with the requested parameters bound.
+
+        Raises:
+            NotImplementedError: Subclasses should implement this function.
+        """
+        raise NotImplementedError
+
+    def adjoint(self) -> List[Gate]:
+        """Returns the adjoint of this gate as a singleton list.
+
+        Returns:
+            List[Gate]: A list containing the gate with negated angle.
+        """
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, TripleAngledGate)
+            and self.name == other.name
+            and _angles_equal(self.angle_1, other.angle_1)
+            and _angles_equal(self.angle_2, other.angle_2)
+            and _angles_equal(self.angle_3, other.angle_3)
+        )
+
+    def __repr__(self):
+        return (
+            f"{self.name}('angles': ({self.angle_1}, {self.angle_2}, {self.angle_3}), "
+            f"'qubit_count': {self.qubit_count})"
+        )
+
+
 @singledispatch
 def _angles_equal(
     angle_1: Union[FreeParameterExpression, float], angle_2: Union[FreeParameterExpression, float]
@@ -259,18 +386,16 @@ def angled_ascii_characters(gate: str, angle: Union[FreeParameterExpression, flo
     return f'{gate}({angle:{".2f" if isinstance(angle, (float, Float)) else ""}})'
 
 
-def _double_angled_ascii_characters(
+def _multi_angled_ascii_characters(
     gate: str,
-    angle_1: Union[FreeParameterExpression, float],
-    angle_2: Union[FreeParameterExpression, float],
+    *angles: List[Union[FreeParameterExpression, float]],
 ) -> str:
     """
     Generates a formatted ascii representation of an angled gate.
 
     Args:
         gate (str): The name of the gate.
-        angle_1 (Union[FreeParameterExpression, float]): angle in radians.
-        angle_2 (Union[FreeParameterExpression, float]): angle in radians.
+        angles (List[Union[FreeParameterExpression, float]]): angles in radians.
 
     Returns:
         str: Returns the ascii representation for an angled gate.
@@ -278,8 +403,10 @@ def _double_angled_ascii_characters(
     """
     return (
         f"{gate}("
-        f'{angle_1:{".2f" if isinstance(angle_1, (float, Float)) else ""}}, '
-        f'{angle_2:{".2f" if isinstance(angle_2, (float, Float)) else ""}})'
+        + ", ".join(
+            f'{angle:{".2f" if isinstance(angle, (float, Float)) else ""}}, ' for angle in angles
+        )
+        + ")"
     )
 
 
@@ -301,17 +428,17 @@ def get_angle(gate: AngledGate, **kwargs) -> AngledGate:
     return type(gate)(angle=new_angle)
 
 
-def _get_angles(gate: DoubleAngledGate, **kwargs) -> DoubleAngledGate:
+def _get_angles(gate: TripleAngledGate, **kwargs) -> TripleAngledGate:
     """
     Gets the angle with all values substituted in that are requested.
 
     Args:
-        gate (DoubleAngledGate): The subclass of DoubleAngledGate for which the angle is being
+        gate (TripleAngledGate): The subclass of TripleAngledGate for which the angle is being
             obtained.
         ``**kwargs``: The named parameters that are being filled for a particular gate.
 
     Returns:
-        DoubleAngledGate: A new gate of the type of the AngledGate originally used with all angles
+        TripleAngledGate: A new gate of the type of the AngledGate originally used with all angles
         updated.
     """
     new_angles = [
@@ -320,6 +447,6 @@ def _get_angles(gate: DoubleAngledGate, **kwargs) -> DoubleAngledGate:
             if isinstance(getattr(gate, angle), FreeParameterExpression)
             else getattr(gate, angle)
         )
-        for angle in ("angle_1", "angle_2")
+        for angle in ("angle_1", "angle_2", "angle_3")
     ]
-    return type(gate)(angle_1=new_angles[0], angle_2=new_angles[1])
+    return type(gate)(angle_1=new_angles[0], angle_2=new_angles[1], angle_3=new_angles[2])

--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -404,7 +404,7 @@ def _multi_angled_ascii_characters(
     return (
         f"{gate}("
         + ", ".join(
-            f'{angle:{".2f" if isinstance(angle, (float, Float)) else ""}}, ' for angle in angles
+            f'{angle:{".2f" if isinstance(angle, (float, Float)) else ""}}' for angle in angles
         )
         + ")"
     )

--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -388,14 +388,14 @@ def angled_ascii_characters(gate: str, angle: Union[FreeParameterExpression, flo
 
 def _multi_angled_ascii_characters(
     gate: str,
-    *angles: List[Union[FreeParameterExpression, float]],
+    *angles: Union[FreeParameterExpression, float],
 ) -> str:
     """
     Generates a formatted ascii representation of an angled gate.
 
     Args:
         gate (str): The name of the gate.
-        angles (List[Union[FreeParameterExpression, float]]): angles in radians.
+        angles (Union[FreeParameterExpression, float]): angles in radians.
 
     Returns:
         str: Returns the ascii representation for an angled gate.

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -2638,15 +2638,35 @@ class MS(TripleAngledGate):
     def to_matrix(self) -> np.ndarray:
         return np.array(
             [
-                [1, 0, 0, -1j * np.exp(-1j * (self.angle_1 + self.angle_2))],
-                [0, 1, -1j * np.exp(-1j * (self.angle_1 - self.angle_2)), 0],
-                [0, -1j * np.exp(1j * (self.angle_1 - self.angle_2)), 1, 0],
-                [-1j * np.exp(1j * (self.angle_1 + self.angle_2)), 0, 0, 1],
+                [
+                    np.cos(self.angle_3 / 2),
+                    0,
+                    0,
+                    -1j * np.exp(-1j * (self.angle_1 + self.angle_2)) * np.sin(self.angle_3 / 2),
+                ],
+                [
+                    0,
+                    np.cos(self.angle_3 / 2),
+                    -1j * np.exp(-1j * (self.angle_1 - self.angle_2)) * np.sin(self.angle_3 / 2),
+                    0,
+                ],
+                [
+                    0,
+                    -1j * np.exp(1j * (self.angle_1 - self.angle_2)) * np.sin(self.angle_3 / 2),
+                    np.cos(self.angle_3 / 2),
+                    0,
+                ],
+                [
+                    -1j * np.exp(1j * (self.angle_1 + self.angle_2)) * np.sin(self.angle_3 / 2),
+                    0,
+                    0,
+                    np.cos(self.angle_3 / 2),
+                ],
             ]
-        ) / np.sqrt(2)
+        )
 
     def adjoint(self) -> List[Gate]:
-        return [MS(self.angle_1 + np.pi, self.angle_2)]
+        return [MS(self.angle_1 + np.pi, self.angle_2, self.angle_3)]
 
     @staticmethod
     def fixed_qubit_count() -> int:

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -23,9 +23,9 @@ import braket.ir.jaqcd as ir
 from braket.circuits import circuit
 from braket.circuits.angled_gate import (
     AngledGate,
-    DoubleAngledGate,
-    _double_angled_ascii_characters,
+    TripleAngledGate,
     _get_angles,
+    _multi_angled_ascii_characters,
     angled_ascii_characters,
     get_angle,
 )
@@ -2608,24 +2608,27 @@ class GPi2(AngledGate):
 Gate.register_gate(GPi2)
 
 
-class MS(DoubleAngledGate):
+class MS(TripleAngledGate):
     """IonQ Mølmer-Sørenson gate.
 
     Args:
         angle_1 (Union[FreeParameterExpression, float]): angle in radians.
         angle_2 (Union[FreeParameterExpression, float]): angle in radians.
+        angle_3 (Union[FreeParameterExpression, float]): angle in radians.
     """
 
     def __init__(
         self,
         angle_1: Union[FreeParameterExpression, float],
         angle_2: Union[FreeParameterExpression, float],
+        angle_3: Union[FreeParameterExpression, float] = np.pi / 2,
     ):
         super().__init__(
             angle_1=angle_1,
             angle_2=angle_2,
+            angle_3=angle_3,
             qubit_count=None,
-            ascii_symbols=[_double_angled_ascii_characters("MS", angle_1, angle_2)] * 2,
+            ascii_symbols=[_multi_angled_ascii_characters("MS", angle_1, angle_2, angle_3)] * 2,
         )
 
     @property
@@ -2659,6 +2662,7 @@ class MS(DoubleAngledGate):
         target2: QubitInput,
         angle_1: Union[FreeParameterExpression, float],
         angle_2: Union[FreeParameterExpression, float],
+        angle_3: Union[FreeParameterExpression, float] = np.pi / 2,
         *,
         control: Optional[QubitSetInput] = None,
         control_state: Optional[BasisStateInput] = None,
@@ -2671,6 +2675,7 @@ class MS(DoubleAngledGate):
             target2 (QubitInput): Target qubit 2 index.
             angle_1 (Union[FreeParameterExpression, float]): angle in radians.
             angle_2 (Union[FreeParameterExpression, float]): angle in radians.
+            angle_3 (Union[FreeParameterExpression, float]): angle in radians.
             control (Optional[QubitSetInput]): Control qubit(s). Default None.
             control_state (Optional[BasisStateInput]): Quantum state on which to control the
                 operation. Must be a binary sequence of same length as number of qubits in
@@ -2690,7 +2695,7 @@ class MS(DoubleAngledGate):
         """
         return [
             Instruction(
-                MS(angle_1, angle_2),
+                MS(angle_1, angle_2, angle_3),
                 target=[target1, target2],
                 control=control,
                 control_state=control_state,

--- a/test/unit_tests/braket/circuits/test_angled_gate.py
+++ b/test/unit_tests/braket/circuits/test_angled_gate.py
@@ -18,7 +18,7 @@ import pytest
 from pydantic import BaseModel
 
 from braket.circuits import AngledGate, FreeParameter, FreeParameterExpression, Gate
-from braket.circuits.angled_gate import DoubleAngledGate
+from braket.circuits.angled_gate import DoubleAngledGate, TripleAngledGate
 
 
 @pytest.fixture
@@ -140,6 +140,11 @@ def test_double_angle_is_none():
         DoubleAngledGate(qubit_count=1, ascii_symbols=["foo"], angle_1=None, angle_2=1)
 
 
+def test_triple_angle_is_none():
+    with pytest.raises(ValueError, match="angles must not be None"):
+        TripleAngledGate(qubit_count=1, ascii_symbols=["foo"], angle_1=None, angle_2=1, angle_3=2)
+
+
 def test_double_angle_equality():
     gate = DoubleAngledGate(angle_1=0.15, angle_2=3, qubit_count=1, ascii_symbols=["bar"])
     equal_gate = DoubleAngledGate(angle_1=0.15, angle_2=3, qubit_count=1, ascii_symbols=["bar"])
@@ -172,3 +177,18 @@ def test_double_angle_repr():
         repr(DoubleAngledGate(qubit_count=1, ascii_symbols=["foo"], angle_1=1, angle_2=2))
         == "DoubleAngledGate('angles': (1.0, 2.0), 'qubit_count': 1)"
     )
+
+
+def test_triple_angle_repr():
+    assert (
+        repr(
+            TripleAngledGate(qubit_count=1, ascii_symbols=["foo"], angle_1=1, angle_2=2, angle_3=3)
+        )
+        == "TripleAngledGate('angles': (1.0, 2.0, 3.0), 'qubit_count': 1)"
+    )
+
+
+def test_double_angle_parameters():
+    assert DoubleAngledGate(
+        qubit_count=1, ascii_symbols=["foo"], angle_1=1, angle_2=2
+    ).parameters == [1, 2]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add optional third angle to IonQ native MS gate.

On the service, fails due to lack of support for third angle: `botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the CreateQuantumTask operation: [line 4] invalid number of argument(s). Expected: 2, Got: 3`

*Testing done:*

Unit testing and manual testing (fails today, will repeat before merging)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
