### PR TITLE
feat: Add dot(), power(), and to_circuit() to PauliString

### DIFF
--- a/src/braket/quantum_information/pauli_string.py
+++ b/src/braket/quantum_information/pauli_string.py
@@ -197,6 +197,25 @@ class PauliString:
             self._nontrivial = out_pauli_string._nontrivial
         return out_pauli_string
 
+    def __mul__(self, other: PauliString) -> PauliString:
+        """Right multiplication operator overload using `dot()`.
+
+        Returns the result of multiplying the current circuit by the argument on its right.
+
+        Args:
+            other (PauliString): The right multiplicand.
+
+        Returns:
+            PauliString: The resultant circuit from right multiplying `self` with `other`.
+
+        Raises:
+            ValueError: If the lengths of the Pauli Strings being multiplied differ.
+
+        See Also:
+            `braket.quantum_information.PauliString.dot()`
+        """
+        return self.dot(other)
+
     def power(self, n: int, inplace: bool = False) -> PauliString:
         """Composes circuit with itself n times.
 
@@ -222,6 +241,25 @@ class PauliString:
             self._qubit_count = pauli_other._qubit_count
             self._nontrivial = pauli_other._nontrivial
         return pauli_other
+
+    def __pow__(self, n: int) -> PauliString:
+        """Pow operator overload for circuit composition.
+
+        Syntactic sugar for `power()`.
+
+        Args:
+            n (int): The number of times to self-multiply. Must be greater than 0.
+
+        Returns:
+            PauliString: The circuit from right multiplying `self` with itself `n` times.
+
+        Raises:
+            ValueError: If `n <= 0`.
+
+        See Also:
+            `braket.quantum_information.PauliString.power()`
+        """
+        return self.power(n)
 
     def to_circuit(self) -> Circuit:
         """Returns circuit represented by this `PauliString`.

--- a/src/braket/quantum_information/pauli_string.py
+++ b/src/braket/quantum_information/pauli_string.py
@@ -321,7 +321,7 @@ class PauliString:
                 circ = circ.x(qubit)
             elif self._nontrivial[qubit] == "Y":
                 circ = circ.y(qubit)
-            elif self._nontrivial[qubit] == "Z":
+            else:
                 circ = circ.z(qubit)
         return circ
 

--- a/src/braket/quantum_information/pauli_string.py
+++ b/src/braket/quantum_information/pauli_string.py
@@ -253,13 +253,11 @@ class PauliString:
         if not isinstance(n, int):
             raise ValueError("Must be raised to integer power")
 
+        # Since pauli ops involutory, result is either identity or unchanged
         pauli_other = PauliString(self)
-        if n == 0:
+        if n % 2 == 0:
             pauli_other._phase = 1
             pauli_other._nontrivial = {}
-        else:
-            for _ in range(n - 1):
-                pauli_other.dot(self, inplace=True)
 
         if inplace:
             self._phase = pauli_other._phase
@@ -268,7 +266,7 @@ class PauliString:
         return pauli_other
 
     def __pow__(self, n: int) -> PauliString:
-        """Pow operator overload for circuit composition.
+        """Pow operator overload for Pauli string composition.
 
         Syntactic sugar for `power()`.
 

--- a/test/unit_tests/braket/quantum_information/test_pauli_string.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from braket.circuits import gates
+from braket.circuits.circuit import Circuit
 from braket.circuits.observables import X, Y, Z
 from braket.quantum_information import PauliString
 
@@ -140,6 +141,9 @@ def test_eigenstate_invalid_signs(sign):
 @pytest.mark.parametrize(
     "circ_arg_1, circ_arg_2, circ_res",
     [
+        ("III", "+III", "III"),
+        ("Z", "I", "Z"),
+        ("I", "-Y", "-Y"),
         ("XYXZY", "+XYXZY", "IIIII"),
         ("XYZ", "ZYX", "YIY"),
         ("YZ", "ZX", "-XY"),
@@ -166,14 +170,40 @@ def test_dot(circ_arg_1, circ_arg_2, circ_res):
     assert circ1 == PauliString(circ_res)
 
 
+@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.parametrize(
+    "circ1, circ2, operation",
+    [
+        (PauliString("III"), PauliString("II"), "dot()"),
+        (PauliString("III"), PauliString("II"), "*"),
+        (PauliString("III"), PauliString("II"), "*="),
+        (PauliString("IXI"), PauliString("II"), "dot()"),
+        (PauliString("IXI"), PauliString("II"), "*"),
+        (PauliString("IXI"), PauliString("II"), "*="),
+    ],
+)
+def test_dot_unequal_lengths(circ1, circ2, operation):
+    if operation == "dot()":
+        circ1.dot(circ2)
+    elif operation == "*":
+        circ1 * circ2
+    elif operation == "*=":
+        circ1 *= circ2
+
+
 @pytest.mark.parametrize(
     "circ, n, circ_res",
     [
         ("-X", 1, "-X"),
         ("Y", 2, "I"),
+        ("Y", -2, "I"),
         ("-X", 3, "-X"),
         ("XYZ", 5, "XYZ"),
+        ("XYZ", -5, "XYZ"),
+        ("XYZ", 6, "III"),
         ("XYZ", 1, "XYZ"),
+        ("-YX", 0, "II"),
+        ("Y", 0, "I"),
     ],
 )
 def test_power(circ, n, circ_res):
@@ -191,3 +221,40 @@ def test_power(circ, n, circ_res):
     assert (circ1**n) == PauliString(circ_res)
     circ1 **= n
     assert circ1 == PauliString(circ_res)
+
+
+@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.parametrize(
+    "circ, n, operation",
+    [
+        (PauliString("XYZ"), "-1.2", "power()"),
+        (PauliString("XYZ"), "-1.2", "**"),
+        (PauliString("XYZ"), "-1.2", "**="),
+        (PauliString("ZYX"), "1.2", "power()"),
+        (PauliString("ZYX"), "1.2", "**"),
+        (PauliString("ZYX"), "1.2", "**="),
+        (PauliString("I"), "3j", "power()"),
+        (PauliString("I"), "3j", "**"),
+        (PauliString("I"), "3j", "**="),
+    ],
+)
+def test_power_invalid_exp(circ, n, operation):
+    if operation == "power()":
+        circ.power(n)
+    elif operation == "**":
+        circ**n
+    elif operation == "**=":
+        circ **= n
+
+
+@pytest.mark.parametrize(
+    "circ, circ_res",
+    [
+        (PauliString("I"), Circuit().i(0)),
+        (PauliString("-X"), Circuit().x(0)),
+        (PauliString("IYX"), Circuit().i(0).y(1).x(2)),
+        (PauliString("ZIIIX"), Circuit().z(0).i(1).i(2).i(3).x(4)),
+    ],
+)
+def test_to_circuit(circ, circ_res):
+    assert circ.to_circuit() == circ_res

--- a/test/unit_tests/braket/quantum_information/test_pauli_string.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string.py
@@ -138,7 +138,7 @@ def test_eigenstate_invalid_signs(sign):
 
 
 @pytest.mark.parametrize(
-    "circ1, circ2, circ_res",
+    "circ_arg_1, circ_arg_2, circ_res",
     [
         ("XYXZY", "+XYXZY", "IIIII"),
         ("XYZ", "ZYX", "YIY"),
@@ -147,13 +147,22 @@ def test_eigenstate_invalid_signs(sign):
         ("Z", "Y", "-X"),
     ],
 )
-def test_dot(circ1, circ2, circ_res):
-    # Test operator overload
-    assert PauliString(circ1) * PauliString(circ2) == PauliString(circ_res)
+def test_dot(circ_arg_1, circ_arg_2, circ_res):
+    circ1 = PauliString(circ_arg_1)
+    circ2 = circ1.dot(PauliString(circ_arg_2))
+    assert circ2 == PauliString(circ_res)
+    assert circ1 == circ1
 
     # Test in-place computation
-    circ1 = PauliString(circ1)
-    circ1.dot(PauliString(circ2), inplace=True)
+    circ1 = PauliString(circ_arg_1)
+    circ1.dot(PauliString(circ_arg_2), inplace=True)
+    assert circ1 == PauliString(circ_res)
+
+    # Test operator overloads
+    circ1 = PauliString(circ_arg_1)
+    circ2 = PauliString(circ_arg_2)
+    assert circ1 * circ2 == PauliString(circ_res)
+    circ1 *= circ2
     assert circ1 == PauliString(circ_res)
 
 
@@ -168,10 +177,17 @@ def test_dot(circ1, circ2, circ_res):
     ],
 )
 def test_power(circ, n, circ_res):
-    # Test operator overload
-    assert (PauliString(circ) ** n) == PauliString(circ_res)
+    circ1 = PauliString(circ)
+    circ2 = circ1.power(n)
+    assert circ2 == PauliString(circ_res)
+    assert circ1 == PauliString(circ)
 
     # Test in-place computation
-    circ = PauliString(circ)
-    circ.power(n, inplace=True)
-    assert circ == PauliString(circ_res)
+    circ1.power(n, inplace=True)
+    assert circ1 == PauliString(circ_res)
+
+    # Test operator overloads
+    circ1 = PauliString(circ)
+    assert (circ1**n) == PauliString(circ_res)
+    circ1 **= n
+    assert circ1 == PauliString(circ_res)

--- a/test/unit_tests/braket/quantum_information/test_pauli_string.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string.py
@@ -135,3 +135,35 @@ def test_eigenstate(string, signs):
 @pytest.mark.parametrize("sign", ["+ab", "--+-", [+2, -1, -1], (-1, 1j, 1)])
 def test_eigenstate_invalid_signs(sign):
     PauliString("XYZ").eigenstate(sign)
+
+
+@pytest.mark.parametrize(
+    "circ1, circ2, circ_res",
+    [
+        ("XYXZY", "+XYXZY", "IIIII"),
+        ("XYZ", "ZYX", "YIY"),
+        ("YZ", "ZX", "-XY"),
+        ("-Z", "Y", "X"),
+        ("Z", "Y", "-X"),
+    ],
+)
+def test_dot(circ1, circ2, circ_res):
+    circ1 = PauliString(circ1)
+    circ1.dot(PauliString(circ2), inplace=True)
+    assert circ1 == PauliString(circ_res)
+
+
+@pytest.mark.parametrize(
+    "circ, n, circ_res",
+    [
+        ("-X", 1, "-X"),
+        ("Y", 2, "I"),
+        ("-X", 3, "-X"),
+        ("XYZ", 5, "XYZ"),
+        ("XYZ", 1, "XYZ"),
+    ],
+)
+def test_power(circ, n, circ_res):
+    circ = PauliString(circ)
+    circ.power(n, inplace=True)
+    assert circ == PauliString(circ_res)

--- a/test/unit_tests/braket/quantum_information/test_pauli_string.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string.py
@@ -148,6 +148,10 @@ def test_eigenstate_invalid_signs(sign):
     ],
 )
 def test_dot(circ1, circ2, circ_res):
+    # Test operator overload
+    assert PauliString(circ1) * PauliString(circ2) == PauliString(circ_res)
+
+    # Test in-place computation
     circ1 = PauliString(circ1)
     circ1.dot(PauliString(circ2), inplace=True)
     assert circ1 == PauliString(circ_res)
@@ -164,6 +168,10 @@ def test_dot(circ1, circ2, circ_res):
     ],
 )
 def test_power(circ, n, circ_res):
+    # Test operator overload
+    assert (PauliString(circ) ** n) == PauliString(circ_res)
+
+    # Test in-place computation
     circ = PauliString(circ)
     circ.power(n, inplace=True)
     assert circ == PauliString(circ_res)


### PR DESCRIPTION
## What?
* Implements half of #553 
* I was confused why the phase is only allowed to be positive or negative one, so I just assumed the convention of dropping the global phase whilst maintaining sign (e.g. `-iX` being treated as `-X`)

## Further Development
* Doesn't include a test case for `to_circuit()`