### PR TITLE
fix: pulse plotting with barriers that have no argument

### DIFF
--- a/src/braket/pulse/ast/approximation_parser.py
+++ b/src/braket/pulse/ast/approximation_parser.py
@@ -155,6 +155,9 @@ class _ApproximationParser(QASMVisitor[_ParseState]):
             context (_ParseState): The parse state context.
         """
         frames = self._get_frame_parameters(node.qubits, context)
+        if len(frames) == 0:
+            # barrier without arguments is applied to all the frames of the context
+            frames = list(context.frame_data.keys())
         dts = [context.frame_data[frame_id].dt for frame_id in frames]
         max_time = max([context.frame_data[frame_id].current_time for frame_id in frames])
         # All frames are delayed till the first multiple of the LCM([port.dts])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `barrier`s in `PulseSequence`s act on all frames with they are used without arguments. When plotting, if the visitor passes by a barrier with no argument, we replace an empty list of frames by the list of all frames used in the `PulseSequence`.
- the tolerance used in pulse plotting tests was 1e-7 while some of the pulses were only few 1e-9 long. The tests were consequently not tight enough. We increase the tolerance to 1e-10.

*Testing done:*
Update unit tests.

## Merge Checklist


#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
