### PR TITLE
fix: mixed free parameters and floats

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -460,9 +460,10 @@ class Circuit:
 
         if self._check_for_params(instruction):
             for param in instruction.operator.parameters:
-                free_params = param.expression.free_symbols
-                for parameter in free_params:
-                    self._parameters.add(FreeParameter(parameter.name))
+                if isinstance(param, FreeParameterExpression):
+                    free_params = param.expression.free_symbols
+                    for parameter in free_params:
+                        self._parameters.add(FreeParameter(parameter.name))
         self._moments.add(instructions_to_add)
 
         return self

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -2445,3 +2445,7 @@ def test_parametrized_pulse_circuit(user_defined_frame):
             "b[1] = measure $1;",
         ]
     )
+
+
+def test_free_param_float_mix():
+    Circuit().ms(0, 1, 0.1, FreeParameter("theta"))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Gates with some floats and some free parameters now supported

Bug:

Code would check if there were *any* free parameters in the instruction and then treat *all* values as free parameters, which would break for floats

*Testing done:*

Unit and manual

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
