### PR TITLE
change: Increase types module coverage to 100% and fix related bugs

### DIFF
--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -40,9 +40,7 @@ The Python code above outputs the following OpenQASM program:
     result[1] = measure __qubits__[1];
 """
 
-from oqpy import BitVar  # noqa: F401
-from oqpy import FloatVar  # noqa: F401
-from oqpy import IntVar  # noqa: F401
+from oqpy import ArrayVar, BitVar, BoolVar, FloatVar, IntVar  # noqa: F401
 
 from . import api, constants, gates, operators, types  # noqa: F401
 from .api import function  # noqa: F401

--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -14,6 +14,7 @@
 
 """Operators for assignment statements."""
 
+import copy
 from typing import Any
 
 import oqpy
@@ -62,7 +63,9 @@ def assign_stmt(target_name: str, value: Any) -> Any:
                 # Set to `value.init_expression` to avoid declaring an unnecessary variable.
                 oqpy_program.set(target, value.init_expression)
         else:
-            target = type(value)(name=target_name, size=value.size)
+            target = copy.copy(value)
+            target.init_expression = None
+            target.name = target_name
 
             if is_value_used:
                 oqpy_program.declare(target)

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -19,7 +19,7 @@ import oqpy.base
 
 
 def is_qasm_type(val: Any) -> bool:
-    """Returns whether the provided object is of a QASM type
+    """Returns whether the provided object is of a QASM type or is itself a QASM type
     which receives special treatment by AutoQASM.
 
     Args:
@@ -28,10 +28,14 @@ def is_qasm_type(val: Any) -> bool:
     Returns:
         bool: Whether the object is a QASM type.
     """
-    return isinstance(
-        val,
-        (oqpy.Range, oqpy._ClassicalVar, oqpy.base.OQPyExpression),
-    )
+    try:
+        if issubclass(val, (oqpy.Range, oqpy._ClassicalVar, oqpy.base.OQPyExpression)):
+            return True
+    except TypeError:
+        # `val` is not a class
+        pass
+
+    return isinstance(val, (oqpy.Range, oqpy._ClassicalVar, oqpy.base.OQPyExpression))
 
 
 def qasm_range(start: int, stop: Optional[int] = None, step: Optional[int] = 1) -> oqpy.Range:

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -13,11 +13,12 @@
 
 """Tests for the types module."""
 
-from typing import Tuple
+from typing import List, Tuple
 
 import oqpy
 import pytest
 
+import braket.experimental.autoqasm as aq
 from braket.experimental.autoqasm.types.types import qasm_range
 
 
@@ -41,3 +42,278 @@ def test_qasm_range(
     qrange = qasm_range(start, stop, step)
     assert isinstance(qrange, oqpy.Range)
     assert (qrange.start, qrange.stop, qrange.step) == expected_range_params
+
+
+def test_return_bit():
+    """Test type discovery of bit return values."""
+
+    @aq.function
+    def ret_test() -> aq.BitVar:
+        # TODO: These should work even in one line
+        res = aq.BitVar(1)
+        return res
+
+    @aq.function
+    def main() -> aq.BitVar:
+        return ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> bit {
+    bit res = 1;
+    return res;
+}
+bit __bit_0__;
+__bit_0__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
+def test_return_int():
+    """Test type discovery of int return values."""
+
+    @aq.function
+    def ret_test() -> int:
+        res = aq.IntVar(1)
+        return res
+
+    @aq.function
+    def main() -> int:
+        return ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> int[32] {
+    int[32] res = 1;
+    return res;
+}
+int[32] __int_0__ = 0;
+__int_0__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
+def test_return_float():
+    """Test type discovery of float return values."""
+
+    @aq.function
+    def ret_test() -> float:
+        res = aq.FloatVar(1.0)
+        return res
+
+    @aq.function
+    def main() -> float:
+        return ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> float[64] {
+    float[64] res = 1.0;
+    return res;
+}
+float[64] __float_0__ = 0.0;
+__float_0__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
+def test_return_bool():
+    """Test type discovery of boolean return values."""
+
+    @aq.function
+    def ret_test() -> bool:
+        res = aq.BoolVar(True)
+        return res
+
+    @aq.function
+    def main() -> bool:
+        return ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> bool {
+    bool res = true;
+    return res;
+}
+bool __bool_0__ = false;
+__bool_0__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
+def test_return_bin_expr():
+    """Test type discovery of int return values from an expression."""
+
+    @aq.function
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    @aq.function
+    def ret_test() -> int:
+        a = aq.IntVar(5)
+        b = aq.IntVar(6)
+        return add(a, b)
+
+    expected = """OPENQASM 3.0;
+def add(int[32] a, int[32] b) -> int[32] {
+    return a + b;
+}
+int[32] __int_0__ = 0;
+int[32] a = 5;
+int[32] b = 6;
+__int_0__ = add(a, b);"""
+
+    assert ret_test().to_ir() == expected
+
+
+def test_return_none():
+    """Test discovery of None return annotation."""
+
+    @aq.function
+    def ret_test() -> None:
+        return None
+
+    ret_test().to_ir()
+
+
+def test_return_array():
+    """Test return type discovery of array values."""
+
+    @aq.function
+    def ret_test() -> List[int]:
+        res = aq.ArrayVar([1, 2, 3], dimensions=[3])
+        return res
+
+    @aq.function
+    def main() -> List[int]:
+        return ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> array[int[32], 3] {
+    array[int[32], 3] res = {1, 2, 3};
+    return res;
+}
+array[int[32], 3] __arr_0__ = {};
+__arr_0__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
+def test_return_func_call():
+    """Test returning the result of another function call."""
+
+    @aq.function
+    def helper() -> int:
+        res = aq.IntVar(1)
+        return res
+
+    @aq.function
+    def ret_test() -> int:
+        return helper()
+
+    expected = """OPENQASM 3.0;
+def helper() -> int[32] {
+    int[32] res = 1;
+    return res;
+}
+int[32] __int_0__ = 0;
+__int_0__ = helper();"""
+
+    assert ret_test().to_ir() == expected
+
+
+def test_map_bool():
+    """Test boolean input parameter type."""
+
+    @aq.function
+    def annotation_test(input: bool):
+        pass
+
+    @aq.function
+    def main():
+        annotation_test(True)
+
+    expected = """OPENQASM 3.0;
+def annotation_test(bool input) {
+}
+annotation_test(true);"""
+
+    assert main().to_ir() == expected
+
+
+def test_map_int():
+    """Test integer input parameter type."""
+
+    @aq.function
+    def annotation_test(input: int):
+        pass
+
+    @aq.function
+    def main():
+        annotation_test(1)
+
+    expected = """OPENQASM 3.0;
+def annotation_test(int[32] input) {
+}
+annotation_test(1);"""
+
+    assert main().to_ir() == expected
+
+
+def test_map_float():
+    """Test float input parameter type."""
+
+    @aq.function
+    def annotation_test(input: float):
+        pass
+
+    @aq.function
+    def main():
+        annotation_test(1.0)
+
+    expected = """OPENQASM 3.0;
+def annotation_test(float[64] input) {
+}
+annotation_test(1.0);"""
+
+    assert main().to_ir() == expected
+
+
+def test_map_array():
+    """Test array input parameter type."""
+
+    @aq.function
+    def annotation_test(input: List[int]):
+        pass
+
+    @aq.function
+    def main():
+        a = aq.ArrayVar([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dimensions=[10])
+        annotation_test(a)
+
+    expected = """OPENQASM 3.0;
+def annotation_test(array[int[32], 10] input) {
+}
+array[int[32], 10] a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+annotation_test(a);"""
+
+    assert main().to_ir() == expected
+
+
+def test_map_other():
+    """Test unexpected input parameter type handling."""
+
+    # TODO: Should be able to pass aq.Bit directly to annotation_test
+
+    @aq.function
+    def annotation_test(input: aq.BitVar):
+        pass
+
+    @aq.function
+    def main():
+        a = aq.BitVar(1)
+        annotation_test(a)
+
+    expected = """OPENQASM 3.0;
+def annotation_test(bit input) {
+}
+bit a = 1;
+annotation_test(a);"""
+
+    assert main().to_ir() == expected


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase code coverage to 100% for types modules of AutoQASM

 - Remove unused code
 - Add lots of tests: various parameter type annotations and various return type annotations
where various means: bit, bool, int, float, array, program.Program and some other random input to check implicit handling
 - Discovered some bugs:
    - bugfix for returned values that are never instantiated
    - bugfix for return variables initialized with length 0 instead of matching subroutine call return size
    - opened issue for bug: return constant value yields no instructions or incomplete instructions
    - opened issue for bug: passing arguments directly to function call doesn't give the generated variable a name
    - opened issue for bug: Array lengths are hardcoded in subroutine parameter types

*Testing done:*

New unit tests!

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
