### PR TITLE
fix: support multiprocessing for autoqasm program generation

### DIFF
--- a/src/braket/experimental/autoqasm/gates/__init__.py
+++ b/src/braket/experimental/autoqasm/gates/__init__.py
@@ -13,5 +13,5 @@
 
 """Quantum operations for use in AutoQASM programs."""
 
-from .gates import QubitIdentifier, cnot, h, x  # noqa: F401
+from .gates import QubitIdentifier, cnot, h, rx, x  # noqa: F401
 from .measurements import measure  # noqa: F401

--- a/src/braket/experimental/autoqasm/gates/gates.py
+++ b/src/braket/experimental/autoqasm/gates/gates.py
@@ -51,6 +51,16 @@ def x(q: QubitIdentifier) -> None:
     oqpy_program.gate(_qubit(q), "x")
 
 
+def rx(q: QubitIdentifier, angle: float) -> None:
+    """Adds a rotation around the X axis by `angle` on the specified qubit.
+    Args:
+        q (QubitIdentifier): The target qubit.
+        angle (float): Angle in radians.
+    """
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
+    oqpy_program.gate(_qubit(q), "rx", angle)
+
+
 def cnot(q_ctrl: QubitIdentifier, q_target: QubitIdentifier) -> None:
     """Adds a CNOT gate to the program on the specified qubits.
 

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -23,9 +23,18 @@ import oqpy.base
 from braket.circuits.serialization import IRType
 from braket.experimental.autoqasm import constants
 
-# Prepare to initialize the global program conversion context.
+# Create the thread-local object for the program conversion context.
 _local = threading.local()
-setattr(_local, "program_conversion_context", None)
+
+
+def _get_local() -> threading.local:
+    """Gets the thread-local object which stores the program conversion context.
+    Returns:
+        local: The thread-local object which stores the program conversion context.
+    """
+    if not hasattr(_local, "program_conversion_context"):
+        setattr(_local, "program_conversion_context", None)
+    return _local
 
 
 class ProgramOptions(enum.Enum):
@@ -188,14 +197,14 @@ class ProgramContextManager:
         self.user_config = user_config
 
     def __enter__(self) -> ProgramConversionContext:
-        if not _local.program_conversion_context:
-            _local.program_conversion_context = ProgramConversionContext(self.user_config)
+        if not _get_local().program_conversion_context:
+            _get_local().program_conversion_context = ProgramConversionContext(self.user_config)
             self.owns_program_conversion_context = True
-        return _local.program_conversion_context
+        return _get_local().program_conversion_context
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         if self.owns_program_conversion_context:
-            _local.program_conversion_context = None
+            _get_local().program_conversion_context = None
 
 
 def build_program(user_config: Optional[UserConfig] = None) -> ProgramContextManager:
@@ -228,7 +237,7 @@ def in_active_program_conversion_context() -> bool:
     Returns:
         bool: Whether there is a program currently being built.
     """
-    return _local.program_conversion_context is not None
+    return _get_local().program_conversion_context is not None
 
 
 def get_program_conversion_context() -> ProgramConversionContext:
@@ -241,6 +250,6 @@ def get_program_conversion_context() -> ProgramConversionContext:
         ProgramConversionContext: The thread-local ProgramConversionContext object.
     """
     assert (
-        _local.program_conversion_context is not None
+        _get_local().program_conversion_context is not None
     ), "get_program_conversion_context() must be called inside build_program() block"
-    return _local.program_conversion_context
+    return _get_local().program_conversion_context

--- a/test/unit_tests/braket/experimental/autoqasm/test_aq_gates.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_aq_gates.py
@@ -13,8 +13,10 @@
 
 """Tests for the gates module."""
 
+import pytest
+
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm.gates import cnot, h, measure
+from braket.experimental.autoqasm.gates import cnot, h, measure, rx, x
 
 
 def test_bell_state_prep(bell_state_program) -> None:
@@ -50,3 +52,20 @@ __bit_0__ = measure __qubits__[0];"""
 
     qasm = program_conversion_context.make_program().to_ir()
     assert qasm == expected.strip()
+
+
+@pytest.mark.parametrize(
+    "gate,qubits,params,expected_qasm",
+    [
+        (h, [0], [], "\nh __qubits__[0];"),
+        (x, [0], [], "\nx __qubits__[0];"),
+        (rx, [0], [0.1], "\nrx(0.1) __qubits__[0];"),
+        (cnot, [0, 1], [], "\ncnot __qubits__[0], __qubits__[1];"),
+    ],
+)
+def test_gates(gate, qubits, params, expected_qasm) -> None:
+    """Tests quantum gates."""
+    with aq.build_program() as program_conversion_context:
+        gate(*qubits, *params)
+
+    assert expected_qasm in program_conversion_context.make_program().to_ir()

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -21,7 +21,7 @@ import pytest
 
 import braket.experimental.autoqasm as aq
 from braket.circuits.serialization import IRType
-from braket.experimental.autoqasm.gates import cnot, h, measure
+from braket.experimental.autoqasm.gates import cnot, measure, rx
 
 
 def test_program_conversion_context() -> None:
@@ -71,8 +71,7 @@ def test_multiprocessing() -> None:
 
     @aq.function
     def circuit(angle: float):
-        # TODO: rx(0, angle)
-        h(0)
+        rx(0, angle)
         cnot(0, 1)
 
     @aq.function
@@ -93,7 +92,7 @@ def test_multiprocessing() -> None:
         return (
             """OPENQASM 3.0;
 def circuit(float[64] angle) {
-    h __qubits__[0];
+    rx(angle) __qubits__[0];
     cnot __qubits__[0], __qubits__[1];
 }
 qubit[2] __qubits__;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=32620276

*Description of changes:*
Fixes management of thread-local program conversion context so that it works correctly with ThreadPool threads.

*Testing done:*
Test added for multiprocessing with ThreadPool using an aq.function call.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
