### PR TITLE
Change: update how num_qubits get supplied by autoqasm functions

### DIFF
--- a/src/braket/experimental/autoqasm/README.md
+++ b/src/braket/experimental/autoqasm/README.md
@@ -59,7 +59,7 @@ AutoQASM enables users to use more complicated program constructs with a compact
 structure. We can demonstrate this with an active reset program:
 ```
 # A program that actively resets a qubit back to the ground state
-@aq.function(num_qubits=1)
+@aq.function
 def reset(qubit: int, num_repeats: int) -> None:
     for repeats in aq.range(num_repeats):
         if measure(qubit):

--- a/src/braket/experimental/autoqasm/README.md
+++ b/src/braket/experimental/autoqasm/README.md
@@ -59,7 +59,7 @@ AutoQASM enables users to use more complicated program constructs with a compact
 structure. We can demonstrate this with an active reset program:
 ```
 # A program that actively resets a qubit back to the ground state
-@aq.function
+@aq.function(num_qubits=1)
 def reset(qubit: int, num_repeats: int) -> None:
     for repeats in aq.range(num_repeats):
         if measure(qubit):
@@ -67,10 +67,8 @@ def reset(qubit: int, num_repeats: int) -> None:
 ```
 
 Now that the program takes inputs, you must pass those inputs when you call your function.
-In this case, the qubits are indexed by variable, rather than by integer literals, so we
-must additionally pass the `num_qubits` keyword argument to AutoQASM.
 ```
-my_reset_program = reset(qubit=0, num_repeats=3, num_qubits=1)
+my_reset_program = reset(qubit=0, num_repeats=3)
 ```
 
 AutoQASM can support nested subroutines and complex control flow. You can use the Python runtime

--- a/src/braket/experimental/autoqasm/api/api.py
+++ b/src/braket/experimental/autoqasm/api/api.py
@@ -26,7 +26,6 @@ import braket.experimental.autoqasm.program as aq_program
 import braket.experimental.autoqasm.transpiler as aq_transpiler
 import braket.experimental.autoqasm.types as aq_types
 from braket.experimental.autoqasm import errors
-from braket.experimental.autoqasm.autograph import ag_logging
 from braket.experimental.autoqasm.autograph.core import ag_ctx, converter
 from braket.experimental.autoqasm.autograph.impl.api_core import (
     autograph_artifact,
@@ -35,7 +34,7 @@ from braket.experimental.autoqasm.autograph.impl.api_core import (
 from braket.experimental.autoqasm.autograph.tf_utils import tf_decorator
 
 
-def function(f: Callable) -> Callable[[Any], aq_program.Program]:
+def function(*args, num_qubits: int = None) -> Callable[[Any], aq_program.Program]:
     """Decorator that converts a function into a callable that returns
     a Program object containing the quantum program.
 
@@ -43,8 +42,43 @@ def function(f: Callable) -> Callable[[Any], aq_program.Program]:
     function is called, and a new Program object is returned.
 
     Args:
+        num_qubits (int): Configuration to set the total number of qubits to declare in the program.
+
+    Returns:
+        Callable[[Any], Program]: A callable which returns the converted
+        quantum program when called.
+    """
+    # First, we just process the arguments to the decorator function
+    user_config = aq_program.UserConfig(num_qubits=num_qubits)
+
+    if len(args):
+        # In this case, num_qubits wasn't supplied.
+        # Matches the following syntax:
+        #    @aq.function
+        #    def my_func(...):
+        # Equivalently, `function(my_func, num_qubits=None)`
+        return _function_without_params(args[0], user_config=user_config)
+    else:
+        # In this case, num_qubits was supplied, and we don't know `f` yet.
+        # Matches the following syntax:
+        #    @aq.function(num_qubits=x)
+        #    def my_func(...):
+        # Equivalently: `function(num_qubits=x)(my_func)`
+        def _function_with_params(f):
+            return _function_without_params(f, user_config=user_config)
+
+        return _function_with_params
+
+
+def _function_without_params(
+    f: Callable, user_config: aq_program.UserConfig
+) -> Callable[[Any], aq_program.Program]:
+    """Wrapping and conversion logic around the user function `f`.
+
+    Args:
         f (Callable): The target function to be converted which represents
             the entry point of the quantum program.
+        user_config (UserConfig): User-specified settings that influence program building
 
     Returns:
         Callable[[Any], Program]: A callable which returns the converted
@@ -53,26 +87,11 @@ def function(f: Callable) -> Callable[[Any], aq_program.Program]:
     if is_autograph_artifact(f):
         return f
 
-    # Update documentation with user configuration
-    try:
-        if f.__doc__ is None:
-            f.__doc__ = ""
-        f.__doc__ += f"""
-
-Keyword Args:
-    {aq_program.ProgramOptions.NUM_QUBITS.value} (int): Configuration to set the total number of
-        qubits to declare in the program.
-"""
-    except AttributeError as e:
-        # AttributeError: object attribute '__doc__' is read-only
-        # Typically occurs when `f` is not a user-defined function. This will likely lead to
-        # another exception down the line, but it's better simply to warn at this point.
-        ag_logging.warning(f"Unable to set docstring for converted function. Exception: {e}")
-
     f_wrapper = f
     decorators, f = tf_decorator.unwrap(f)
 
-    wrapper_factory = convert_wrapper(
+    wrapper_factory = _convert_wrapper(
+        user_config=user_config,
         recursive=False,
         optional_features=(
             converter.Feature.ASSERT_STATEMENTS,
@@ -88,7 +107,8 @@ Keyword Args:
     return autograph_artifact(wrapper)
 
 
-def convert_wrapper(
+def _convert_wrapper(
+    user_config: aq_program.UserConfig,
     recursive: bool = False,
     optional_features: Optional[Tuple[converter.Feature]] = None,
     user_requested: bool = True,
@@ -98,6 +118,7 @@ def convert_wrapper(
     that returns a Program object containing the quantum program.
 
     Args:
+        user_config (UserConfig): User-specified settings that influence program building
         recursive (bool): whether to recursively convert any functions or classes
             that the converted function may use. Defaults to False.
         optional_features (Optional[Tuple[Feature]]): allows toggling
@@ -118,12 +139,15 @@ def convert_wrapper(
 
         def _wrapper(*args, **kwargs) -> aq_program.Program:
             """Wrapper that calls the converted version of f."""
+            # This code is executed once the decorated function is called
+            if aq_program.in_active_program_conversion_context():
+                _validate_subroutine_args(user_config)
             options = converter.ConversionOptions(
                 recursive=recursive,
                 user_requested=user_requested,
                 optional_features=optional_features,
             )
-            return _convert(f, conversion_ctx, options, args, kwargs)
+            return _convert(f, conversion_ctx, options, user_config, args, kwargs)
 
         if inspect.isfunction(f) or inspect.ismethod(f):
             _wrapper = functools.update_wrapper(_wrapper, f)
@@ -134,10 +158,29 @@ def convert_wrapper(
     return _decorator
 
 
+def _validate_subroutine_args(user_config: aq_program.UserConfig) -> None:
+    """Validate decorator arguments to subroutines. Subroutines do not currently support
+    decorator parameters; however, we allow them if they match the arguments provided to
+    main.
+
+    Args:
+        user_config (UserConfig): User-specified settings that influence program building
+
+    Raises:
+        InconsistentUserConfiguration: If subroutine num_qubits does not match the main
+            function's num_qubits argument.
+    """
+    if user_config.num_qubits is None:
+        return
+    if user_config.num_qubits != aq_program.get_program_conversion_context().get_declared_qubits():
+        raise errors.InconsistentNumQubits()
+
+
 def _convert(
     f: Callable,
     conversion_ctx: ag_ctx.ControlStatusCtx,
     options: converter.ConversionOptions,
+    user_config: aq_program.UserConfig,
     args: List[Any],
     kwargs: Dict[str, Any],
 ) -> aq_program.Program:
@@ -150,16 +193,13 @@ def _convert(
         f (Callable): The function to be converted.
         conversion_ctx (ControlStatusCtx): the Autograph context in which `f` is used.
         options (converter.ConversionOptions): Converter options.
+        user_config (UserConfig): User-specified settings that influence program building
         args (List[Any]): Arguments passed to the program when called.
         kwargs (Dict[str, Any]): Keyword arguments passed to the program when called.
 
     Returns:
         Program: The converted program.
     """
-    # User-supplied kwargs need to be processed and removed
-    # _before_ the program is processed
-    user_config = _process_user_config(kwargs)
-
     # We will convert this function as a subroutine if we are already inside an
     # existing conversion process (i.e., this is a subroutine call).
     convert_as_subroutine = aq_program.in_active_program_conversion_context()
@@ -182,21 +222,6 @@ def _convert(
                 raise
 
         return program_conversion_context.make_program()
-
-
-def _process_user_config(kwargs: Dict[str, Any]) -> aq_program.UserConfig:
-    """
-    Process the user supplied kwargs and return a standardized user config dictionary.
-
-    Args:
-        kwargs (Dict[str, Any]): Keyword arguments passed to the program when called.
-
-    Returns:
-        UserConfig: Processed user-config keyword arguments.
-    """
-    return aq_program.UserConfig(
-        num_qubits=kwargs.pop(aq_program.ProgramOptions.NUM_QUBITS.value, None)
-    )
 
 
 def _convert_program_as_main(

--- a/src/braket/experimental/autoqasm/api/api.py
+++ b/src/braket/experimental/autoqasm/api/api.py
@@ -34,7 +34,7 @@ from braket.experimental.autoqasm.autograph.impl.api_core import (
 from braket.experimental.autoqasm.autograph.tf_utils import tf_decorator
 
 
-def function(*args, num_qubits: int = None) -> Callable[[Any], aq_program.Program]:
+def function(*args, num_qubits: Optional[int] = None) -> Callable[[Any], aq_program.Program]:
     """Decorator that converts a function into a callable that returns
     a Program object containing the quantum program.
 
@@ -159,9 +159,7 @@ def _convert_wrapper(
 
 
 def _validate_subroutine_args(user_config: aq_program.UserConfig) -> None:
-    """Validate decorator arguments to subroutines. Subroutines do not currently support
-    decorator parameters; however, we allow them if they match the arguments provided to
-    main.
+    """Validate decorator arguments to subroutines.
 
     Args:
         user_config (UserConfig): User-specified settings that influence program building
@@ -172,6 +170,7 @@ def _validate_subroutine_args(user_config: aq_program.UserConfig) -> None:
     """
     if user_config.num_qubits is None:
         return
+    # Allow num_qubits only if the arg matches the value provided to the main function
     if user_config.num_qubits != aq_program.get_program_conversion_context().get_declared_qubits():
         raise errors.InconsistentNumQubits()
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -41,9 +41,9 @@ class InconsistentNumQubits(AutoQasmError):
 
     def __init__(self):
         self.message = """\
-The number of qubits specified by one of your subroutines does not match the \
-arguments supplied to your main function. Remove the num_qubits decorator \
-argument to all AutoQASM decorated functions except the one you wish to call."""
+The number of qubits specified by one of your functions does not match the \
+argument supplied elsewhere. Remove the `num_qubits` argument from nested \
+function calls."""
 
     def __str__(self):
         return self.message

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -43,7 +43,7 @@ class InconsistentNumQubits(AutoQasmError):
         self.message = """\
 The number of qubits specified by one of your subroutines does not match the \
 arguments supplied to your main function. Remove the num_qubits decorator \
-argument to all aq.functions except the one you wish to call."""
+argument to all AutoQASM decorated functions except the one you wish to call."""
 
     def __str__(self):
         return self.message

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -13,8 +13,6 @@
 
 """Errors raised in the AutoQASM build process."""
 
-from braket.experimental.autoqasm.program import ProgramOptions
-
 
 class AutoQasmError(Exception):
     """Base class for all AutoQASM exceptions."""
@@ -24,12 +22,28 @@ class UnknownQubitCountError(AutoQasmError):
     """Missing declaration for the number of qubits."""
 
     def __init__(self):
-        self.message = f"""Unspecified number of qubits.
+        self.message = """Unspecified number of qubits.
 
-Please declare the total number of qubits for your program. \
-You can do that by calling your AutoQASM program with the \
-{ProgramOptions.NUM_QUBITS.value} keyword argument. \
+Specify the number of qubits used by your program by supplying the \
+`num_qubits` argument to `autoqasm.function`. For example:
+
+    @autoqasm.function(num_qubits=5)
+    def my_autoqasm_function():
+        ...
 """
+
+    def __str__(self):
+        return self.message
+
+
+class InconsistentNumQubits(AutoQasmError):
+    """Num qubits supplied to main function does not match subroutine."""
+
+    def __init__(self):
+        self.message = """\
+The number of qubits specified by one of your subroutines does not match the \
+arguments supplied to your main function. Remove the num_qubits decorator \
+argument to all aq.functions except the one you wish to call."""
 
     def __str__(self):
         return self.message

--- a/src/braket/experimental/autoqasm/program/__init__.py
+++ b/src/braket/experimental/autoqasm/program/__init__.py
@@ -19,7 +19,6 @@ from .pragmas import Verbatim  # noqa: F401
 from .program import (  # noqa: F401
     Program,
     ProgramConversionContext,
-    ProgramOptions,
     UserConfig,
     build_program,
     get_program_conversion_context,

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -13,7 +13,6 @@
 
 """AutoQASM Program class, context managers, and related functions."""
 
-import enum
 import threading
 from dataclasses import dataclass
 from typing import List, Optional
@@ -26,16 +25,6 @@ from braket.experimental.autoqasm import constants
 # Prepare to initialize the global program conversion context.
 _local = threading.local()
 setattr(_local, "program_conversion_context", None)
-
-
-class ProgramOptions(enum.Enum):
-    """All options configurable by the user at program invocation time via keyword arguments
-    injected by the aq.function decorator.
-    """
-
-    # Note: this is the exact kwarg name that the user must pass,
-    # which is later input to UserConfig
-    NUM_QUBITS = "num_qubits"
 
 
 @dataclass

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -779,3 +779,16 @@ a = __bit_0__;
 bit b;
 b = a;"""
     assert prog().to_ir() == expected
+
+
+def test_mismatched_qubits():
+    @aq.function(num_qubits=4)
+    def subroutine() -> None:
+        a = measure(0)
+
+    @aq.function(num_qubits=8)
+    def main() -> None:
+        subroutine()
+    
+    with pytest.raises(errors.InconsistentNumQubits):
+        main()

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -112,14 +112,14 @@ def do_h(q: int):
     h(q)
 
 
-@aq.function
+@aq.function(num_qubits=6)
 def recursive_h(q: int):
     do_h(q)
     if q > 0:
         recursive_h(q - 1)
 
 
-@aq.function
+@aq.function(num_qubits=6)
 def recursive_h_wrapper(q: int):
     recursive_h(q)
 
@@ -137,11 +137,11 @@ def recursive_h(int[32] q) {
 }
 qubit[6] __qubits__;
 recursive_h(5);"""
-    assert recursive_h_wrapper(5, num_qubits=6).to_ir() == expected
+    assert recursive_h_wrapper(5).to_ir() == expected
 
 
 def test_sim_recursive_h_wrapper():
-    _test_on_local_sim(recursive_h_wrapper(5, num_qubits=6))
+    _test_on_local_sim(recursive_h_wrapper(5))
 
 
 def test_recursive_h():
@@ -158,11 +158,11 @@ def recursive_h(int[32] q) {
 qubit[6] __qubits__;
 do_h(5);
 recursive_h(4);"""
-    assert recursive_h(5, num_qubits=6).to_ir() == expected
+    assert recursive_h(5).to_ir() == expected
 
 
 def test_sim_recursive_h():
-    _test_on_local_sim(recursive_h(5, num_qubits=6))
+    _test_on_local_sim(recursive_h(5))
 
 
 @aq.function
@@ -171,7 +171,7 @@ def bell_state_arbitrary_qubits(q0: int, q1: int) -> None:
     cnot(q0, q1)
 
 
-@aq.function
+@aq.function(num_qubits=4)
 def double_bell_state() -> None:
     bell_state_arbitrary_qubits(0, 1)
     bell_state_arbitrary_qubits(2, 3)
@@ -186,11 +186,11 @@ def bell_state_arbitrary_qubits(int[32] q0, int[32] q1) {
 qubit[4] __qubits__;
 bell_state_arbitrary_qubits(0, 1);
 bell_state_arbitrary_qubits(2, 3);"""
-    assert double_bell_state(num_qubits=4).to_ir() == expected
+    assert double_bell_state().to_ir() == expected
 
 
 def test_sim_double_bell() -> None:
-    _test_on_local_sim(double_bell_state(num_qubits=4))
+    _test_on_local_sim(double_bell_state())
 
 
 @aq.function
@@ -294,7 +294,7 @@ def test_bell_measurement_invalid_declared_size() -> None:
     assert expected_error_message in str(exc_info.value)
 
 
-@aq.function
+@aq.function(num_qubits=5)
 def ghz_qasm_for_loop() -> None:
     """A function that generates a GHZ state using a QASM for loop."""
     n_qubits = 5
@@ -310,11 +310,11 @@ h __qubits__[0];
 for int i in [0:3] {
     cnot __qubits__[i], __qubits__[i + 1];
 }"""
-    assert ghz_qasm_for_loop(num_qubits=5).to_ir() == expected
+    assert ghz_qasm_for_loop().to_ir() == expected
 
 
 def test_sim_ghz_qasm_for_loop() -> None:
-    _test_on_local_sim(ghz_qasm_for_loop(num_qubits=5))
+    _test_on_local_sim(ghz_qasm_for_loop())
 
 
 @aq.function
@@ -521,12 +521,6 @@ def test_physical_qubit_decl(physical_bell_program) -> None:
     assert "__qubits__" not in qasm
 
 
-def test_explicit_qubit_decl() -> None:
-    """Tests the qubit declaration functionality."""
-    qasm = ghz_py_for_loop(num_qubits=10).to_ir()
-    assert "\nqubit[10] __qubits__;" in qasm
-
-
 def test_invalid_physical_qubit_fails() -> None:
     """Tests invalid physical qubit formatting."""
 
@@ -671,13 +665,6 @@ def test_program_with_expr() -> None:
         qubit_expr()
 
 
-def test_program_with_expr_and_declaration() -> None:
-    """Test that a program with expressions for the qubit index does not
-    raise an error if the user explicitly declares the number of qubits.
-    """
-    ghz_qasm_for_loop(num_qubits=8)
-
-
 def test_multi_for_loop() -> None:
     """Test that a program with multiple differing for loops is generated
     correctly.
@@ -691,7 +678,7 @@ for int i in [0:4] {
     h __qubits__[i];
 }"""
 
-    @aq.function
+    @aq.function(num_qubits=6)
     def prog():
         for i in aq.range(3):
             cnot(i, i + 1)
@@ -699,7 +686,7 @@ for int i in [0:4] {
         for i in aq.range(5):
             h(i)
 
-    assert prog(num_qubits=6).to_ir() == expected
+    assert prog().to_ir() == expected
 
 
 @aq.function
@@ -708,7 +695,7 @@ def bell(q0: int, q1: int) -> None:
     cnot(q0, q1)
 
 
-@aq.function
+@aq.function(num_qubits=5)
 def bell_in_for_loop() -> None:
     for i in aq.range(3):
         bell(0, 1)
@@ -726,7 +713,7 @@ for int i in [0:2] {
     bell(0, 1);
 }"""
 
-    assert bell_in_for_loop(num_qubits=5).to_ir() == expected
+    assert bell_in_for_loop().to_ir() == expected
 
 
 def test_classical_variables_types():
@@ -792,7 +779,3 @@ a = __bit_0__;
 bit b;
 b = a;"""
     assert prog().to_ir() == expected
-
-
-def test_generated_docstring(bell_state_program) -> None:
-    assert "num_qubits (int)" in bell_state_program.__doc__

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -789,6 +789,6 @@ def test_mismatched_qubits():
     @aq.function(num_qubits=8)
     def main() -> None:
         subroutine()
-    
+
     with pytest.raises(errors.InconsistentNumQubits):
         main()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=32622428

*Description of changes:*

Previous:
```
@aq.function
def my_func():
    for i in aq.range(5):
        cnot(i, i + 1)

prog = my_func(num_qubits=6)
```

New:
```
@aq.function(num_qubits=6)
def my_func():
    for i in aq.range(5):
        cnot(i, i + 1)

prog = my_func()
```

*Testing done:*
Updated unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
