### PR TITLE
infra: change top level permissions to read for the stale issue workflow

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -6,9 +6,14 @@ on:
   schedule:
     - cron: "0 10 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write  # comment on issues
     name: Stale issue job
     steps:
       - uses: aws-actions/stale-issue-cleanup@7de35968489e4142233d2a6812519a82e68b5c38 # v6

--- a/test/unit_tests/braket/pulse/test_waveforms.py
+++ b/test/unit_tests/braket/pulse/test_waveforms.py
@@ -59,10 +59,10 @@ def test_arbitrary_wf_eq():
         assert wf != wfc
 
 
-@pytest.mark.xfail(raises=TypeError)
 def test_arbitrary_waveform_not_castable_into_list():
     amps = 1
-    ArbitraryWaveform(amps)
+    with pytest.raises(TypeError):
+        ArbitraryWaveform(amps)
 
 
 def test_constant_waveform():

--- a/test/unit_tests/braket/pulse/test_waveforms.py
+++ b/test/unit_tests/braket/pulse/test_waveforms.py
@@ -57,10 +57,10 @@ def test_arbitrary_wf_eq():
         assert wf != wfc
 
 
+@pytest.mark.xfail(raises=TypeError)
 def test_arbitrary_waveform_not_castable_into_list():
     amps = 1
-    with pytest.raises(TypeError):
-        wf = ArbitraryWaveform(amps)
+    ArbitraryWaveform(amps)
 
 
 def test_constant_waveform():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The stale issue workflow is still scoped to write permissions but the top level permissions defaults to read only.

Included a minor linter fix for a waveform test.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
