### PR TITLE
fix: copy calibrations in to_ir

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -604,7 +604,7 @@ def _(
     openqasm_program = circuit.to_ir(
         ir_type=IRType.OPENQASM,
         serialization_properties=serialization_properties,
-        gate_calibrations=gate_calibrations.copy() if gate_calibrations is not None else None,
+        gate_calibrations=gate_calibrations,
     )
 
     if inputs:

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1133,7 +1133,7 @@ class Circuit:
                 )
             return self._to_openqasm(
                 serialization_properties or OpenQASMSerializationProperties(),
-                gate_calibrations,
+                gate_calibrations.copy() if gate_calibrations is not None else None,
             )
         else:
             raise ValueError(f"Supplied ir_type {ir_type} is not supported.")

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -1001,6 +1001,7 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
     ],
 )
 def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir, gate_calibrations):
+    copy_of_gate_calibrations = gate_calibrations.copy()
     assert (
         circuit.to_ir(
             ir_type=IRType.OPENQASM,
@@ -1009,6 +1010,7 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir, 
         )
         == expected_ir
     )
+    assert copy_of_gate_calibrations.pulse_sequences == gate_calibrations.pulse_sequences
 
 
 def test_parametric_circuit_with_fixed_argument_defcal(pulse_sequence):


### PR DESCRIPTION
*Issue #, if available:*
`to_ir` mutates calibrations because we copy it in `device.run`

*Description of changes:*
moved the copy function call in `to_ir`

*Testing done:*
Added a test in an existing unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
