### PR TITLE
change: making additional meta available in AHS results

### DIFF
--- a/src/braket/tasks/analog_hamiltonian_simulation_quantum_task_result.py
+++ b/src/braket/tasks/analog_hamiltonian_simulation_quantum_task_result.py
@@ -20,7 +20,7 @@ from typing import Dict, List
 
 import numpy as np
 
-from braket.task_result import AnalogHamiltonianSimulationTaskResult, TaskMetadata
+from braket.task_result import AnalogHamiltonianSimulationTaskResult, TaskMetadata, AdditionalMetadata
 
 
 class AnalogHamiltonianSimulationShotStatus(str, Enum):
@@ -48,6 +48,7 @@ class ShotResult:
 @dataclass
 class AnalogHamiltonianSimulationQuantumTaskResult:
     task_metadata: TaskMetadata
+    additionalMetadata: AdditionalMetadata
     measurements: List[ShotResult] = None
 
     def __eq__(self, other) -> bool:
@@ -80,6 +81,7 @@ class AnalogHamiltonianSimulationQuantumTaskResult:
             measurements = None
         return cls(
             task_metadata=result.taskMetadata,
+            additionalMetadata=result.additionalMetadata,
             measurements=measurements,
         )
 

--- a/src/braket/tasks/analog_hamiltonian_simulation_quantum_task_result.py
+++ b/src/braket/tasks/analog_hamiltonian_simulation_quantum_task_result.py
@@ -48,7 +48,7 @@ class ShotResult:
 @dataclass
 class AnalogHamiltonianSimulationQuantumTaskResult:
     task_metadata: TaskMetadata
-    additionalMetadata: AdditionalMetadata
+    additional_metadata: AdditionalMetadata
     measurements: List[ShotResult] = None
 
     def __eq__(self, other) -> bool:
@@ -81,7 +81,7 @@ class AnalogHamiltonianSimulationQuantumTaskResult:
             measurements = None
         return cls(
             task_metadata=result.taskMetadata,
-            additionalMetadata=result.additionalMetadata,
+            additional_metadata=result.additionalMetadata,
             measurements=measurements,
         )
 

--- a/src/braket/tasks/analog_hamiltonian_simulation_quantum_task_result.py
+++ b/src/braket/tasks/analog_hamiltonian_simulation_quantum_task_result.py
@@ -20,7 +20,11 @@ from typing import Dict, List
 
 import numpy as np
 
-from braket.task_result import AnalogHamiltonianSimulationTaskResult, TaskMetadata, AdditionalMetadata
+from braket.task_result import (
+    AdditionalMetadata,
+    AnalogHamiltonianSimulationTaskResult,
+    TaskMetadata,
+)
 
 
 class AnalogHamiltonianSimulationShotStatus(str, Enum):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The results from the QPU contain additional metadata, but we weren't exposing them in our results object. With this change the additional metadata can be retrieved just like task metadata.

*Testing done:*

Tested in Gamma that I can run a task and get results back in the object. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
