### PR TITLE
fix: fix a bug in time series and add trapezoidal time series

### DIFF
--- a/src/braket/timings/time_series.py
+++ b/src/braket/timings/time_series.py
@@ -318,11 +318,11 @@ class TimeSeries:
                 time_separation_min (float): The minimum separation of time points
 
             Returns:
-                TimeSeries: A trapezoidal_signal time series
+                TimeSeries: A trapezoidal time series
 
-            Notes: The area of a time series \Omega(t) is defined as the time integral
-            \int_0^T\Omega(t)dt, where T is the duration. We also assume the trapezoidal
-            time series starts and ends at zero.
+            Notes: The area of a time series f(t) is defined as the time integral of 
+            f(t) from t=0 to t=T, where T is the duration. 
+            We also assume the trapezoidal time series starts and ends at zero.
         """
 
         if area <= 0.0:

--- a/src/braket/timings/time_series.py
+++ b/src/braket/timings/time_series.py
@@ -20,8 +20,6 @@ from enum import Enum
 from numbers import Number
 from typing import Iterator, List, Union
 
-import numpy as np
-
 
 @dataclass
 class TimeSeriesItem:
@@ -311,16 +309,17 @@ class TimeSeries:
         """Get a trapezoidal time series with specified area, maximum value, maximum slew rate
         and minimum separation of time points
 
-            Args:
-                area (float): Total area under the time series
-                value_max (float): The maximum value of the time series
-                slew_rate_max (float): The maximum slew rate
-                time_separation_min (float): The minimum separation of time points
+        Args:
+            area (float): Total area under the time series
+            value_max (float): The maximum value of the time series
+            slew_rate_max (float): The maximum slew rate
+            time_separation_min (float): The minimum separation of time points
 
-            Returns:
-                TimeSeries: A trapezoidal time series
+        Returns:
+            TimeSeries: A trapezoidal time series
 
-            Notes: The area of a time series f(t) is defined as the time integral of
+            Notes:
+            The area of a time series f(t) is defined as the time integral of
             f(t) from t=0 to t=T, where T is the duration.
             We also assume the trapezoidal time series starts and ends at zero.
         """

--- a/src/braket/timings/time_series.py
+++ b/src/braket/timings/time_series.py
@@ -320,8 +320,8 @@ class TimeSeries:
             Returns:
                 TimeSeries: A trapezoidal time series
 
-            Notes: The area of a time series f(t) is defined as the time integral of 
-            f(t) from t=0 to t=T, where T is the duration. 
+            Notes: The area of a time series f(t) is defined as the time integral of
+            f(t) from t=0 to t=T, where T is the duration.
             We also assume the trapezoidal time series starts and ends at zero.
         """
 

--- a/src/braket/timings/time_series.py
+++ b/src/braket/timings/time_series.py
@@ -306,7 +306,7 @@ class TimeSeries:
 
     @staticmethod
     def trapezoidal_signal(
-        area: float, value_max: float, slew_rate_max: float, time_separation_min: float
+        area: float, value_max: float, slew_rate_max: float, time_separation_min: float = 0.0
     ) -> TimeSeries:
         """Get a trapezoidal time series with specified area, maximum value, maximum slew rate
         and minimum separation of time points
@@ -333,10 +333,10 @@ class TimeSeries:
             raise ValueError(
                 "The maximum slew rate of the trapezoidal time series has to be positive."
             )
-        if time_separation_min <= 0.0:
+        if time_separation_min < 0.0:
             raise ValueError(
                 "The minimum separation of time points of the trapezoidal time series "
-                "has to be positive."
+                "has to be non-negative."
             )
 
         # Determine the ramp time to reach the max allowed value

--- a/test/unit_tests/braket/timings/test_time_series.py
+++ b/test/unit_tests/braket/timings/test_time_series.py
@@ -81,10 +81,7 @@ def test_constant_like_with_time_series():
 
 
 @pytest.mark.parametrize(
-    "area",
-    "value_max",
-    "slew_rate_max",
-    "time_separation_min",
+    "area, value_max, slew_rate_max, time_separation_min",
     [
         (2.0, 2.0, 4.0, 1.0),
         (1.0, 2.0, 4.0, 1.0),
@@ -103,10 +100,7 @@ def test_trapezoidal_signal_as_triangular_signal(
 
 
 @pytest.mark.parametrize(
-    "area",
-    "value_max",
-    "slew_rate_max",
-    "time_separation_min",
+    "area, value_max, slew_rate_max, time_separation_min",
     [
         (4.0, 2.0, 4.0, 1.0),
         (2.1, 2.0, 4.0, 1.0),
@@ -125,10 +119,7 @@ def test_trapezoidal_signal_as_min_trapezoidal_signal(
 
 
 @pytest.mark.parametrize(
-    "area",
-    "value_max",
-    "slew_rate_max",
-    "time_separation_min",
+    "area, value_max, slew_rate_max, time_separation_min",
     [
         (4.1, 2.0, 4.0, 1.0),
         (6.1, 2.0, 1.0, 1.0),
@@ -142,21 +133,18 @@ def test_trapezoidal_signal_with_large_area(area, value_max, slew_rate_max, time
     assert ts.values() == [0, value_max, value_max, 0]
 
 
-# @pytest.mark.xfail(raises=ValueError)
-# @pytest.mark.parametrize(
-#     "area",
-#     "value_max",
-#     "slew_rate_max",
-#     "time_separation_min",
-#     [
-#         (-4.1, 2.0, 4.0, 1.0),
-#         (4.1, -2.0, 4.0, 1.0),
-#         (4.1, 2.0, -4.0, 1.0),
-#         (4.1, 2.0, 4.0, -1.0),
-#     ],
-# )
-# def test_trapezoidal_signal_with_negative_para(area, value_max, slew_rate_max, time_separation_min):
-#     TimeSeries.trapezoidal_signal(area, value_max, slew_rate_max, time_separation_min)
+@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.parametrize(
+    "area, value_max, slew_rate_max, time_separation_min",
+    [
+        (-4.1, 2.0, 4.0, 1.0),
+        (4.1, -2.0, 4.0, 1.0),
+        (4.1, 2.0, -4.0, 1.0),
+        (4.1, 2.0, 4.0, -1.0),
+    ],
+)
+def test_trapezoidal_signal_with_negative_para(area, value_max, slew_rate_max, time_separation_min):
+    TimeSeries.trapezoidal_signal(area, value_max, slew_rate_max, time_separation_min)
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
*Issue #, if available:*

1. The TimeSeries.constant_like method is supposed to be able to take in TimeSeries as an argument, but from the implementation, it is not
2. Add a method to create trapezoidal time series

*Description of changes:*
see above

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
