### PR TITLE
fix: move import back to top level in job example

### DIFF
--- a/examples/job.py
+++ b/examples/job.py
@@ -15,6 +15,7 @@ import os
 
 from braket.aws import AwsDevice, AwsQuantumJob
 from braket.circuits import Circuit
+from braket.devices import Devices
 from braket.jobs import save_job_result
 
 
@@ -35,8 +36,6 @@ def run_job():
 
 
 if __name__ == "__main__":
-    from braket.devices import Devices
-
     job = AwsQuantumJob.create(
         device=Devices.Amazon.SV1,
         source_module="job.py",


### PR DESCRIPTION
This reverts commit 1fed55d88333d4acd2302734ee88f707ce418a12.

*Issue #, if available:*

*Description of changes:*

move Devices enum import back to top level

*Testing done:*

manually ran example successfully

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
