### PR TITLE
fix: Update quantum job tests for latest containers

### DIFF
--- a/test/integ_tests/test_create_quantum_job.py
+++ b/test/integ_tests/test_create_quantum_job.py
@@ -59,7 +59,7 @@ def test_failed_quantum_job(aws_session, capsys):
     assert errors == ""
     logs_to_validate = [
         "Invoking script with the following command:",
-        "/usr/local/bin/python3.8 braket_container.py",
+        "braket_container.py",
         "Running Code As Process",
         "Test job started!!!!!",
         "AssertionError",
@@ -167,7 +167,7 @@ def test_completed_quantum_job(aws_session, capsys):
     assert errors == ""
     logs_to_validate = [
         "Invoking script with the following command:",
-        "/usr/local/bin/python3.8 braket_container.py",
+        "braket_container.py",
         "Running Code As Process",
         "Test job started!!!!!",
         "Test job completed!!!!!",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update tests for quantum jobs to remove log entries which assert a specific python version. 
* These started failing after change #644

*Testing done:*
* `tox -e integ-tests -- -s -k "test_completed_quantum_job"` and `tox -e integ-tests -- -s -k "test_failed_quantum_job"` succeeded.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
