### PR TITLE
fix: autoqasm programs with assignments inside conditionals and branches

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -425,9 +425,11 @@ def _wrap_for_oqpy_subroutine(f: Callable, options: converter.ConversionOptions)
 
     @functools.wraps(f)
     def _func(*args, **kwargs) -> Any:
-        inner_program = args[0]
+        inner_program: oqpy.Program = args[0]
         with aq_program.get_program_conversion_context().push_oqpy_program(inner_program):
-            return aq_transpiler.converted_call(f, args[1:], kwargs, options=options)
+            result = aq_transpiler.converted_call(f, args[1:], kwargs, options=options)
+        inner_program.autodeclare()
+        return result
 
     # Replace the function signature with a new signature where the first
     # argument is of type `oqpy.Program`.

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -14,6 +14,9 @@
 """Errors raised in the AutoQASM build process."""
 
 
+from typing import Optional
+
+
 class AutoQasmError(Exception):
     """Base class for all AutoQASM exceptions."""
 
@@ -52,11 +55,15 @@ function calls."""
 class UnsupportedConditionalExpressionError(AutoQasmError):
     """Conditional expressions which return values are not supported."""
 
-    def __init__(self):
+    def __init__(self, true_type: Optional[type], false_type: Optional[type]):
+        if_type = true_type.__name__ if true_type else "None"
+        else_type = false_type.__name__ if false_type else "None"
         self.message = """\
-Inline conditional expressions (ternary operators) which return values are \
-not supported by AutoQASM. Please rewrite this conditional expression as an \
-if-else statement."""
+`if` clause resolves to {}, but `else` clause resolves to {}. \
+Both the `if` and `else` clauses of an inline conditional expression \
+must resolve to the same type.""".format(
+            if_type, else_type
+        )
 
     def __str__(self):
         return self.message

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -47,3 +47,16 @@ function calls."""
 
     def __str__(self):
         return self.message
+
+
+class UnsupportedConditionalExpressionError(AutoQasmError):
+    """Conditional expressions which return values are not supported."""
+
+    def __init__(self):
+        self.message = """\
+Inline conditional expressions (ternary operators) which return values are \
+not supported by AutoQASM. Please rewrite this conditional expression as an \
+if-else statement."""
+
+    def __str__(self):
+        return self.message

--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -68,23 +68,16 @@ def assign_stmt(target_name: str, value: Any) -> Any:
         if is_target_name_used:
             target = _get_oqpy_program_variable(target_name)
             _validate_variables_type_size(target, value)
-            if is_value_name_used:
-                oqpy_program.set(target, value)
-            else:
-                # Set to `value.init_expression` to avoid declaring an unnecessary variable.
-                oqpy_program.set(target, value.init_expression)
         else:
             target = copy.copy(value)
             target.init_expression = None
             target.name = target_name
 
-            if is_value_name_used:
-                oqpy_program.declare(target)
-                oqpy_program.set(target, value)
-            else:
-                # Set to `value.init_expression` to avoid declaring an unnecessary variable.
-                target.init_expression = value.init_expression
-                oqpy_program.declare(target)
+        if is_value_name_used or value.init_expression is None:
+            oqpy_program.set(target, value)
+        else:
+            # Set to `value.init_expression` to avoid declaring an unnecessary variable.
+            oqpy_program.set(target, value.init_expression)
 
         return target
 

--- a/src/braket/experimental/autoqasm/operators/conditional_expressions.py
+++ b/src/braket/experimental/autoqasm/operators/conditional_expressions.py
@@ -48,7 +48,7 @@ def _oqpy_if_exp(
     if_true: Callable[[None], Any],
     if_false: Callable[[None], Any],
     expr_repr: Optional[str],
-) -> None:
+) -> Optional[oqpy.base.Var]:
     """Overload of if_exp that stages an oqpy conditional."""
     oqpy_program = aq_program.get_program_conversion_context().get_oqpy_program()
     if isinstance(cond, oqpy.base.Var) and cond.name not in oqpy_program.declared_vars.keys():

--- a/src/braket/experimental/autoqasm/operators/conditional_expressions.py
+++ b/src/braket/experimental/autoqasm/operators/conditional_expressions.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Optional
 import oqpy.base
 
 from braket.experimental.autoqasm import program
+from braket.experimental.autoqasm.errors import UnsupportedConditionalExpressionError
 from braket.experimental.autoqasm.types import is_qasm_type
 
 
@@ -53,9 +54,13 @@ def _oqpy_if_exp(
     if isinstance(cond, oqpy.base.Var) and cond.name not in oqpy_program.declared_vars.keys():
         oqpy_program.declare(cond)
     with oqpy.If(oqpy_program, cond):
-        if_true()
+        result = if_true()
+        if result is not None:
+            raise UnsupportedConditionalExpressionError()
     with oqpy.Else(oqpy_program):
-        if_false()
+        result = if_false()
+        if result is not None:
+            raise UnsupportedConditionalExpressionError()
 
 
 def _py_if_exp(cond: Any, if_true: Callable[[None], Any], if_false: Callable[[None], Any]) -> Any:

--- a/src/braket/experimental/autoqasm/operators/conditional_expressions.py
+++ b/src/braket/experimental/autoqasm/operators/conditional_expressions.py
@@ -69,8 +69,6 @@ def _oqpy_if_exp(
         if false_result is not None:
             oqpy_program.set(result_var, false_result)
 
-    if result_var is not None:
-        oqpy_program.declare(result_var, to_beginning=True)
     return result_var
 
 

--- a/src/braket/experimental/autoqasm/operators/conditional_expressions.py
+++ b/src/braket/experimental/autoqasm/operators/conditional_expressions.py
@@ -50,11 +50,8 @@ def _oqpy_if_exp(
     expr_repr: Optional[str],
 ) -> Optional[oqpy.base.Var]:
     """Overload of if_exp that stages an oqpy conditional."""
-    oqpy_program = aq_program.get_program_conversion_context().get_oqpy_program()
-    if isinstance(cond, oqpy.base.Var) and cond.name not in oqpy_program.declared_vars.keys():
-        oqpy_program.declare(cond)
-
     result_var = None
+    oqpy_program = aq_program.get_program_conversion_context().get_oqpy_program()
     with oqpy.If(oqpy_program, cond):
         true_result = aq_types.wrap_value(if_true())
         true_result_type = aq_types.var_type_from_oqpy(true_result)

--- a/src/braket/experimental/autoqasm/operators/control_flow.py
+++ b/src/braket/experimental/autoqasm/operators/control_flow.py
@@ -154,8 +154,6 @@ def _oqpy_if_stmt(
 ) -> None:
     """Overload of if_stmt that stages an oqpy cond."""
     oqpy_program = program.get_program_conversion_context().get_oqpy_program()
-    if isinstance(cond, oqpy.base.Var) and cond.name not in oqpy_program.declared_vars.keys():
-        oqpy_program.declare(cond)
     with oqpy.If(oqpy_program, cond):
         body()
     with oqpy.Else(oqpy_program):

--- a/src/braket/experimental/autoqasm/operators/slices.py
+++ b/src/braket/experimental/autoqasm/operators/slices.py
@@ -89,13 +89,14 @@ def _oqpy_set_item(target: Any, i: Any, x: Any) -> Any:
     if not isinstance(target, oqpy.BitVar):
         raise NotImplementedError("Slice assignment is not supported.")
 
+    is_var_name_used = program.get_program_conversion_context().is_var_name_used(x.name)
     oqpy_program = program.get_program_conversion_context().get_oqpy_program()
-    if x.name in oqpy_program.declared_vars.keys() or x.init_expression is None:
-        value = x
+    if is_var_name_used or x.init_expression is None:
+        oqpy_program.set(target[i], x)
     else:
         # Set to `x.init_expression` to avoid declaring an unnecessary variable.
-        value = x.init_expression
-    oqpy_program.set(target[i], value)
+        oqpy_program.set(target[i], x.init_expression)
+
     return target
 
 

--- a/src/braket/experimental/autoqasm/operators/slices.py
+++ b/src/braket/experimental/autoqasm/operators/slices.py
@@ -90,9 +90,10 @@ def _oqpy_set_item(target: Any, i: Any, x: Any) -> Any:
         raise NotImplementedError("Slice assignment is not supported.")
 
     oqpy_program = program.get_program_conversion_context().get_oqpy_program()
-    if x.name in oqpy_program.declared_vars.keys():
+    if x.name in oqpy_program.declared_vars.keys() or x.init_expression is None:
         value = x
     else:
+        # Set to `x.init_expression` to avoid declaring an unnecessary variable.
         value = x.init_expression
     oqpy_program.set(target[i], value)
     return target

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -144,6 +144,21 @@ class ProgramConversionContext:
 
         raise NotImplementedError(f"Program's do not yet support type {kind}.")
 
+    def is_var_name_used(self, var_name: str) -> bool:
+        """Check if the variable already exists in the oqpy program.
+
+        Args:
+            var_name (str): variable name
+
+        Returns:
+            bool: Return True if the variable already exists
+        """
+        oqpy_program = self.get_oqpy_program()
+        return (
+            var_name in oqpy_program.declared_vars.keys()
+            or var_name in oqpy_program.undeclared_vars.keys()
+        )
+
     def get_oqpy_program(self) -> oqpy.Program:
         """Gets the oqpy program from the top of the stack.
 

--- a/src/braket/experimental/autoqasm/types/__init__.py
+++ b/src/braket/experimental/autoqasm/types/__init__.py
@@ -15,7 +15,7 @@
 for type handling.
 """
 
-from .conversions import map_type, wrap_value  # noqa: F401
+from .conversions import map_type, var_type_from_oqpy, wrap_value  # noqa: F401
 from .types import (  # noqa: F401
     ArrayVar,
     BitVar,

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -77,6 +77,8 @@ def var_type_from_ast_type(ast_type: ast.ClassicalType) -> type:
     if isinstance(ast_type, ast.ArrayType):
         return aq_types.ArrayVar
 
+    raise NotImplementedError
+
 
 def var_type_from_oqpy(expr_or_var: Union[oqpy.base.OQPyExpression, oqpy.base.Var]) -> type:
     """Returns the AutoQASM variable type corresponding to the provided OQPy object.

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -19,6 +19,7 @@ from typing import Any, Union
 
 import numpy as np
 import oqpy
+from openpulse import ast
 
 from braket.experimental.autoqasm import types as aq_types
 
@@ -54,6 +55,41 @@ def map_type(python_type: type) -> type:
 
     # TODO add all supported types
     return python_type
+
+
+def var_type_from_ast_type(ast_type: ast.ClassicalType) -> type:
+    """Converts an OpenQASM AST type to the corresponding AutoQASM variable type.
+
+    Args:
+        ast_type (ast.ClassicalType): The OpenQASM AST type to be converted.
+
+    Returns:
+        type: The corresponding AutoQASM variable type.
+    """
+    if isinstance(ast_type, ast.IntType):
+        return aq_types.IntVar
+    if isinstance(ast_type, ast.FloatType):
+        return aq_types.FloatVar
+    if isinstance(ast_type, ast.BoolType):
+        return aq_types.BoolVar
+    if isinstance(ast_type, ast.BitType):
+        return aq_types.BitVar
+    if isinstance(ast_type, ast.ArrayType):
+        return aq_types.ArrayVar
+
+
+def var_type_from_oqpy(expr_or_var: Union[oqpy.base.OQPyExpression, oqpy.base.Var]) -> type:
+    """Returns the AutoQASM variable type corresponding to the provided OQPy object.
+
+    Args:
+        expr_or_var (Union[OQPyExpression, Var]): An OQPy expression or variable.
+
+    Returns:
+        type: The corresponding AutoQASM variable type.
+    """
+    if isinstance(expr_or_var, oqpy.base.OQPyExpression):
+        return var_type_from_ast_type(expr_or_var.type)
+    return type(expr_or_var)
 
 
 @singledispatch

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -203,13 +203,13 @@ def bell_measurement_undeclared() -> None:
 
 def test_bell_measurement_undeclared() -> None:
     expected = """OPENQASM 3.0;
+bit[2] c;
 qubit[2] __qubits__;
 h __qubits__[0];
 cnot __qubits__[0], __qubits__[1];
 bit[2] __bit_0__;
 __bit_0__[0] = measure __qubits__[0];
 __bit_0__[1] = measure __qubits__[1];
-bit[2] c;
 c = __bit_0__;"""
     assert bell_measurement_undeclared().to_ir() == expected
 
@@ -225,8 +225,9 @@ def bell_measurement_declared() -> None:
 
 def test_bell_measurement_declared() -> None:
     expected = """OPENQASM 3.0;
+bit[2] c;
 qubit[2] __qubits__;
-bit[2] c = {0, 0};
+c = {0, 0};
 h __qubits__[0];
 cnot __qubits__[0], __qubits__[1];
 bit[2] __bit_1__;
@@ -246,12 +247,12 @@ def bell_partial_measurement() -> None:
 
 def test_bell_partial_measurement() -> None:
     expected = """OPENQASM 3.0;
+bit c;
 qubit[2] __qubits__;
 h __qubits__[0];
 cnot __qubits__[0], __qubits__[1];
 bit __bit_0__;
 __bit_0__ = measure __qubits__[1];
-bit c;
 c = __bit_0__;"""
     assert bell_partial_measurement().to_ir() == expected
 
@@ -734,15 +735,21 @@ def test_classical_variables_types():
         c = aq.FloatVar(3.4)  # noqa: F841
 
     expected = """OPENQASM 3.0;
-bit a = 0;
-a = 1;
-int[32] i = 1;
+bit a;
+int[32] i;
 bit[2] a_array;
+bit[2] __bit_3__;
+int[32] b;
+float[64] c;
+a = 0;
+a = 1;
+i = 1;
+a_array = __bit_3__;
 a_array[0] = 0;
 a_array[i] = 1;
-int[32] b = 10;
+b = 10;
 b = 15;
-float[64] c = 1.2;
+c = 1.2;
 c = 3.4;"""
     assert prog().to_ir() == expected
 
@@ -756,9 +763,10 @@ def test_classical_variables_assignment():
         a = b  # declared target, declared value # noqa: F841
 
     expected = """OPENQASM 3.0;
-int[32] a = 1;
-a = 2;
+int[32] a;
 int[32] b;
+a = 1;
+a = 2;
 b = a;
 a = b;"""
     assert prog().to_ir() == expected
@@ -771,12 +779,12 @@ def test_assignment_measurement_results():
         b = a  # noqa: F841
 
     expected = """OPENQASM 3.0;
+bit a;
+bit b;
 qubit[1] __qubits__;
 bit __bit_0__;
 __bit_0__ = measure __qubits__[0];
-bit a;
 a = __bit_0__;
-bit b;
 b = a;"""
     assert prog().to_ir() == expected
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -402,13 +402,13 @@ def qasm_inline_var_condition() -> aq.BitVar:
 def test_qasm_inline_var_condition() -> None:
     """Tests the QASM contents of qasm_inline_var_condition."""
     expected = """OPENQASM 3.0;
+bit __bit_0__ = 1;
+int[32] __int_1__ = 1;
 qubit[2] __qubits__;
 h __qubits__[0];
-bit __bit_0__ = 1;
 if (__bit_0__) {
     cnot __qubits__[0], __qubits__[1];
 }
-int[32] __int_1__ = 1;
 if (__int_1__) {
     x __qubits__[0];
 } else {

--- a/test/unit_tests/braket/experimental/autoqasm/test_converters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_converters.py
@@ -51,9 +51,11 @@ def test_assignment(program_ctx: ag_ctx.ControlStatusCtx) -> None:
 
     qasm = program_conversion_context.make_program().to_ir()
     expected_qasm = """OPENQASM 3.0;
-int[32] a = 5;
-float[64] b = 1.2;
-a = 1;
+int[32] a;
+float[64] b;
 int[32] e;
+a = 5;
+b = 1.2;
+a = 1;
 e = a;"""
     assert qasm == expected_qasm

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -93,9 +93,9 @@ def test_inline_conditional_assignment() -> None:
 int[32] __int_3__;
 int[32] __int_1__ = 2;
 int[32] __int_2__ = 3;
+bool __bool_0__ = true;
 int[32] __int_4__ = 4;
 int[32] a;
-bool __bool_0__ = true;
 if (__bool_0__) {
     __int_3__ = __int_1__ * __int_2__;
 } else {
@@ -161,8 +161,8 @@ def test_branch_assignment_declared() -> None:
 
     expected = """OPENQASM 3.0;
 int[32] a;
-a = 5;
 bool __bool_1__ = true;
+a = 5;
 if (__bool_1__) {
     a = 6;
 } else {

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -87,31 +87,40 @@ def test_inline_conditional_assignment() -> None:
 
     @aq.function
     def cond_exp_assignment():
-        a = aq.IntVar(2) * aq.IntVar(4) if aq.BoolVar(True) else aq.IntVar(2)  # noqa: F841
+        a = aq.IntVar(2) * aq.IntVar(3) if aq.BoolVar(True) else aq.IntVar(4)  # noqa: F841
 
     expected = """OPENQASM 3.0;
-int[32] __int_1__ = 2;
-int[32] __int_2__ = 4;
-int[32] __int_4__ = 2;
 int[32] __int_3__;
+int[32] __int_1__ = 2;
+int[32] __int_2__ = 3;
+int[32] __int_4__ = 4;
+int[32] a;
 bool __bool_0__ = true;
 if (__bool_0__) {
     __int_3__ = __int_1__ * __int_2__;
 } else {
     __int_3__ = __int_4__;
 }
-int[32] a;
 a = __int_3__;"""
 
     assert cond_exp_assignment().to_ir() == expected
 
 
-def test_unsupported_inline_conditional_assignment() -> None:
+@pytest.mark.parametrize(
+    "else_value",
+    [
+        lambda: aq.FloatVar(2),
+        lambda: aq.BoolVar(False),
+        lambda: aq.BitVar(0),
+        lambda: aq.ArrayVar(dimensions=[3]),
+    ],
+)
+def test_unsupported_inline_conditional_assignment(else_value) -> None:
     """Tests conditional expression where the if and else clauses return different types."""
 
     @aq.function
     def cond_exp_assignment_different_types():
-        a = aq.IntVar(1) if aq.BoolVar(True) else aq.FloatVar(2)  # noqa: F841
+        a = aq.IntVar(1) if aq.BoolVar(True) else else_value()  # noqa: F841
 
     with pytest.raises(UnsupportedConditionalExpressionError):
         cond_exp_assignment_different_types()
@@ -128,9 +137,9 @@ def test_branch_assignment_undeclared() -> None:
             a = aq.IntVar(2)  # noqa: F841
 
     expected = """OPENQASM 3.0;
-int[32] a = 0;
-bool __bool_1__ = true;
-if (__bool_1__) {
+int[32] a;
+bool __bool_0__ = true;
+if (__bool_0__) {
     a = 1;
 } else {
     a = 2;
@@ -151,7 +160,8 @@ def test_branch_assignment_declared() -> None:
             a = aq.IntVar(7)  # noqa: F841
 
     expected = """OPENQASM 3.0;
-int[32] a = 5;
+int[32] a;
+a = 5;
 bool __bool_1__ = true;
 if (__bool_1__) {
     a = 6;
@@ -438,8 +448,10 @@ def test_slice_bits() -> None:
         a[3] = b
 
     expected = """OPENQASM 3.0;
-bit[6] a = 0;
-bit b = 1;
+bit[6] a;
+bit b;
+a = 0;
+b = 1;
 a[3] = b;"""
 
     assert slice().to_ir() == expected
@@ -455,11 +467,13 @@ def test_slice_bits_w_measure() -> None:
         b0[3] = c
 
     expected = """OPENQASM 3.0;
-qubit[1] __qubits__;
 bit[10] b0;
+bit[10] __bit_0__;
+bit c;
+qubit[1] __qubits__;
+b0 = __bit_0__;
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];
-bit c;
 c = __bit_1__;
 b0[3] = c;"""
 
@@ -469,9 +483,9 @@ b0[3] = c;"""
 @pytest.mark.parametrize(
     "target_name,value,expected_qasm",
     [
-        ("foo", oqpy.IntVar(5), "\nint[32] foo = 5;"),
-        ("bar", oqpy.FloatVar(1.2), "\nfloat[64] bar = 1.2;"),
-        ("baz", oqpy.BitVar(0), "\nbit baz = 0;"),
+        ("foo", oqpy.IntVar(5), "\nint[32] foo;\nfoo = 5;"),
+        ("bar", oqpy.FloatVar(1.2), "\nfloat[64] bar;\nbar = 1.2;"),
+        ("baz", oqpy.BitVar(0), "\nbit baz;\nbaz = 0;"),
     ],
 )
 def test_assignment_qasm_undeclared_target(

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -595,10 +595,11 @@ def test_assignment_py(value: Any) -> None:
     Args:
         value (Any): Assignment value.
     """
-    new_value = aq.operators.assign_stmt(
-        target_name="foo",
-        value=value,
-    )
+    with aq.build_program():
+        new_value = aq.operators.assign_stmt(
+            target_name="foo",
+            value=value,
+        )
     assert new_value == value
 
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -19,6 +19,7 @@ import oqpy.base
 import pytest
 
 import braket.experimental.autoqasm as aq
+from braket.experimental.autoqasm.errors import UnsupportedConditionalExpressionError
 from braket.experimental.autoqasm.gates import cnot, h, measure, x
 
 
@@ -79,6 +80,62 @@ def test_conditional_expressions_py_cond(if_true: dict, if_false: dict) -> None:
     assert str(py_cond) not in qasm
     assert if_true["qasm"] in qasm
     assert if_false["qasm"] not in qasm
+
+
+def test_unsupported_conditional_assignment() -> None:
+    """Tests conditional expression where the result is assigned to a variable."""
+
+    @aq.function
+    def cond_exp_assignment():
+        a = aq.IntVar(1) if aq.BoolVar(True) else aq.IntVar(2)  # noqa: F841
+
+    with pytest.raises(UnsupportedConditionalExpressionError):
+        cond_exp_assignment()
+
+
+def test_branch_assignment_undeclared() -> None:
+    """Tests if-else branch where an undeclared variable is assigned in both branches."""
+
+    @aq.function
+    def branch_assignment_undeclared():
+        if aq.BoolVar(True):
+            a = aq.IntVar(1)  # noqa: F841
+        else:
+            a = aq.IntVar(2)  # noqa: F841
+
+    expected = """OPENQASM 3.0;
+int[32] a = 0;
+bool __bool_1__ = true;
+if (__bool_1__) {
+    a = 1;
+} else {
+    a = 2;
+}"""
+
+    assert branch_assignment_undeclared().to_ir() == expected
+
+
+def test_branch_assignment_declared() -> None:
+    """Tests if-else branch where a declared variable is assigned in both branches."""
+
+    @aq.function
+    def branch_assignment_declared():
+        a = aq.IntVar(5)
+        if aq.BoolVar(True):
+            a = aq.IntVar(6)  # noqa: F841
+        else:
+            a = aq.IntVar(7)  # noqa: F841
+
+    expected = """OPENQASM 3.0;
+int[32] a = 5;
+bool __bool_1__ = true;
+if (__bool_1__) {
+    a = 6;
+} else {
+    a = 7;
+}"""
+
+    assert branch_assignment_declared().to_ir() == expected
 
 
 def for_body(i: aq.QubitIdentifierType) -> None:

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -58,7 +58,8 @@ def test_return_bit():
 
     expected = """OPENQASM 3.0;
 def ret_test() -> bit {
-    bit res = 1;
+    bit res;
+    res = 1;
     return res;
 }
 bit __bit_1__;
@@ -81,7 +82,8 @@ def test_return_int():
 
     expected = """OPENQASM 3.0;
 def ret_test() -> int[32] {
-    int[32] res = 1;
+    int[32] res;
+    res = 1;
     return res;
 }
 int[32] __int_1__ = 0;
@@ -104,7 +106,8 @@ def test_return_float():
 
     expected = """OPENQASM 3.0;
 def ret_test() -> float[64] {
-    float[64] res = 1.0;
+    float[64] res;
+    res = 1.0;
     return res;
 }
 float[64] __float_1__ = 0.0;
@@ -127,7 +130,8 @@ def test_return_bool():
 
     expected = """OPENQASM 3.0;
 def ret_test() -> bool {
-    bool res = true;
+    bool res;
+    res = true;
     return res;
 }
 bool __bool_1__ = false;
@@ -153,8 +157,10 @@ def test_return_bin_expr():
 def add(int[32] a, int[32] b) -> int[32] {
     return a + b;
 }
-int[32] a = 5;
-int[32] b = 6;
+int[32] a;
+int[32] b;
+a = 5;
+b = 6;
 int[32] __int_2__ = 0;
 __int_2__ = add(a, b);"""
 
@@ -168,7 +174,9 @@ def test_return_none():
     def ret_test() -> None:
         return None
 
-    ret_test().to_ir()
+    expected = "OPENQASM 3.0;"
+
+    assert ret_test().to_ir() == expected
 
 
 def test_return_array():
@@ -185,7 +193,8 @@ def test_return_array():
 
     expected = """OPENQASM 3.0;
 def ret_test() -> array[int[32], 3] {
-    array[int[32], 3] res = {1, 2, 3};
+    array[int[32], 3] res;
+    res = {1, 2, 3};
     return res;
 }
 array[int[32], 3] __arr_1__ = {};
@@ -208,7 +217,8 @@ def test_return_func_call():
 
     expected = """OPENQASM 3.0;
 def helper() -> int[32] {
-    int[32] res = 1;
+    int[32] res;
+    res = 1;
     return res;
 }
 int[32] __int_1__ = 0;
@@ -289,7 +299,8 @@ def test_map_array():
     expected = """OPENQASM 3.0;
 def annotation_test(array[int[32], 10] input) {
 }
-array[int[32], 10] a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+array[int[32], 10] a;
+a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 annotation_test(a);"""
 
     assert main().to_ir() == expected
@@ -310,7 +321,8 @@ def test_map_other():
     expected = """OPENQASM 3.0;
 def annotation_test(bit input) {
 }
-bit a = 1;
+bit a;
+a = 1;
 annotation_test(a);"""
 
     assert main().to_ir() == expected
@@ -349,7 +361,8 @@ def test_unnamed_retval_python_type() -> None:
 
     expected_qasm = """OPENQASM 3.0;
 def retval_test() -> int[32] {
-    int[32] retval_ = 1;
+    int[32] retval_;
+    retval_ = 1;
     return retval_;
 }
 int[32] __int_1__ = 0;
@@ -371,7 +384,8 @@ def test_unnamed_retval_qasm_type() -> None:
 
     expected_qasm = """OPENQASM 3.0;
 def retval_test() -> bit {
-    bit retval_ = 1;
+    bit retval_;
+    retval_ = 1;
     return retval_;
 }
 bit __bit_1__;
@@ -390,14 +404,16 @@ def test_recursive_unassigned_retval_python_type() -> None:
 
     expected_qasm = """OPENQASM 3.0;
 def retval_recursive() -> int[32] {
+    int[32] retval_;
     int[32] __int_1__ = 0;
     __int_1__ = retval_recursive();
-    int[32] retval_ = 1;
+    retval_ = 1;
     return retval_;
 }
+int[32] retval_;
 int[32] __int_3__ = 0;
 __int_3__ = retval_recursive();
-int[32] retval_ = 1;"""
+retval_ = 1;"""
 
     assert retval_recursive().to_ir() == expected_qasm
 
@@ -412,18 +428,20 @@ def test_recursive_assigned_retval_python_type() -> None:
 
     expected_qasm = """OPENQASM 3.0;
 def retval_recursive() -> int[32] {
+    int[32] a;
+    int[32] retval_;
     int[32] __int_1__ = 0;
     __int_1__ = retval_recursive();
-    int[32] a;
     a = __int_1__;
-    int[32] retval_ = 1;
+    retval_ = 1;
     return retval_;
 }
+int[32] a;
+int[32] retval_;
 int[32] __int_3__ = 0;
 __int_3__ = retval_recursive();
-int[32] a;
 a = __int_3__;
-int[32] retval_ = 1;"""
+retval_ = 1;"""
 
     assert retval_recursive().to_ir() == expected_qasm
 
@@ -453,7 +471,8 @@ def retval_recursive() -> int[32] {
     return 2 * __int_1__ + (__int_3__ + 2) / 3;
 }
 def retval_constant() -> int[32] {
-    int[32] retval_ = 3;
+    int[32] retval_;
+    retval_ = 3;
     return retval_;
 }
 int[32] __int_4__ = 0;


### PR DESCRIPTION
*Issue #, if available:*
- [Branches/conditional expressions with variable assignment produce incorrect results
](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=32619400)

*Description of changes:*
- For conditional expressions, the `if_exp` operator needs to return the appropriate variable object. It also needs to validate that both the `if` and `else` expressions are of the same type.
- For branches (if-else blocks), manually calling `declare()` for assignment statements caused the variable to be defined inside the if-else block. Instead, we need to allow `oqpy` to automatically declare the variable, which will put it at the correct scope. Note that for subroutines, we now must call `autodeclare()` after executing the subroutine function so that `oqpy` will properly place any necessary variable declarations inside the subroutine.

*Testing done:*
- tox passes.
- Tests added for newly supported scenarios. Diff code coverage is 100%.
- Existing tests updated to pass. Note that many variable declarations have moved around a bit due to the changes in `assignments.py`. But the resulting programs are equivalent.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
