### PR TITLE
fix: Ensure AutoQASM bit registers are always properly initialized

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,6 +40,7 @@ jobs:
       # NOTE: Do not merge this part to main. The AutoQASM example notebooks should be moved
       # to the example notebooks repo rather than living in the Braket SDK repo.
       run: |
+        pip install notebook
         jupyter run ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
         jupyter run ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
         jupyter run ./examples/autoqasm/3_Iterative_phase_estimation.ipynb

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
       # NOTE: Do not merge this part to main. The AutoQASM example notebooks should be moved
       # to the example notebooks repo rather than living in the Braket SDK repo.
       run: |
-        pip install notebook
+        pip install notebook matplotlib
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/3_Iterative_phase_estimation.ipynb

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Run unit tests
       run: |
         tox -e unit-tests
+    - name: Run AutoQASM example notebooks
+      # NOTE: Do not merge this part to main. The AutoQASM example notebooks should be moved
+      # to the example notebooks repo rather than living in the Braket SDK repo.
+      run: |
+        jupyter run ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
+        jupyter run ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
+        jupyter run ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       if: ${{ strategy.job-index }} == 0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,9 +41,9 @@ jobs:
       # to the example notebooks repo rather than living in the Braket SDK repo.
       run: |
         pip install notebook
-        jupyter run ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
-        jupyter run ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
-        jupyter run ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
+        jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
+        jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
+        jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       if: ${{ strategy.job-index }} == 0

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 import oqpy
 import oqpy.base
+from openpulse import ast
 
 from braket.experimental.autoqasm import program
 
@@ -68,6 +69,9 @@ class BitVar(oqpy.BitVar):
     def __init__(self, *args, **kwargs):
         super(BitVar, self).__init__(*args, **kwargs)
         self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
+        if self.size:
+            value = self.init_expression or 0
+            self.init_expression = ast.BitstringLiteral(value, self.size)
 
 
 class BoolVar(oqpy.BoolVar):

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -729,23 +729,24 @@ for int i in [0:2] {
     assert bell_in_for_loop().to_ir() == expected
 
 
+@aq.function
+def classical_variables_types() -> None:
+    a = aq.BitVar(0)
+    a = aq.BitVar(1)  # noqa: F841
+
+    i = aq.IntVar(1)
+    a_array = aq.BitVar(size=2)
+    a_array[0] = aq.BitVar(0)
+    a_array[i] = aq.BitVar(1)
+
+    b = aq.IntVar(10)
+    b = aq.IntVar(15)  # noqa: F841
+
+    c = aq.FloatVar(1.2)
+    c = aq.FloatVar(3.4)  # noqa: F841
+
+
 def test_classical_variables_types():
-    @aq.function
-    def prog() -> None:
-        a = aq.BitVar(0)
-        a = aq.BitVar(1)  # noqa: F841
-
-        i = aq.IntVar(1)
-        a_array = aq.BitVar(size=2)
-        a_array[0] = aq.BitVar(0)
-        a_array[i] = aq.BitVar(1)
-
-        b = aq.IntVar(10)
-        b = aq.IntVar(15)  # noqa: F841
-
-        c = aq.FloatVar(1.2)
-        c = aq.FloatVar(3.4)  # noqa: F841
-
     expected = """OPENQASM 3.0;
 bit a;
 int[32] i;
@@ -762,7 +763,11 @@ b = 10;
 b = 15;
 c = 1.2;
 c = 3.4;"""
-    assert prog().to_ir() == expected
+    assert classical_variables_types().to_ir() == expected
+
+
+def test_sim_classical_variables_types():
+    _test_on_local_sim(classical_variables_types())
 
 
 def test_classical_variables_assignment():

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -207,17 +207,21 @@ bit[2] c;
 qubit[2] __qubits__;
 h __qubits__[0];
 cnot __qubits__[0], __qubits__[1];
-bit[2] __bit_0__;
+bit[2] __bit_0__ = "00";
 __bit_0__[0] = measure __qubits__[0];
 __bit_0__[1] = measure __qubits__[1];
 c = __bit_0__;"""
     assert bell_measurement_undeclared().to_ir() == expected
 
 
+def test_sim_bell_measurement_undeclared() -> None:
+    _test_on_local_sim(bell_measurement_undeclared())
+
+
 @aq.function
 def bell_measurement_declared() -> None:
     """A function that generates and measures a two-qubit Bell state."""
-    c = aq.BitVar([0, 0], size=2)
+    c = aq.BitVar(0, size=2)
     h(0)
     cnot(0, 1)
     c = measure([0, 1])  # noqa: F841
@@ -227,14 +231,18 @@ def test_bell_measurement_declared() -> None:
     expected = """OPENQASM 3.0;
 bit[2] c;
 qubit[2] __qubits__;
-c = {0, 0};
+c = "00";
 h __qubits__[0];
 cnot __qubits__[0], __qubits__[1];
-bit[2] __bit_1__;
+bit[2] __bit_1__ = "00";
 __bit_1__[0] = measure __qubits__[0];
 __bit_1__[1] = measure __qubits__[1];
 c = __bit_1__;"""
     assert bell_measurement_declared().to_ir() == expected
+
+
+def test_sim_bell_measurement_declared() -> None:
+    _test_on_local_sim(bell_measurement_declared())
 
 
 @aq.function
@@ -441,11 +449,15 @@ def test_simple_measurement() -> None:
     """Test that a program with only measurements is generated correctly."""
     expected = """OPENQASM 3.0;
 qubit[6] __qubits__;
-bit[3] __bit_0__;
+bit[3] __bit_0__ = "000";
 __bit_0__[0] = measure __qubits__[5];
 __bit_0__[1] = measure __qubits__[2];
 __bit_0__[2] = measure __qubits__[1];"""
     assert ground_state_measurements().to_ir() == expected
+
+
+def test_sim_simple_measurement() -> None:
+    _test_on_local_sim(ground_state_measurements())
 
 
 def test_simple_measurement_return() -> None:
@@ -459,7 +471,7 @@ def test_simple_measurement_return() -> None:
 
     expected = """OPENQASM 3.0;
 def ground_state_measurements() -> bit[3] {
-    bit[3] __bit_0__;
+    bit[3] __bit_0__ = "000";
     __bit_0__[0] = measure __qubits__[5];
     __bit_0__[1] = measure __qubits__[2];
     __bit_0__[2] = measure __qubits__[1];
@@ -738,13 +750,12 @@ def test_classical_variables_types():
 bit a;
 int[32] i;
 bit[2] a_array;
-bit[2] __bit_3__;
 int[32] b;
 float[64] c;
 a = 0;
 a = 1;
 i = 1;
-a_array = __bit_3__;
+a_array = "00";
 a_array[0] = 0;
 a_array[i] = 1;
 b = 10;

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -450,7 +450,7 @@ def test_slice_bits() -> None:
     expected = """OPENQASM 3.0;
 bit[6] a;
 bit b;
-a = 0;
+a = "000000";
 b = 1;
 a[3] = b;"""
 
@@ -468,10 +468,9 @@ def test_slice_bits_w_measure() -> None:
 
     expected = """OPENQASM 3.0;
 bit[10] b0;
-bit[10] __bit_0__;
 bit c;
 qubit[1] __qubits__;
-b0 = __bit_0__;
+b0 = "0000000000";
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];
 c = __bit_1__;

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,linters,docs,unit-tests
+envlist = clean,linters,docs,unit-tests,notebooks
 
 [testenv:clean]
 deps = coverage
@@ -26,6 +26,21 @@ passenv =
     BRAKET_ENDPOINT
 commands =
     pytest test/integ_tests {posargs}
+extras = test
+
+[testenv:notebooks]
+# NOTE: Do not merge this part to main. The AutoQASM example notebooks should be moved
+# to the example notebooks repo rather than living in the Braket SDK repo.
+usedevelop=True
+basepython = python3
+deps =
+    {[testenv:unit-tests]deps}
+    notebook
+    matplotlib
+commands =
+    jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
+    jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
+    jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
 extras = test
 
 [testenv:linters]


### PR DESCRIPTION
*Issue #, if available:*
- [IPE example notebook failure: "Identifier '`__bit_1__`' is not initialized."](https://github.com/orgs/amazon-braket/projects/2/views/6?pane=issue&itemId=34795314)

*Description of changes:*
- Ensure that `aq.BitVar` registers always have an appropriate `init_expression`.
- Add AutoQASM example notebooks to tox and CI pipeline to prevent future failures.

*Testing done:*
- Existing tests updated.
- Added tests to run a few relevant programs on LocalSimulator to ensure that these programs are syntactically correct. Verified that these new tests would have caught this bug prior to fixing it.
- Ensure that notebook validation is working in tox and CI pipeline.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
