### PR TITLE
fix: autoqasm api module code coverage to 100%

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -88,17 +88,11 @@ def _function_without_params(
     if is_autograph_artifact(f):
         return f
 
-    f_wrapper = f
-    decorators, f = tf_decorator.unwrap(f)
-
     wrapper_factory = _convert_wrapper(
         user_config=user_config,
         recursive=False,
     )
     wrapper = wrapper_factory(f)
-
-    if decorators:
-        wrapper = tf_decorator.rewrap(f_wrapper, f, wrapper)
 
     return autograph_artifact(wrapper)
 
@@ -357,10 +351,6 @@ def _add_qubit_declaration(program_conversion_context: aq_program.ProgramConvers
     """
     root_oqpy_program = program_conversion_context.oqpy_program_stack[0]
 
-    # Return early if the qubit register is already declared
-    if aq_constants.QUBIT_REGISTER in root_oqpy_program.declared_vars:
-        return
-
     # Declare the global qubit register if necessary
     user_specified_num_qubits = program_conversion_context.get_declared_qubits()
 
@@ -399,7 +389,7 @@ def _dummy_function(f_source: Callable) -> Callable:
     return_instance = _make_return_instance(f_source, aq_program.get_program_conversion_context())
 
     def f_dummy(*args, **kwargs) -> Any:
-        return return_instance
+        return return_instance  # pragma: no cover
 
     f_dummy.__name__ = copy.deepcopy(f_source.__name__)
     f_dummy.__defaults__ = copy.deepcopy(f_source.__defaults__)

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -39,6 +39,12 @@ def test_empty_function(empty_program) -> None:
     assert empty_program().to_ir() == expected
 
 
+def test_empty_function_double_wrapped(empty_program) -> None:
+    """Test that a double-wrapped function with no instructions generates an empty program."""
+    expected = """OPENQASM 3.0;"""
+    assert aq.function(empty_program)().to_ir() == expected
+
+
 def test_sim_empty(empty_program) -> None:
     """Test an empty subroutine on the local simulator."""
     _test_on_local_sim(empty_program())


### PR DESCRIPTION
*Issue #, if available:*
- [Code coverage: api (94%)](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=32618758)

*Description of changes:*
- Remove dead code.
- Add a test case for double-decorated functions.
- Ignore code coverage on one line which is actually called, but for some reason codecov doesn't detect it.

*Testing done:*
- tox and CI.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
