### PR TITLE
fix: assigning AutoQASM subroutine arg to a local variable

### DIFF
--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -22,6 +22,7 @@ import oqpy.base
 
 from braket.experimental.autoqasm import constants, program, types
 from braket.experimental.autoqasm.autograph.operators.variables import UndefinedReturnValue
+from braket.experimental.autoqasm.types.conversions import var_type_from_oqpy
 
 
 def assign_stmt(target_name: str, value: Any) -> Any:
@@ -109,7 +110,7 @@ def _validate_variables_type_size(var1: oqpy.base.Var, var2: oqpy.base.Var) -> N
     var1_size = var1.size or 1
     var2_size = var2.size or 1
 
-    if type(var1) != type(var2):
+    if var_type_from_oqpy(var1) != var_type_from_oqpy(var2):
         raise ValueError("Variables in assignment statements must have the same type")
     if var1_size != var2_size:
         raise ValueError("Variables in assignment statements must have the same size")

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -348,6 +348,32 @@ annotation_test(__bit_0__);"""
     assert main().to_ir() == expected
 
 
+def test_map_and_assign_arg():
+    """Test input parameter handling which is assigned to another variable."""
+
+    @aq.function
+    def assign_param(c: int) -> None:
+        d = aq.IntVar(4)
+        c = d  # noqa: F841
+
+    @aq.function
+    def main():
+        c = aq.IntVar(0)
+        assign_param(c)
+
+    expected = """OPENQASM 3.0;
+def assign_param(int[32] c) {
+    int[32] d;
+    d = 4;
+    c = d;
+}
+int[32] c;
+c = 0;
+assign_param(c);"""
+
+    assert main().to_ir() == expected
+
+
 def test_unnamed_retval_python_type() -> None:
     """Tests subroutines which return unnamed Python values."""
 


### PR DESCRIPTION
*Issue #, if available:*
- [incorrect assignment type check for subroutine input arg](https://github.com/orgs/amazon-braket/projects/2/views/6?pane=issue&itemId=34477183)

*Description of changes:*
- Convert the types of each variable before checking the types for equality.

*Testing done:*
- Added a test for the newly-working scenario.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
