### PR TITLE
Return type hint ignored when possible in favor of actual return type

### DIFF
--- a/src/braket/experimental/autoqasm/converters/break_statements.py
+++ b/src/braket/experimental/autoqasm/converters/break_statements.py
@@ -24,7 +24,7 @@ from braket.experimental.autoqasm.autograph.core import ag_ctx, converter
 class BreakValidator(converter.Base):
     def visit_Break(self, node: ast.stmt) -> ast.stmt:
         """Break statements are currently unsupported."""
-        raise errors.UnsupportedFeature("Break statements are currently unsupported.")
+        raise errors.UnsupportedFeatureError("Break statements are currently unsupported.")
 
 
 def transform(

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -21,7 +21,11 @@ class AutoQasmError(Exception):
     """Base class for all AutoQASM exceptions."""
 
 
-class UnsupportedFeature(AutoQasmError):
+class UnsupportedFeatureError(AutoQasmError):
+    """AutoQASM unsupported feature."""
+
+
+class ParameterTypeError(AutoQasmError):
     """AutoQASM unsupported feature."""
 
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -26,7 +26,7 @@ class UnsupportedFeatureError(AutoQasmError):
 
 
 class ParameterTypeError(AutoQasmError):
-    """AutoQASM unsupported feature."""
+    """AutoQASM parameter type error."""
 
 
 class MissingParameterTypeError(AutoQasmError):

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -46,16 +46,21 @@ def map_type(python_type: type) -> type:
     if issubclass(origin_type, list):
         if not type_args:
             raise errors.ParameterTypeError("Please supply a type argument to list.")
-        elif issubclass(type_args[0], (int, np.integer)):
-            # TODO: Update array length to match the input rather than hardcoding
-            # OQPY and QASM require arrays have a set length. python doesn't require this,
-            # so the length of the array is indeterminate.
-            # At this point we only have access to the _parameter_ (type hint), not the
-            # _argument_ (concrete value), which is the only place length information is stored
-            # Here's where the info is stored for oqpy variables:
-            # ctx = program.get_program_conversion_context()
-            # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
-            return oqpy.ArrayVar[oqpy.IntVar, 10]
+
+        item_type = map_type(type_args[0])
+        if not item_type == oqpy.IntVar:
+            raise errors.ParameterTypeError(
+                f"Unsupported array type: {item_type}. AutoQASM arrays only support ints."
+            )
+        # TODO: Update array length to match the input rather than hardcoding
+        # OQPY and QASM require arrays have a set length. python doesn't require this,
+        # so the length of the array is indeterminate.
+        # At this point we only have access to the _parameter_ (type hint), not the
+        # _argument_ (concrete value), which is the only place length information is stored
+        # Here's where the info is stored for oqpy variables:
+        # ctx = program.get_program_conversion_context()
+        # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
+        return oqpy.ArrayVar[oqpy.IntVar, 10]
     if issubclass(origin_type, tuple):
         raise TypeError(
             "Tuples are not supported as parameters to AutoQASM functions; "

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -48,10 +48,10 @@ def map_type(python_type: type) -> type:
             raise errors.ParameterTypeError("Please supply a type argument to list.")
         elif issubclass(type_args[0], (int, np.integer)):
             # TODO: Update array length to match the input rather than hardcoding
-            #       OQPY and QASM require arrays have a set length. python doesn't require this,
-            #       so the length of the array is indeterminate.
-            #       At this point we only have access to the _parameter_ (type hint), not the
-            #       _argument_ (concrete value), which is the only place length information is stored
+            # OQPY and QASM require arrays have a set length. python doesn't require this,
+            # so the length of the array is indeterminate.
+            # At this point we only have access to the _parameter_ (type hint), not the
+            # _argument_ (concrete value), which is the only place length information is stored
             # Here's where the info is stored for oqpy variables:
             # ctx = program.get_program_conversion_context()
             # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -21,6 +21,7 @@ import numpy as np
 import oqpy
 from openpulse import ast
 
+from braket.experimental.autoqasm import errors
 from braket.experimental.autoqasm import types as aq_types
 
 
@@ -42,16 +43,19 @@ def map_type(python_type: type) -> type:
         return oqpy.IntVar
     if issubclass(origin_type, (float, np.floating)):
         return oqpy.FloatVar
-    if issubclass(origin_type, list) and issubclass(type_args[0], (int, np.integer)):
-        # TODO: Update array length to match the input rather than hardcoding
-        #       OQPY and QASM require arrays have a set length. python doesn't require this,
-        #       so the length of the array is indeterminate.
-        #       At this point we only have access to the _parameter_ (type hint), not the
-        #       _argument_ (concrete value), which is the only place length information is stored
-        # Here's where the info is stored for oqpy variables:
-        # ctx = program.get_program_conversion_context()
-        # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
-        return oqpy.ArrayVar[oqpy.IntVar, 10]
+    if issubclass(origin_type, list):
+        if not type_args:
+            raise errors.ParameterTypeError("Please supply a type argument to list.")
+        elif issubclass(type_args[0], (int, np.integer)):
+            # TODO: Update array length to match the input rather than hardcoding
+            #       OQPY and QASM require arrays have a set length. python doesn't require this,
+            #       so the length of the array is indeterminate.
+            #       At this point we only have access to the _parameter_ (type hint), not the
+            #       _argument_ (concrete value), which is the only place length information is stored
+            # Here's where the info is stored for oqpy variables:
+            # ctx = program.get_program_conversion_context()
+            # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
+            return oqpy.ArrayVar[oqpy.IntVar, 10]
     if issubclass(origin_type, tuple):
         raise TypeError(
             "Tuples are not supported as parameters to AutoQASM functions; "
@@ -135,6 +139,12 @@ def _(node: Union[int, np.integer]):
 @wrap_value.register(np.floating)
 def _(node: Union[float, np.floating]):
     return aq_types.FloatVar(node)
+
+
+@wrap_value.register(list)
+def _(node: list):
+    # TODO: Update array length to match the input rather than hardcoding
+    return aq_types.ArrayVar(node, dimensions=[10])
 
 
 @wrap_value.register

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -382,7 +382,7 @@ def qasm_simple_condition(bool do_cnot) -> bool {
     return do_cnot;
 }
 qubit[2] __qubits__;
-bool __bool_0__ = false;
+bool __bool_0__;
 """
     expected += f"__bool_0__ = qasm_simple_condition({'true' if do_cnot else 'false'});"
     assert qasm_simple_condition_wrapper(do_cnot).to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_converters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_converters.py
@@ -68,7 +68,7 @@ def test_break_for_loop():
             aq.gates.h(i)
             break
 
-    with pytest.raises(aq.errors.UnsupportedFeature):
+    with pytest.raises(aq.errors.UnsupportedFeatureError):
         main()
 
 
@@ -79,5 +79,5 @@ def test_break_while_loop():
             aq.gates.x(0)
             break
 
-    with pytest.raises(aq.errors.UnsupportedFeature):
+    with pytest.raises(aq.errors.UnsupportedFeatureError):
         uses_while_w_break()

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -207,7 +207,7 @@ def test_return_python_array():
     """Test returning a python array."""
 
     @aq.function
-    def tester(arr: list[int]) -> list[int]:
+    def tester(arr: List[int]) -> List[int]:
         return [1, 2, 3]
 
     @aq.function(num_qubits=4)
@@ -564,7 +564,7 @@ def test_ignore_ret_typehint_bool():
     """Test type discovery of boolean return values."""
 
     @aq.function
-    def ret_test() -> list[int]:
+    def ret_test() -> List[int]:
         return True
 
     @aq.function
@@ -611,7 +611,7 @@ def test_param_array_list_missing_arg():
     """Test list parameter with missing type arg (list rather than list[int])."""
 
     @aq.function
-    def param_test(arr: list) -> int:
+    def param_test(arr: List) -> int:
         return 1
 
     @aq.function(num_qubits=4)

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -621,7 +621,7 @@ __bool_1__ = ret_test();"""
 
 
 def test_ignore_ret_typehint_list():
-    """Test type discovery of boolean return values."""
+    """Test type discovery of list return values."""
 
     @aq.function
     def ret_test() -> int:

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -607,6 +607,54 @@ __arr_1__ = ret_test();"""
     assert main().to_ir() == expected
 
 
+def test_ignore_missing_ret_typehint_list():
+    """Test type discovery of return types with no annotations."""
+
+    @aq.function
+    def ret_test():
+        return [1, 2, 3]
+
+    @aq.function(num_qubits=4)
+    def main():
+        ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> array[int[32], 10] {
+    array[int[32], 10] retval_;
+    retval_ = {1, 2, 3};
+    return retval_;
+}
+array[int[32], 10] __arr_1__ = {};
+qubit[4] __qubits__;
+__arr_1__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
+def test_ignore_missing_ret_typehint_float():
+    """Test type discovery of return types with no annotations."""
+
+    @aq.function
+    def ret_test():
+        return 1.2
+
+    @aq.function(num_qubits=4)
+    def main():
+        ret_test()
+
+    expected = """OPENQASM 3.0;
+def ret_test() -> float[64] {
+    float[64] retval_;
+    retval_ = 1.2;
+    return retval_;
+}
+qubit[4] __qubits__;
+float[64] __float_1__;
+__float_1__ = ret_test();"""
+
+    assert main().to_ir() == expected
+
+
 def test_param_array_list_missing_arg():
     """Test list parameter with missing type arg (list rather than list[int])."""
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 - rename `UnsupportedFeature` -> `UnsupportedFeatureError`
 - Use actual return variable to set return type, except for recursive functions (task created: https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=35482594)
 - better error message if user supplies `list` instead of `list[type]` for parameter type hint
 - follow up task: https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=35482594

*Testing done:*

unit tests

### TODO
 - [ ] Fix coverage

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
