### PR TITLE
Improve error message for tuple parameters

### DIFF
--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -52,6 +52,8 @@ def map_type(python_type: type) -> type:
         # ctx = program.get_program_conversion_context()
         # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
         return oqpy.ArrayVar[oqpy.IntVar, 10]
+    if issubclass(origin_type, tuple):
+        raise TypeError('Tuple parameter types are not supported; please use "list" instead.')
 
     # TODO add all supported types
     return python_type

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -53,7 +53,10 @@ def map_type(python_type: type) -> type:
         # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
         return oqpy.ArrayVar[oqpy.IntVar, 10]
     if issubclass(origin_type, tuple):
-        raise TypeError('Tuples are not supported as parameters to AutoQASM functions; please separate the tuple into multiple parameters or use a list instead.')
+        raise TypeError(
+            "Tuples are not supported as parameters to AutoQASM functions; "
+            "please separate the tuple into multiple parameters or use a list instead."
+        )
 
     # TODO add all supported types
     return python_type

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -53,7 +53,7 @@ def map_type(python_type: type) -> type:
         # dims = ctx.get_oqpy_program().declared_vars[name_of_var].dimensions
         return oqpy.ArrayVar[oqpy.IntVar, 10]
     if issubclass(origin_type, tuple):
-        raise TypeError('Tuple parameter types are not supported; please use "list" instead.')
+        raise TypeError('Tuples are not supported as parameters to AutoQASM functions; please separate the tuple into multiple parameters or use a list instead.')
 
     # TODO add all supported types
     return python_type

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -505,3 +505,18 @@ int[32] __int_4__ = 0;
 __int_4__ = retval_recursive();"""
 
     assert caller().to_ir() == expected_qasm
+
+
+def test_error_for_tuple_param() -> None:
+    """Tuples are not supported as parameters."""
+
+    @aq.function
+    def param_test(input: Tuple):
+        pass
+
+    @aq.function
+    def main():
+        param_test(aq.BitVar(1))
+
+    with pytest.raises(TypeError):
+        main()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
  - previous error message: `TypeError: tuple() takes no keyword arguments`
  - new error message: `Tuple parameter types are not supported; please use "list" instead.`

*Testing done:*
new test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
