### PR TITLE
Add error for missing parameter type hints

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -433,6 +433,12 @@ def _wrap_for_oqpy_subroutine(f: Callable, options: converter.ConversionOptions)
 
     new_params = [first_param]
     for param in sig.parameters.values():
+        if param.annotation is param.empty:
+            raise errors.MissingParameterTypeError(
+                f'Parameter "{param.name}" for subroutine "{_func.__name__}" '
+                "is missing a required type hint."
+            )
+
         new_param = inspect.Parameter(
             name=param.name, kind=param.kind, annotation=aq_types.map_type(param.annotation)
         )

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -25,6 +25,10 @@ class UnsupportedFeature(AutoQasmError):
     """AutoQASM unsupported feature."""
 
 
+class MissingParameterTypeError(AutoQasmError):
+    """AutoQASM requires type hints for subroutine parameters."""
+
+
 class UnknownQubitCountError(AutoQasmError):
     """Missing declaration for the number of qubits."""
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -520,3 +520,18 @@ def test_error_for_tuple_param() -> None:
 
     with pytest.raises(TypeError):
         main()
+
+
+def test_error_for_missing_param_type() -> None:
+    """Parameters require type hints."""
+
+    @aq.function
+    def param_test(input):
+        pass
+
+    @aq.function
+    def main():
+        param_test(aq.BitVar(1))
+
+    with pytest.raises(aq.errors.MissingParameterTypeError):
+        main()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, we got a very unhelpful message if a parameter was missing a type hint, because we were mistakenly adding 
(empty) annotations to parameters that were not annotated. This prevented us from getting the nice OQPY error message, but rather than handle empty annotations (that are invalid anyway), raise our own error.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
