### PR TITLE
[autoqasm] aliasing Verbatim class

### DIFF
--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -42,7 +42,7 @@ The Python code above outputs the following OpenQASM program:
 
 from .api import function  # noqa: F401
 from .gates import QubitIdentifierType  # noqa: F401
-from .program import Program, Verbatim, build_program  # noqa: F401
+from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401
 from .types import ArrayVar, BitVar, BoolVar, FloatVar, IntVar  # noqa: F401
 from .types import qasm_range as range  # noqa: F401

--- a/src/braket/experimental/autoqasm/program/__init__.py
+++ b/src/braket/experimental/autoqasm/program/__init__.py
@@ -15,7 +15,7 @@
 for AutoQASM.
 """
 
-from .pragmas import Verbatim  # noqa: F401
+from .pragmas import Verbatim as verbatim  # noqa: F401
 from .program import (  # noqa: F401
     Program,
     ProgramConversionContext,

--- a/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
@@ -24,7 +24,7 @@ def test_with_verbatim_box() -> None:
     def program_func() -> None:
         """User program to test."""
         h(0)
-        with aq.Verbatim():
+        with aq.verbatim():
             cnot(1, 2)
 
     expected = """OPENQASM 3.0;


### PR DESCRIPTION
*Description of changes:*
Aliasing `Verbatim()` so that it is accessible at the top level as `aq.verbatim()`.

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
