### PR TITLE
update: restricting parameter names to not collide with ones we use for OpenQASM generation.

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1195,7 +1195,7 @@ class Circuit:
             )
             for idx, qubit in enumerate(qubits):
                 qubit_target = serialization_properties.format_target(int(qubit))
-                ir_instructions.append(f"b[{idx}] = measure {qubit_target};")
+                ir_instructions.append(f"__bits__[{idx}] = measure {qubit_target};")
 
         return OpenQasmProgram.construct(source="\n".join(ir_instructions), inputs={})
 
@@ -1206,11 +1206,11 @@ class Circuit:
         for parameter in self.parameters:
             ir_instructions.append(f"input float {parameter};")
         if not self.result_types:
-            ir_instructions.append(f"bit[{self.qubit_count}] b;")
+            ir_instructions.append(f"bit[{self.qubit_count}] __bits__;")
 
         if serialization_properties.qubit_reference_type == QubitReferenceType.VIRTUAL:
             total_qubits = max(self.qubits).real + 1
-            ir_instructions.append(f"qubit[{total_qubits}] q;")
+            ir_instructions.append(f"qubit[{total_qubits}] __qubits__;")
         elif serialization_properties.qubit_reference_type != QubitReferenceType.PHYSICAL:
             raise ValueError(
                 f"Invalid qubit_reference_type "

--- a/src/braket/circuits/serialization.py
+++ b/src/braket/circuits/serialization.py
@@ -39,7 +39,7 @@ class OpenQASMSerializationProperties:
     Properties for serializing a circuit to OpenQASM.
 
     qubit_reference_type (QubitReferenceType): determines whether to use
-        logical qubits or physical qubits (q[i] vs $i).
+        logical qubits or physical qubits (__qubits__[i] vs $i).
     """
 
     qubit_reference_type: QubitReferenceType = QubitReferenceType.VIRTUAL
@@ -53,7 +53,7 @@ class OpenQASMSerializationProperties:
             str: The OpenQASM representation of the target qubit.
         """
         qubit_reference_format = (
-            "q[{}]" if self.qubit_reference_type == QubitReferenceType.VIRTUAL else "${}"
+            "__qubits__[{}]" if self.qubit_reference_type == QubitReferenceType.VIRTUAL else "${}"
         )
         return qubit_reference_format.format(target)
 

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -47,12 +47,12 @@ class FreeParameter(FreeParameterExpression):
             name (str): Name of the :class:'FreeParameter'. Must begin with a letter [A-Za-z],
                 an underscore or an element from the Unicode character categories Lu/Ll/Lt/Lm/Lo/Nl.
                 Must not begin with two underscores '__'. May contain numbers [0-9] after the
-                first characeter.
+                first character.
 
         Examples:
             >>> param1 = FreeParameter("theta")
             >>> param1 = FreeParameter("\u03B8")
-            >>> param1 = FreeParameter("a1")
+            >>> param1 = FreeParameter("a1b2")
         """
         FreeParameter._validate_name(name)
         self._name = Symbol(name)

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from numbers import Number
 from typing import Dict, Union
-from unicodedata import category
 
 from sympy import Symbol
 
@@ -44,15 +43,12 @@ class FreeParameter(FreeParameterExpression):
         Initializes a new :class:'FreeParameter' object.
 
         Args:
-            name (str): Name of the :class:'FreeParameter'. Must begin with a letter [A-Za-z],
-                an underscore or an element from the Unicode character categories Lu/Ll/Lt/Lm/Lo/Nl.
-                Must not begin with two underscores '__'. May contain numbers [0-9] after the
-                first character.
+            name (str): Name of the :class:'FreeParameter'. Can be a unicode value.
+                Must not start with '__'.
 
         Examples:
             >>> param1 = FreeParameter("theta")
             >>> param1 = FreeParameter("\u03B8")
-            >>> param1 = FreeParameter("a1b2Ï")
         """
         FreeParameter._validate_name(name)
         self._name = Symbol(name)
@@ -111,13 +107,8 @@ class FreeParameter(FreeParameterExpression):
             raise ValueError("FreeParameter names must be non empty")
         if not isinstance(name, str):
             raise TypeError("FreeParameter name must be a string")
-        if name.startswith("_"):
-            if name.startswith("__"):
-                raise ValueError("FreeParameter names must not start with two underscores '__'")
-        else:
-            uni_category = category(name[0])
-            if not uni_category or (not uni_category.startswith("L") and uni_category != "Nl"):
-                raise ValueError("FreeParameter names must start with a letter or underscore")
+        if name.startswith("__"):
+            raise ValueError("FreeParameter names must not start with two underscores '__'")
 
     @classmethod
     def from_dict(cls, parameter: dict) -> FreeParameter:

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -115,10 +115,8 @@ class FreeParameter(FreeParameterExpression):
             if name.startswith("__"):
                 raise ValueError("FreeParameter names must not start with two underscores '__'")
         else:
-            unicode_category = category(name[0])
-            if not unicode_category:
-                raise ValueError("FreeParameter names must start with a valid character")
-            if not unicode_category.startswith("L") and unicode_category != "Nl":
+            uni_category = category(name[0])
+            if not uni_category or (not uni_category.startswith("L") and uni_category != "Nl"):
                 raise ValueError("FreeParameter names must start with a letter or underscore")
 
     @classmethod

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -50,8 +50,7 @@ class FreeParameter(FreeParameterExpression):
             >>> param1 = FreeParameter("theta")
             >>> param1 = FreeParameter("\u03B8")
         """
-        FreeParameter._validate_name(name)
-        self._name = Symbol(name)
+        self._set_name(name)
         super().__init__(expression=self._name)
 
     @property
@@ -100,6 +99,10 @@ class FreeParameter(FreeParameterExpression):
             "__class__": self.__class__.__name__,
             "name": self.name,
         }
+
+    def _set_name(self, name: str) -> None:
+        FreeParameter._validate_name(name)
+        self._name = Symbol(name)
 
     @staticmethod
     def _validate_name(name: str) -> None:

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -13,10 +13,9 @@
 
 from __future__ import annotations
 
-from unicodedata import category
-
 from numbers import Number
 from typing import Dict, Union
+from unicodedata import category
 
 from sympy import Symbol
 
@@ -45,7 +44,9 @@ class FreeParameter(FreeParameterExpression):
         Initializes a new :class:'FreeParameter' object.
 
         Args:
-            name (str): Name of the :class:'FreeParameter'. Can be a unicode value.
+            name (str): Name of the :class:'FreeParameter'. Must begin with a letter [A-Za-z],
+                an underscore or an element from the Unicode character categories Lu/Ll/Lt/Lm/Lo/Nl.
+                May not begin with two underscores '__'.
 
         Examples:
             >>> param1 = FreeParameter("theta")
@@ -103,15 +104,20 @@ class FreeParameter(FreeParameterExpression):
         }
 
     @staticmethod
-    def _validate_name(name):
+    def _validate_name(name: str) -> None:
         if not name:
             raise ValueError("Symbol names must be non empty")
-        unicode_category = category(name[0])
-        if not unicode_category:
-            raise ValueError("Symbol names must start with a valid character")
-        if not unicode_category.startswith("L") and unicode_category != "Nl":
-            raise ValueError("Symbol names must start with a letter")
-
+        if not isinstance(name, str):
+            raise TypeError("Symbol name must be a string")
+        if name.startswith("_"):
+            if name.startswith("__"):
+                raise ValueError("Symbol names must not start with two underscores '__'")
+        else:
+            unicode_category = category(name[0])
+            if not unicode_category:
+                raise ValueError("Symbol names must start with a valid character")
+            if not unicode_category.startswith("L") and unicode_category != "Nl":
+                raise ValueError("Symbol names must start with a letter or underscore")
 
     @classmethod
     def from_dict(cls, parameter: dict) -> FreeParameter:

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -13,6 +13,8 @@
 
 from __future__ import annotations
 
+from unicodedata import category
+
 from numbers import Number
 from typing import Dict, Union
 
@@ -49,6 +51,7 @@ class FreeParameter(FreeParameterExpression):
             >>> param1 = FreeParameter("theta")
             >>> param1 = FreeParameter("\u03B8")
         """
+        FreeParameter._validate_name(name)
         self._name = Symbol(name)
         super().__init__(expression=self._name)
 
@@ -98,6 +101,17 @@ class FreeParameter(FreeParameterExpression):
             "__class__": self.__class__.__name__,
             "name": self.name,
         }
+
+    @staticmethod
+    def _validate_name(name):
+        if not name:
+            raise ValueError("Symbol names must be non empty")
+        unicode_category = category(name[0])
+        if not unicode_category:
+            raise ValueError("Symbol names must start with a valid character")
+        if not unicode_category.startswith("L") and unicode_category != "Nl":
+            raise ValueError("Symbol names must start with a letter")
+
 
     @classmethod
     def from_dict(cls, parameter: dict) -> FreeParameter:

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -52,7 +52,7 @@ class FreeParameter(FreeParameterExpression):
         Examples:
             >>> param1 = FreeParameter("theta")
             >>> param1 = FreeParameter("\u03B8")
-            >>> param1 = FreeParameter("a1b2")
+            >>> param1 = FreeParameter("a1b2Ï")
         """
         FreeParameter._validate_name(name)
         self._name = Symbol(name)
@@ -108,18 +108,18 @@ class FreeParameter(FreeParameterExpression):
     @staticmethod
     def _validate_name(name: str) -> None:
         if not name:
-            raise ValueError("Symbol names must be non empty")
+            raise ValueError("FreeParameter names must be non empty")
         if not isinstance(name, str):
-            raise TypeError("Symbol name must be a string")
+            raise TypeError("FreeParameter name must be a string")
         if name.startswith("_"):
             if name.startswith("__"):
-                raise ValueError("Symbol names must not start with two underscores '__'")
+                raise ValueError("FreeParameter names must not start with two underscores '__'")
         else:
             unicode_category = category(name[0])
             if not unicode_category:
-                raise ValueError("Symbol names must start with a valid character")
+                raise ValueError("FreeParameter names must start with a valid character")
             if not unicode_category.startswith("L") and unicode_category != "Nl":
-                raise ValueError("Symbol names must start with a letter or underscore")
+                raise ValueError("FreeParameter names must start with a letter or underscore")
 
     @classmethod
     def from_dict(cls, parameter: dict) -> FreeParameter:

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -109,7 +109,7 @@ class FreeParameter(FreeParameterExpression):
         if not name:
             raise ValueError("FreeParameter names must be non empty")
         if not isinstance(name, str):
-            raise TypeError("FreeParameter name must be a string")
+            raise TypeError("FreeParameter names must be strings")
         if name.startswith("__"):
             raise ValueError("FreeParameter names must not start with two underscores '__'")
 

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -46,11 +46,13 @@ class FreeParameter(FreeParameterExpression):
         Args:
             name (str): Name of the :class:'FreeParameter'. Must begin with a letter [A-Za-z],
                 an underscore or an element from the Unicode character categories Lu/Ll/Lt/Lm/Lo/Nl.
-                May not begin with two underscores '__'.
+                Must not begin with two underscores '__'. May contain numbers [0-9] after the
+                first characeter.
 
         Examples:
             >>> param1 = FreeParameter("theta")
             >>> param1 = FreeParameter("\u03B8")
+            >>> param1 = FreeParameter("a1")
         """
         FreeParameter._validate_name(name)
         self._name = Symbol(name)

--- a/src/braket/pulse/ast/qasm_transformer.py
+++ b/src/braket/pulse/ast/qasm_transformer.py
@@ -43,8 +43,8 @@ class _IRQASMTransformer(QASMTransformer):
         ):
             # For capture_v0 nodes, it replaces it with classical assignment statements
             # of the form:
-            # b[0] = capture_v0(...)
-            # b[1] = capture_v0(...)
+            # __bits__[0] = capture_v0(...)
+            # __bits__[1] = capture_v0(...)
             new_val = ast.ClassicalAssignment(
                 # Ideally should use IndexedIdentifier here, but this works since it is just
                 # for printing.

--- a/test/integ_tests/test_adjoint_gradient.py
+++ b/test/integ_tests/test_adjoint_gradient.py
@@ -42,10 +42,10 @@ def test_adjoint_gradient_quantum_task_with_nested_targets(
     expected_openqasm = (
         "OPENQASM 3.0;\n"
         "input float theta;\n"
-        "qubit[4] q;\n"
-        "rx(theta) q[0];\n"
-        "#pragma braket result adjoint_gradient expectation(-6 * y(q[0]) @ i(q[1]) + 0.75 * "
-        "y(q[2]) @ z(q[3])) theta"
+        "qubit[4] __qubits__;\n"
+        "rx(theta) __qubits__[0];\n"
+        "#pragma braket result adjoint_gradient expectation(-6 * "
+        "y(__qubits__[0]) @ i(__qubits__[1]) + 0.75 * y(__qubits__[2]) @ z(__qubits__[3])) theta"
     )
 
     gradient_task = AwsQuantumTask.create(
@@ -83,10 +83,10 @@ def test_adjoint_gradient_with_standard_observable_terms(
     expected_openqasm = (
         "OPENQASM 3.0;\n"
         "input float theta;\n"
-        "qubit[3] q;\n"
-        "rx(theta) q[0];\n"
-        "#pragma braket result adjoint_gradient expectation(2 * x(q[0]) + 3 * y(q[1]) "
-        "- 1 * z(q[2])) theta"
+        "qubit[3] __qubits__;\n"
+        "rx(theta) __qubits__[0];\n"
+        "#pragma braket result adjoint_gradient expectation(2 * "
+        "x(__qubits__[0]) + 3 * y(__qubits__[1]) - 1 * z(__qubits__[2])) theta"
     )
 
     gradient_task = AwsQuantumTask.create(
@@ -132,17 +132,19 @@ def test_adjoint_gradient_with_batch_circuits(aws_session, s3_destination_folder
         (
             "OPENQASM 3.0;\n"
             "input float theta;\n"
-            "qubit[2] q;\n"
-            "rx(theta) q[0];\n"
-            "#pragma braket result adjoint_gradient expectation(6 * y(q[0]) @ i(q[1])) theta"
+            "qubit[2] __qubits__;\n"
+            "rx(theta) __qubits__[0];\n"
+            "#pragma braket result adjoint_gradient expectation(6 *"
+            " y(__qubits__[0]) @ i(__qubits__[1])) theta"
         ),
         (
             "OPENQASM 3.0;\n"
             "input float theta;\n"
-            "qubit[2] q;\n"
-            "rx(theta) q[0];\n"
-            "#pragma braket result adjoint_gradient expectation(-6 * y(q[0]) @ i(q[1]) + 0.75 * "
-            "y(q[0]) @ z(q[1])) theta"
+            "qubit[2] __qubits__;\n"
+            "rx(theta) __qubits__[0];\n"
+            "#pragma braket result adjoint_gradient expectation(-6 *"
+            " y(__qubits__[0]) @ i(__qubits__[1]) + 0.75 *"
+            " y(__qubits__[0]) @ z(__qubits__[1])) theta"
         ),
     ]
 

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -573,12 +573,12 @@ def test_create_pulse_gate_circuit(
     expected_openqasm = "\n".join(
         (
             "OPENQASM 3.0;",
-            "bit[2] b;",
+            "bit[2] __bits__;",
             "cal {",
             "    set_frequency(predefined_frame_1, 6000000.0);",
             "}",
-            "b[0] = measure $0;",
-            "b[1] = measure $1;",
+            "__bits__[0] = measure $0;",
+            "__bits__[1] = measure $1;",
         )
     )
 

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -852,11 +852,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "negctrl @ h q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "negctrl @ h __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -868,11 +868,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "cnot q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "cnot __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -884,11 +884,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "negctrl @ x q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "negctrl @ x __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -900,11 +900,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "ctrl @ rx(0.15) q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "ctrl @ rx(0.15) __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -916,11 +916,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "ctrl @ ry(0.2) q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "ctrl @ ry(0.2) __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -932,11 +932,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "negctrl @ rz(0.25) q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "negctrl @ rz(0.25) __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -948,11 +948,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "negctrl @ s q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "negctrl @ s __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -964,11 +964,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "negctrl @ t q[0], q[1];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "negctrl @ t __qubits__[0], __qubits__[1];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -980,11 +980,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "cphaseshift(0.15) q[1], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "cphaseshift(0.15) __qubits__[1], __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -996,12 +996,12 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[3] b;",
-                        "qubit[3] q;",
-                        "ccnot q[0], q[1], q[2];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
-                        "b[2] = measure q[2];",
+                        "bit[3] __bits__;",
+                        "qubit[3] __qubits__;",
+                        "ccnot __qubits__[0], __qubits__[1], __qubits__[2];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
+                        "__bits__[2] = measure __qubits__[2];",
                     ]
                 ),
                 inputs={},
@@ -1013,8 +1013,8 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[1] q;",
-                        "h q[0];",
+                        "qubit[1] __qubits__;",
+                        "h __qubits__[0];",
                         "#pragma braket result state_vector",
                     ]
                 ),
@@ -1027,9 +1027,9 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[1] q;",
-                        "h q[0];",
-                        "#pragma braket result expectation x(q[0])",
+                        "qubit[1] __qubits__;",
+                        "h __qubits__[0];",
+                        "#pragma braket result expectation x(__qubits__[0])",
                     ]
                 ),
                 inputs={},
@@ -1041,9 +1041,9 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[2] q;",
-                        "h q[0];",
-                        "#pragma braket result expectation h(q[0]) @ x(q[1])",
+                        "qubit[2] __qubits__;",
+                        "h __qubits__[0];",
+                        "#pragma braket result expectation h(__qubits__[0]) @ x(__qubits__[1])",
                     ]
                 ),
                 inputs={},
@@ -1055,9 +1055,9 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[2] q;",
-                        "h q[0];",
-                        "#pragma braket result variance h(q[0]) @ x(q[1])",
+                        "qubit[2] __qubits__;",
+                        "h __qubits__[0];",
+                        "#pragma braket result variance h(__qubits__[0]) @ x(__qubits__[1])",
                     ]
                 ),
                 inputs={},
@@ -1069,9 +1069,9 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[1] q;",
-                        "h q[0];",
-                        "#pragma braket result probability q[0]",
+                        "qubit[1] __qubits__;",
+                        "h __qubits__[0];",
+                        "#pragma braket result probability __qubits__[0]",
                     ]
                 ),
                 inputs={},
@@ -1083,10 +1083,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise bit_flip(0.1) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise bit_flip(0.1) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1098,10 +1098,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise generalized_amplitude_damping(0.1, 0.1) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise generalized_amplitude_damping(0.1, 0.1) __qubits__[0]",  # noqa
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1113,10 +1113,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise phase_flip(0.2) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise phase_flip(0.2) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1128,10 +1128,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise depolarizing(0.5) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise depolarizing(0.5) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1143,10 +1143,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise amplitude_damping(0.8) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise amplitude_damping(0.8) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1158,10 +1158,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise phase_damping(0.1) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise phase_damping(0.1) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1173,8 +1173,8 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[1] q;",
-                        "h q[0];",
+                        "qubit[1] __qubits__;",
+                        "h __qubits__[0];",
                         '#pragma braket result amplitude "0", "1"',
                     ]
                 ),
@@ -1190,16 +1190,16 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[5] b;",
-                        "qubit[5] q;",
-                        "negctrl @ rx(0.15) q[2], q[0];",
-                        "ctrl(2) @ rx(0.3) q[2], q[3], q[1];",
-                        "ctrl(2) @ cnot q[2], q[3], q[4], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
-                        "b[2] = measure q[2];",
-                        "b[3] = measure q[3];",
-                        "b[4] = measure q[4];",
+                        "bit[5] __bits__;",
+                        "qubit[5] __qubits__;",
+                        "negctrl @ rx(0.15) __qubits__[2], __qubits__[0];",
+                        "ctrl(2) @ rx(0.3) __qubits__[2], __qubits__[3], __qubits__[1];",
+                        "ctrl(2) @ cnot __qubits__[2], __qubits__[3], __qubits__[4], __qubits__[0];",  # noqa
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
+                        "__bits__[2] = measure __qubits__[2];",
+                        "__bits__[3] = measure __qubits__[3];",
+                        "__bits__[4] = measure __qubits__[4];",
                     ]
                 ),
                 inputs={},
@@ -1211,18 +1211,18 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[7] b;",
-                        "qubit[7] q;",
-                        "cnot q[0], q[1];",
-                        "cnot q[3], q[2];",
-                        "ctrl @ cnot q[5], q[6], q[4];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
-                        "b[2] = measure q[2];",
-                        "b[3] = measure q[3];",
-                        "b[4] = measure q[4];",
-                        "b[5] = measure q[5];",
-                        "b[6] = measure q[6];",
+                        "bit[7] __bits__;",
+                        "qubit[7] __qubits__;",
+                        "cnot __qubits__[0], __qubits__[1];",
+                        "cnot __qubits__[3], __qubits__[2];",
+                        "ctrl @ cnot __qubits__[5], __qubits__[6], __qubits__[4];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
+                        "__bits__[2] = measure __qubits__[2];",
+                        "__bits__[3] = measure __qubits__[3];",
+                        "__bits__[4] = measure __qubits__[4];",
+                        "__bits__[5] = measure __qubits__[5];",
+                        "__bits__[6] = measure __qubits__[6];",
                     ]
                 ),
                 inputs={},
@@ -1234,11 +1234,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "inv @ pow(2.5) @ h q[0];",
-                        "pow(0) @ h q[0];",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "inv @ pow(2.5) @ h __qubits__[0];",
+                        "pow(0) @ h __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1250,10 +1250,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket unitary([[0, 1.0], [1.0, 0]]) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket unitary([[0, 1.0], [1.0, 0]]) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1265,10 +1265,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "#pragma braket noise pauli_channel(0.1, 0.2, 0.3) q[0]",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "#pragma braket noise pauli_channel(0.1, 0.2, 0.3) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1280,11 +1280,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "#pragma braket noise two_qubit_depolarizing(0.1) q[0], q[1]",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "#pragma braket noise two_qubit_depolarizing(0.1) __qubits__[0], __qubits__[1]",  # noqa
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1296,11 +1296,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "#pragma braket noise two_qubit_dephasing(0.1) q[0], q[1]",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "#pragma braket noise two_qubit_dephasing(0.1) __qubits__[0], __qubits__[1]",  # noqa
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1312,11 +1312,11 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "#pragma braket noise two_qubit_dephasing(0.1) q[0], q[1]",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "#pragma braket noise two_qubit_dephasing(0.1) __qubits__[0], __qubits__[1]",  # noqa
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1328,9 +1328,9 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[1] q;",
-                        "h q[0];",
-                        "#pragma braket result sample z(q[0])",
+                        "qubit[1] __qubits__;",
+                        "h __qubits__[0];",
+                        "#pragma braket result sample z(__qubits__[0])",
                     ]
                 ),
                 inputs={},
@@ -1342,9 +1342,9 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[1] q;",
-                        "h q[0];",
-                        "#pragma braket result sample z(q[0])",
+                        "qubit[1] __qubits__;",
+                        "h __qubits__[0];",
+                        "#pragma braket result sample z(__qubits__[0])",
                     ]
                 ),
                 inputs={},
@@ -1356,10 +1356,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[2] q;",
-                        "h q[0];",
-                        "x q[1];",
-                        "#pragma braket result density_matrix q[0], q[1]",
+                        "qubit[2] __qubits__;",
+                        "h __qubits__[0];",
+                        "x __qubits__[1];",
+                        "#pragma braket result density_matrix __qubits__[0], __qubits__[1]",
                     ]
                 ),
                 inputs={},
@@ -1377,12 +1377,12 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
                         "#pragma braket noise "
                         "kraus([[0.9486833im, 0], [0, 0.9486833im]], [[0, 0.31622777], "
-                        "[0.31622777, 0]]) q[0]",
-                        "b[0] = measure q[0];",
+                        "[0.31622777, 0]]) __qubits__[0]",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1395,10 +1395,10 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
                     [
                         "OPENQASM 3.0;",
                         "input float theta;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "rx(theta) q[0];",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "rx(theta) __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1421,15 +1421,15 @@ def test_circuit_from_ir(expected_circuit, ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
                         "gate my_gate a,b {",
                         "h a;",
                         "cnot a,b;",
                         "}",
-                        "my_gate q[0], q[1];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "my_gate __qubits__[0], __qubits__[1];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1441,15 +1441,15 @@ def test_circuit_from_ir(expected_circuit, ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
                         "def my_sub(qubit q) {",
                         "h q;",
                         "}",
-                        "h q[0];",
-                        "my_sub(q[1]);",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "h __qubits__[0];",
+                        "my_sub(__qubits__[1]);",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1461,14 +1461,14 @@ def test_circuit_from_ir(expected_circuit, ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
                         "for uint i in [0:1] {",
-                        "h q[i];",
+                        "h __qubits__[i];",
                         "}",
-                        "cnot q[0], q[1];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "cnot __qubits__[0], __qubits__[1];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1480,14 +1480,14 @@ def test_circuit_from_ir(expected_circuit, ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
                         "for uint i in [0:1] {",
-                        "h q[i];",
+                        "h __qubits__[i];",
                         "}",
-                        "cnot q[0], q[1];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "cnot __qubits__[0], __qubits__[1];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -1499,13 +1499,13 @@ def test_circuit_from_ir(expected_circuit, ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
                         "bit c = 0;",
                         "if (c ==0){",
-                        "x q[0];",
+                        "x __qubits__[0];",
                         "}",
-                        "b[0] = measure q[0];",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -1517,11 +1517,11 @@ def test_circuit_from_ir(expected_circuit, ir):
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "input float theta;" "bit[1] b;",
-                        "qubit[1] q;",
-                        "rx(theta) q[0];",
-                        "rx(2*theta) q[0];",
-                        "b[0] = measure q[0];",
+                        "input float theta;" "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "rx(theta) __qubits__[0];",
+                        "rx(2*theta) __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -679,12 +679,12 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "rx(0.15) q[0];",
-                        "rx(0.3) q[1];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "rx(0.15) __qubits__[0];",
+                        "rx(0.3) __qubits__[1];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -697,11 +697,11 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[2] b;",
+                        "bit[2] __bits__;",
                         "rx(0.15) $0;",
                         "rx(0.3) $4;",
-                        "b[0] = measure $0;",
-                        "b[1] = measure $4;",
+                        "__bits__[0] = measure $0;",
+                        "__bits__[1] = measure $4;",
                     ]
                 ),
                 inputs={},
@@ -739,11 +739,11 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "qubit[5] q;",
-                        "rx(0.15) q[0];",
-                        "rx(0.3) q[4];",
-                        "#pragma braket noise bit_flip(0.2) q[3]",
-                        "#pragma braket result expectation i(q[0])",
+                        "qubit[5] __qubits__;",
+                        "rx(0.15) __qubits__[0];",
+                        "rx(0.3) __qubits__[4];",
+                        "#pragma braket noise bit_flip(0.2) __qubits__[3]",
+                        "#pragma braket result expectation i(__qubits__[0])",
                     ]
                 ),
                 inputs={},
@@ -757,12 +757,12 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                     [
                         "OPENQASM 3.0;",
                         "input float theta;",
-                        "bit[2] b;",
-                        "qubit[2] q;",
-                        "rx(0.15) q[0];",
-                        "rx(theta) q[1];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
+                        "bit[2] __bits__;",
+                        "qubit[2] __qubits__;",
+                        "rx(0.15) __qubits__[0];",
+                        "rx(theta) __qubits__[1];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
                     ]
                 ),
                 inputs={},
@@ -778,16 +778,16 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[5] b;",
-                        "qubit[5] q;",
-                        "negctrl @ rx(0.15) q[2], q[0];",
-                        "ctrl(2) @ rx(0.3) q[2], q[3], q[1];",
-                        "ctrl(2) @ cnot q[2], q[3], q[4], q[0];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
-                        "b[2] = measure q[2];",
-                        "b[3] = measure q[3];",
-                        "b[4] = measure q[4];",
+                        "bit[5] __bits__;",
+                        "qubit[5] __qubits__;",
+                        "negctrl @ rx(0.15) __qubits__[2], __qubits__[0];",
+                        "ctrl(2) @ rx(0.3) __qubits__[2], __qubits__[3], __qubits__[1];",
+                        "ctrl(2) @ cnot __qubits__[2], __qubits__[3], __qubits__[4], __qubits__[0];",  # noqa
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
+                        "__bits__[2] = measure __qubits__[2];",
+                        "__bits__[3] = measure __qubits__[3];",
+                        "__bits__[4] = measure __qubits__[4];",
                     ]
                 ),
                 inputs={},
@@ -800,18 +800,18 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[7] b;",
-                        "qubit[7] q;",
-                        "cnot q[0], q[1];",
-                        "cnot q[3], q[2];",
-                        "ctrl @ cnot q[5], q[6], q[4];",
-                        "b[0] = measure q[0];",
-                        "b[1] = measure q[1];",
-                        "b[2] = measure q[2];",
-                        "b[3] = measure q[3];",
-                        "b[4] = measure q[4];",
-                        "b[5] = measure q[5];",
-                        "b[6] = measure q[6];",
+                        "bit[7] __bits__;",
+                        "qubit[7] __qubits__;",
+                        "cnot __qubits__[0], __qubits__[1];",
+                        "cnot __qubits__[3], __qubits__[2];",
+                        "ctrl @ cnot __qubits__[5], __qubits__[6], __qubits__[4];",
+                        "__bits__[0] = measure __qubits__[0];",
+                        "__bits__[1] = measure __qubits__[1];",
+                        "__bits__[2] = measure __qubits__[2];",
+                        "__bits__[3] = measure __qubits__[3];",
+                        "__bits__[4] = measure __qubits__[4];",
+                        "__bits__[5] = measure __qubits__[5];",
+                        "__bits__[6] = measure __qubits__[6];",
                     ]
                 ),
                 inputs={},
@@ -824,11 +824,11 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
                 source="\n".join(
                     [
                         "OPENQASM 3.0;",
-                        "bit[1] b;",
-                        "qubit[1] q;",
-                        "inv @ pow(2.5) @ h q[0];",
-                        "pow(0) @ h q[0];",
-                        "b[0] = measure q[0];",
+                        "bit[1] __bits__;",
+                        "qubit[1] __qubits__;",
+                        "inv @ pow(2.5) @ h __qubits__[0];",
+                        "pow(0) @ h __qubits__[0];",
+                        "__bits__[0] = measure __qubits__[0];",
                     ]
                 ),
                 inputs={},
@@ -3024,7 +3024,7 @@ def test_pulse_circuit_to_openqasm(predefined_frame_1, user_defined_frame):
     ).source == "\n".join(
         [
             "OPENQASM 3.0;",
-            "bit[2] b;",
+            "bit[2] __bits__;",
             "cal {",
             "    frame user_defined_frame_0 = newframe(device_port_x0, 10000000.0, 3.14);",
             "    waveform gauss_wf = gaussian(1000000.0ns, 700000000.0ns, 1, false);",
@@ -3046,8 +3046,8 @@ def test_pulse_circuit_to_openqasm(predefined_frame_1, user_defined_frame):
             "    play(predefined_frame_1, drag_gauss_wf_2);",
             "}",
             "h $1;",
-            "b[0] = measure $0;",
-            "b[1] = measure $1;",
+            "__bits__[0] = measure $0;",
+            "__bits__[1] = measure $1;",
         ]
     )
 
@@ -3141,7 +3141,7 @@ def test_parametrized_pulse_circuit(user_defined_frame):
         [
             "OPENQASM 3.0;",
             "input float frequency;",
-            "bit[2] b;",
+            "bit[2] __bits__;",
             "cal {",
             "    frame user_defined_frame_0 = newframe(device_port_x0, 10000000.0, 3.14);",
             "    waveform gauss_wf = gaussian(10000.0ns, 700000000.0ns, 1, false);",
@@ -3151,8 +3151,8 @@ def test_parametrized_pulse_circuit(user_defined_frame):
             "    set_frequency(user_defined_frame_0, frequency);",
             "    play(user_defined_frame_0, gauss_wf);",
             "}",
-            "b[0] = measure $0;",
-            "b[1] = measure $1;",
+            "__bits__[0] = measure $0;",
+            "__bits__[1] = measure $1;",
         ]
     )
 
@@ -3166,7 +3166,7 @@ def test_parametrized_pulse_circuit(user_defined_frame):
     ).source == "\n".join(
         [
             "OPENQASM 3.0;",
-            "bit[2] b;",
+            "bit[2] __bits__;",
             "cal {",
             "    frame user_defined_frame_0 = newframe(device_port_x0, 10000000.0, 3.14);",
             "    waveform gauss_wf = gaussian(10000.0ns, 700000000.0ns, 1, false);",
@@ -3176,8 +3176,8 @@ def test_parametrized_pulse_circuit(user_defined_frame):
             "    set_frequency(user_defined_frame_0, 10000000.0);",
             "    play(user_defined_frame_0, gauss_wf);",
             "}",
-            "b[0] = measure $0;",
-            "b[1] = measure $1;",
+            "__bits__[0] = measure $0;",
+            "__bits__[1] = measure $1;",
         ]
     )
 

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -306,7 +306,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Rx(angle=0.17),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "rx(0.17) q[4];",
+            "rx(0.17) __qubits__[4];",
         ),
         (
             Gate.Rx(angle=0.17),
@@ -318,7 +318,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.X(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "x q[4];",
+            "x __qubits__[4];",
         ),
         (
             Gate.X(),
@@ -330,7 +330,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Z(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "z q[4];",
+            "z __qubits__[4];",
         ),
         (
             Gate.Z(),
@@ -342,7 +342,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Y(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "y q[4];",
+            "y __qubits__[4];",
         ),
         (
             Gate.Y(),
@@ -354,7 +354,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.H(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "h q[4];",
+            "h __qubits__[4];",
         ),
         (
             Gate.H(),
@@ -366,7 +366,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Ry(angle=0.17),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "ry(0.17) q[4];",
+            "ry(0.17) __qubits__[4];",
         ),
         (
             Gate.Ry(angle=0.17),
@@ -378,7 +378,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.ZZ(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "zz(0.17) q[4], q[5];",
+            "zz(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.ZZ(angle=0.17),
@@ -390,7 +390,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.I(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "i q[4];",
+            "i __qubits__[4];",
         ),
         (
             Gate.I(),
@@ -402,7 +402,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.V(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "v q[4];",
+            "v __qubits__[4];",
         ),
         (
             Gate.V(),
@@ -414,7 +414,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CY(),
             [0, 1],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cy q[0], q[1];",
+            "cy __qubits__[0], __qubits__[1];",
         ),
         (
             Gate.CY(),
@@ -426,7 +426,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Rz(angle=0.17),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "rz(0.17) q[4];",
+            "rz(0.17) __qubits__[4];",
         ),
         (
             Gate.Rz(angle=0.17),
@@ -438,7 +438,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.XX(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "xx(0.17) q[4], q[5];",
+            "xx(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.XX(angle=0.17),
@@ -450,7 +450,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.T(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "t q[4];",
+            "t __qubits__[4];",
         ),
         (
             Gate.T(),
@@ -468,13 +468,13 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CZ(),
             [0, 1],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cz q[0], q[1];",
+            "cz __qubits__[0], __qubits__[1];",
         ),
         (
             Gate.YY(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "yy(0.17) q[4], q[5];",
+            "yy(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.YY(angle=0.17),
@@ -486,7 +486,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.XY(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "xy(0.17) q[4], q[5];",
+            "xy(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.XY(angle=0.17),
@@ -504,7 +504,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.ISwap(),
             [0, 1],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "iswap q[0], q[1];",
+            "iswap __qubits__[0], __qubits__[1];",
         ),
         (
             Gate.Swap(),
@@ -516,7 +516,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Swap(),
             [0, 1],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "swap q[0], q[1];",
+            "swap __qubits__[0], __qubits__[1];",
         ),
         (
             Gate.ECR(),
@@ -528,7 +528,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.ECR(),
             [0, 1],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "ecr q[0], q[1];",
+            "ecr __qubits__[0], __qubits__[1];",
         ),
         (
             Gate.CV(),
@@ -540,13 +540,13 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CV(),
             [0, 1],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cv q[0], q[1];",
+            "cv __qubits__[0], __qubits__[1];",
         ),
         (
             Gate.Vi(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "vi q[4];",
+            "vi __qubits__[4];",
         ),
         (
             Gate.Vi(),
@@ -558,7 +558,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CSwap(),
             [0, 1, 2],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cswap q[0], q[1], q[2];",
+            "cswap __qubits__[0], __qubits__[1], __qubits__[2];",
         ),
         (
             Gate.CSwap(),
@@ -570,7 +570,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CPhaseShift01(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cphaseshift01(0.17) q[4], q[5];",
+            "cphaseshift01(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.CPhaseShift01(angle=0.17),
@@ -582,7 +582,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CPhaseShift00(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cphaseshift00(0.17) q[4], q[5];",
+            "cphaseshift00(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.CPhaseShift00(angle=0.17),
@@ -594,7 +594,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CPhaseShift(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cphaseshift(0.17) q[4], q[5];",
+            "cphaseshift(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.CPhaseShift(angle=0.17),
@@ -606,7 +606,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.S(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "s q[4];",
+            "s __qubits__[4];",
         ),
         (
             Gate.S(),
@@ -618,7 +618,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Si(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "si q[4];",
+            "si __qubits__[4];",
         ),
         (
             Gate.Si(),
@@ -630,7 +630,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Ti(),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "ti q[4];",
+            "ti __qubits__[4];",
         ),
         (
             Gate.Ti(),
@@ -642,7 +642,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.PhaseShift(angle=0.17),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "phaseshift(0.17) q[4];",
+            "phaseshift(0.17) __qubits__[4];",
         ),
         (
             Gate.PhaseShift(angle=0.17),
@@ -654,7 +654,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CNot(),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cnot q[4], q[5];",
+            "cnot __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.CNot(),
@@ -666,7 +666,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.PSwap(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "pswap(0.17) q[4], q[5];",
+            "pswap(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.PSwap(angle=0.17),
@@ -678,7 +678,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CPhaseShift10(angle=0.17),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "cphaseshift10(0.17) q[4], q[5];",
+            "cphaseshift10(0.17) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.CPhaseShift10(angle=0.17),
@@ -690,7 +690,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.CCNot(),
             [4, 5, 6],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "ccnot q[4], q[5], q[6];",
+            "ccnot __qubits__[4], __qubits__[5], __qubits__[6];",
         ),
         (
             Gate.CCNot(),
@@ -711,7 +711,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             "[0, 0, 0, 0, 0, 1.0, 0, 0], "
             "[0, 0, 0, 0, 0, 0, 0, 1.0], "
             "[0, 0, 0, 0, 0, 0, 1.0, 0]"
-            "]) q[4], q[5], q[6]",
+            "]) __qubits__[4], __qubits__[5], __qubits__[6]",
         ),
         (
             Gate.Unitary(Gate.CCNot().to_matrix()),
@@ -737,7 +737,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             "[0, 0, 0.70710678im, 0.70710678], "
             "[0.70710678, -0.70710678im, 0, 0], "
             "[-0.70710678im, 0.70710678, 0, 0]"
-            "]) q[4], q[5]",
+            "]) __qubits__[4], __qubits__[5]",
         ),
         (
             Gate.Unitary(np.round(Gate.ECR().to_matrix(), 8)),
@@ -754,7 +754,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Unitary(np.round(Gate.T().to_matrix(), 8)),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket unitary([[1.0, 0], [0, 0.70710678 + 0.70710678im]]) q[4]",
+            "#pragma braket unitary([[1.0, 0], [0, 0.70710678 + 0.70710678im]]) __qubits__[4]",
         ),
         (
             Gate.Unitary(np.round(Gate.T().to_matrix(), 8)),
@@ -766,7 +766,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.Unitary(np.array([[1.0, 0], [0, 0.70710678 - 0.70710678j]])),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket unitary([[1.0, 0], [0, 0.70710678 - 0.70710678im]]) q[4]",
+            "#pragma braket unitary([[1.0, 0], [0, 0.70710678 - 0.70710678im]]) __qubits__[4]",
         ),
         (
             Gate.PulseGate(
@@ -784,7 +784,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.GPi(angle=0.17),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "gpi(0.17) q[4];",
+            "gpi(0.17) __qubits__[4];",
         ),
         (
             Gate.GPi(angle=0.17),
@@ -796,7 +796,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.GPi2(angle=0.17),
             [4],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "gpi2(0.17) q[4];",
+            "gpi2(0.17) __qubits__[4];",
         ),
         (
             Gate.GPi2(angle=0.17),
@@ -808,7 +808,7 @@ def test_ir_gate_level(testclass, subroutine_name, irclass, irsubclasses, kwargs
             Gate.MS(angle_1=0.17, angle_2=3.45),
             [4, 5],
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            f"ms(0.17, 3.45, {np.pi / 2}) q[4], q[5];",
+            f"ms(0.17, 3.45, {np.pi / 2}) __qubits__[4], __qubits__[5];",
         ),
         (
             Gate.MS(angle_1=0.17, angle_2=3.45),
@@ -1015,22 +1015,34 @@ def test_pulse_gate_to_matrix():
 @pytest.mark.parametrize(
     "gate, target, control, control_state, expected_ir",
     (
-        (Gate.H(), QubitSet(0), QubitSet(1), None, "ctrl @ h q[1], q[0];"),
-        (Gate.H(), QubitSet(0), QubitSet([1, 2]), None, "ctrl(2) @ h q[1], q[2], q[0];"),
-        (Gate.Ry(angle=1.23), QubitSet(0), QubitSet([2]), None, "ctrl @ ry(1.23) q[2], q[0];"),
+        (Gate.H(), QubitSet(0), QubitSet(1), None, "ctrl @ h __qubits__[1], __qubits__[0];"),
+        (
+            Gate.H(),
+            QubitSet(0),
+            QubitSet([1, 2]),
+            None,
+            "ctrl(2) @ h __qubits__[1], __qubits__[2], __qubits__[0];",
+        ),
+        (
+            Gate.Ry(angle=1.23),
+            QubitSet(0),
+            QubitSet([2]),
+            None,
+            "ctrl @ ry(1.23) __qubits__[2], __qubits__[0];",
+        ),
         (
             Gate.MS(angle_1=0.17, angle_2=3.45),
             QubitSet(0),
             QubitSet([1, 2]),
             None,
-            f"ctrl(2) @ ms(0.17, 3.45, {np.pi / 2}) q[1], q[2], q[0];",
+            f"ctrl(2) @ ms(0.17, 3.45, {np.pi / 2}) __qubits__[1], __qubits__[2], __qubits__[0];",
         ),
         (
             Gate.CCNot(),
             QubitSet([0, 1, 2]),
             QubitSet([3, 4]),
             None,
-            "ctrl(2) @ ccnot q[3], q[4], q[0], q[1], q[2];",
+            "ctrl(2) @ ccnot __qubits__[3], __qubits__[4], __qubits__[0], __qubits__[1], __qubits__[2];",  # noqa
         ),
         (
             Gate.Z(),
@@ -1038,7 +1050,7 @@ def test_pulse_gate_to_matrix():
             QubitSet([1, 2, 3, 4, 5, 6, 7]),
             [1, 1, 1, 0, 0, 1, 0],
             "ctrl(3) @ negctrl(2) @ ctrl @ negctrl @ "
-            "z q[1], q[2], q[3], q[4], q[5], q[6], q[7], q[0];",
+            "z __qubits__[1], __qubits__[2], __qubits__[3], __qubits__[4], __qubits__[5], __qubits__[6], __qubits__[7], __qubits__[0];",  # noqa
         ),
         (
             Gate.Z(),
@@ -1046,7 +1058,7 @@ def test_pulse_gate_to_matrix():
             QubitSet([1, 2, 3, 4, 5, 6, 7]),
             "1110010",
             "ctrl(3) @ negctrl(2) @ ctrl @ negctrl @ "
-            "z q[1], q[2], q[3], q[4], q[5], q[6], q[7], q[0];",
+            "z __qubits__[1], __qubits__[2], __qubits__[3], __qubits__[4], __qubits__[5], __qubits__[6], __qubits__[7], __qubits__[0];",  # noqa
         ),
         (
             Gate.Z(),
@@ -1054,21 +1066,21 @@ def test_pulse_gate_to_matrix():
             QubitSet([1, 2, 3, 4, 5, 6, 7]),
             114,
             "ctrl(3) @ negctrl(2) @ ctrl @ negctrl @ "
-            "z q[1], q[2], q[3], q[4], q[5], q[6], q[7], q[0];",
+            "z __qubits__[1], __qubits__[2], __qubits__[3], __qubits__[4], __qubits__[5], __qubits__[6], __qubits__[7], __qubits__[0];",  # noqa
         ),
         (
             Gate.Z(),
             QubitSet([0]),
             QubitSet([1, 2, 3]),
             [1, 0],
-            "negctrl @ ctrl @ negctrl @ z q[1], q[2], q[3], q[0];",
+            "negctrl @ ctrl @ negctrl @ z __qubits__[1], __qubits__[2], __qubits__[3], __qubits__[0];",  # noqa
         ),
         (
             Gate.Z(),
             QubitSet([0]),
             QubitSet([1, 2, 3]),
             "10",
-            "negctrl @ ctrl @ negctrl @ z q[1], q[2], q[3], q[0];",
+            "negctrl @ ctrl @ negctrl @ z __qubits__[1], __qubits__[2], __qubits__[3], __qubits__[0];",  # noqa
         ),
     ),
 )
@@ -1127,13 +1139,13 @@ def test_gate_control_invalid_state(control, control_state, error_string):
 @pytest.mark.parametrize(
     "gate, target, power, expected_ir",
     (
-        (Gate.H(), QubitSet(0), 2, "pow(2) @ h q[0];"),
-        (Gate.H(), QubitSet(0), 2.0, "pow(2.0) @ h q[0];"),
-        (Gate.H(), QubitSet(0), 2.5, "pow(2.5) @ h q[0];"),
-        (Gate.H(), QubitSet(0), 0, "pow(0) @ h q[0];"),
-        (Gate.H(), QubitSet(0), -2, "inv @ pow(2) @ h q[0];"),
-        (Gate.H(), QubitSet(0), -2.0, "inv @ pow(2.0) @ h q[0];"),
-        (Gate.H(), QubitSet(0), -2.5, "inv @ pow(2.5) @ h q[0];"),
+        (Gate.H(), QubitSet(0), 2, "pow(2) @ h __qubits__[0];"),
+        (Gate.H(), QubitSet(0), 2.0, "pow(2.0) @ h __qubits__[0];"),
+        (Gate.H(), QubitSet(0), 2.5, "pow(2.5) @ h __qubits__[0];"),
+        (Gate.H(), QubitSet(0), 0, "pow(0) @ h __qubits__[0];"),
+        (Gate.H(), QubitSet(0), -2, "inv @ pow(2) @ h __qubits__[0];"),
+        (Gate.H(), QubitSet(0), -2.0, "inv @ pow(2.0) @ h __qubits__[0];"),
+        (Gate.H(), QubitSet(0), -2.5, "inv @ pow(2.5) @ h __qubits__[0];"),
     ),
 )
 def test_gate_power(gate, target, power, expected_ir):

--- a/test/unit_tests/braket/circuits/test_noises.py
+++ b/test/unit_tests/braket/circuits/test_noises.py
@@ -547,7 +547,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.BitFlip(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise bit_flip(0.5) q[3]",
+            "#pragma braket noise bit_flip(0.5) __qubits__[3]",
         ),
         (
             Noise.BitFlip(0.5),
@@ -559,7 +559,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.PhaseFlip(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise phase_flip(0.5) q[3]",
+            "#pragma braket noise phase_flip(0.5) __qubits__[3]",
         ),
         (
             Noise.PhaseFlip(0.5),
@@ -571,7 +571,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.PauliChannel(0.1, 0.2, 0.3),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise pauli_channel(0.1, 0.2, 0.3) q[3]",
+            "#pragma braket noise pauli_channel(0.1, 0.2, 0.3) __qubits__[3]",
         ),
         (
             Noise.PauliChannel(0.1, 0.2, 0.3),
@@ -583,7 +583,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.Depolarizing(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise depolarizing(0.5) q[3]",
+            "#pragma braket noise depolarizing(0.5) __qubits__[3]",
         ),
         (
             Noise.Depolarizing(0.5),
@@ -595,7 +595,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.TwoQubitDepolarizing(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3, 5],
-            "#pragma braket noise two_qubit_depolarizing(0.5) q[3], q[5]",
+            "#pragma braket noise two_qubit_depolarizing(0.5) __qubits__[3], __qubits__[5]",
         ),
         (
             Noise.TwoQubitDepolarizing(0.5),
@@ -607,7 +607,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.TwoQubitDephasing(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3, 5],
-            "#pragma braket noise two_qubit_dephasing(0.5) q[3], q[5]",
+            "#pragma braket noise two_qubit_dephasing(0.5) __qubits__[3], __qubits__[5]",
         ),
         (
             Noise.TwoQubitDephasing(0.5),
@@ -619,7 +619,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.AmplitudeDamping(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise amplitude_damping(0.5) q[3]",
+            "#pragma braket noise amplitude_damping(0.5) __qubits__[3]",
         ),
         (
             Noise.AmplitudeDamping(0.5),
@@ -631,7 +631,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.GeneralizedAmplitudeDamping(0.5, 0.1),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise generalized_amplitude_damping(0.5, 0.1) q[3]",
+            "#pragma braket noise generalized_amplitude_damping(0.5, 0.1) __qubits__[3]",
         ),
         (
             Noise.GeneralizedAmplitudeDamping(0.5, 0.1),
@@ -643,7 +643,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             Noise.PhaseDamping(0.5),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "#pragma braket noise phase_damping(0.5) q[3]",
+            "#pragma braket noise phase_damping(0.5) __qubits__[3]",
         ),
         (
             Noise.PhaseDamping(0.5),
@@ -668,7 +668,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             "[0, 0.31622776601683794, 0, 0], "
             "[0.31622776601683794, 0, 0, 0], "
             "[0, 0, 0, 0.31622776601683794], "
-            "[0, 0, 0.31622776601683794, 0]]) q[3], q[5]",
+            "[0, 0, 0.31622776601683794, 0]]) __qubits__[3], __qubits__[5]",
         ),
         (
             Noise.Kraus(
@@ -700,7 +700,7 @@ def test_valid_values_pauli_channel_two_qubit(probs):
             [3],
             "#pragma braket noise kraus(["
             "[0.9486833im, 0], [0, 0.9486833im]], ["
-            "[0, 0.31622777], [0.31622777, 0]]) q[3]",
+            "[0, 0.31622777], [0.31622777, 0]]) __qubits__[3]",
         ),
         (
             Noise.Kraus(

--- a/test/unit_tests/braket/circuits/test_observables.py
+++ b/test/unit_tests/braket/circuits/test_observables.py
@@ -67,7 +67,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.I(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "i(q[3])",
+            "i(__qubits__[3])",
         ),
         (
             Observable.I(),
@@ -85,7 +85,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.X(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "x(q[3])",
+            "x(__qubits__[3])",
         ),
         (
             Observable.X(),
@@ -103,7 +103,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.Y(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "y(q[3])",
+            "y(__qubits__[3])",
         ),
         (
             Observable.Y(),
@@ -121,7 +121,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.Z(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "z(q[3])",
+            "z(__qubits__[3])",
         ),
         (
             Observable.Z(),
@@ -139,7 +139,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.H(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3],
-            "h(q[3])",
+            "h(__qubits__[3])",
         ),
         (
             Observable.H(),
@@ -158,7 +158,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [1, 2],
             "hermitian([[1+0im, 0im, 0im, 0im], [0im, 1+0im, 0im, 0im], "
-            "[0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) q[1], q[2]",
+            "[0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) __qubits__[1], __qubits__[2]",
         ),
         (
             Observable.Hermitian(np.eye(4)),
@@ -177,7 +177,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.H() @ Observable.Z(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3, 0],
-            "h(q[3]) @ z(q[0])",
+            "h(__qubits__[3]) @ z(__qubits__[0])",
         ),
         (
             Observable.H() @ Observable.Z(),
@@ -189,7 +189,7 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             Observable.H() @ Observable.Z() @ Observable.I(),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3, 0, 1],
-            "h(q[3]) @ z(q[0]) @ i(q[1])",
+            "h(__qubits__[3]) @ z(__qubits__[0]) @ i(__qubits__[1])",
         ),
         (
             Observable.H() @ Observable.Z() @ Observable.I(),
@@ -202,8 +202,8 @@ def test_to_ir(testobject, gateobject, expected_ir, basis_rotation_gates, eigenv
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             [3, 0, 1],
             "hermitian([[1+0im, 0im, 0im, 0im], [0im, 1+0im, 0im, 0im], "
-            "[0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) q[3], q[0]"
-            " @ i(q[1])",
+            "[0im, 0im, 1+0im, 0im], [0im, 0im, 0im, 1+0im]]) __qubits__[3], __qubits__[0]"
+            " @ i(__qubits__[1])",
         ),
         (
             Observable.I() @ Observable.Hermitian(np.eye(4)),

--- a/test/unit_tests/braket/circuits/test_result_types.py
+++ b/test/unit_tests/braket/circuits/test_result_types.py
@@ -155,7 +155,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.Expectation(Observable.I(), target=0),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result expectation i(q[0])",
+            "#pragma braket result expectation i(__qubits__[0])",
         ),
         (
             ResultType.Expectation(Observable.I()),
@@ -175,7 +175,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.DensityMatrix([0, 2]),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result density_matrix q[0], q[2]",
+            "#pragma braket result density_matrix __qubits__[0], __qubits__[2]",
         ),
         (
             ResultType.DensityMatrix(0),
@@ -195,7 +195,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.Probability([0, 2]),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result probability q[0], q[2]",
+            "#pragma braket result probability __qubits__[0], __qubits__[2]",
         ),
         (
             ResultType.Probability(0),
@@ -205,7 +205,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.Sample(Observable.I(), target=0),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result sample i(q[0])",
+            "#pragma braket result sample i(__qubits__[0])",
         ),
         (
             ResultType.Sample(Observable.I()),
@@ -215,7 +215,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.Variance(Observable.I(), target=0),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result variance i(q[0])",
+            "#pragma braket result variance i(__qubits__[0])",
         ),
         (
             ResultType.Variance(Observable.I()),
@@ -225,12 +225,12 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
         (
             ResultType.AdjointGradient(Observable.I(), target=0, parameters=["alpha", "beta"]),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result adjoint_gradient expectation(i(q[0])) alpha, beta",
+            "#pragma braket result adjoint_gradient expectation(i(__qubits__[0])) alpha, beta",
         ),
         (
             ResultType.AdjointGradient(Observable.I(), target=0, parameters=["alpha"]),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result adjoint_gradient expectation(i(q[0])) alpha",
+            "#pragma braket result adjoint_gradient expectation(i(__qubits__[0])) alpha",
         ),
         (
             ResultType.AdjointGradient(
@@ -239,7 +239,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
                 parameters=[FreeParameter("alpha"), "beta", FreeParameter("gamma")],
             ),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result adjoint_gradient expectation(h(q[0]) @ i(q[1])) "
+            "#pragma braket result adjoint_gradient expectation(h(__qubits__[0]) @ i(__qubits__[1])) "  # noqa
             "alpha, beta, gamma",
         ),
         (
@@ -249,20 +249,20 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
                 parameters=[FreeParameter("alpha"), "beta", FreeParameter("gamma")],
             ),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result adjoint_gradient expectation(h(q[0]) @ i(q[1]) + 2 * z(q[2])) "
+            "#pragma braket result adjoint_gradient expectation(h(__qubits__[0]) @ i(__qubits__[1]) + 2 * z(__qubits__[2])) "  # noqa
             "alpha, beta, gamma",
         ),
         (
             ResultType.AdjointGradient(Observable.I(), target=0, parameters=[]),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result adjoint_gradient expectation(i(q[0])) all",
+            "#pragma braket result adjoint_gradient expectation(i(__qubits__[0])) all",
         ),
         (
             ResultType.AdjointGradient(
                 Observable.X() @ Observable.Y(), target=[0, 1], parameters=[]
             ),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
-            "#pragma braket result adjoint_gradient expectation(x(q[0]) @ y(q[1])) all",
+            "#pragma braket result adjoint_gradient expectation(x(__qubits__[0]) @ y(__qubits__[1])) all",  # noqa
         ),
         (
             ResultType.AdjointGradient(
@@ -270,7 +270,7 @@ def test_ir_result_level(testclass, subroutine_name, irclass, input, ir_input):
             ),
             OpenQASMSerializationProperties(qubit_reference_type=QubitReferenceType.VIRTUAL),
             "#pragma braket result adjoint_gradient expectation(hermitian([[1+0im, 0im], "
-            "[0im, 1+0im]]) q[0]) all",
+            "[0im, 1+0im]]) __qubits__[0]) all",
         ),
     ],
 )

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -404,10 +404,10 @@ def test_run_gate_model_inputs():
                 (
                     "OPENQASM 3.0;",
                     "input float theta;",
-                    "bit[1] b;",
-                    "qubit[1] q;",
-                    "rx(theta) q[0];",
-                    "b[0] = measure q[0];",
+                    "bit[1] __bits__;",
+                    "qubit[1] __qubits__;",
+                    "rx(theta) __qubits__[0];",
+                    "__bits__[0] = measure __qubits__[0];",
                 )
             ),
             inputs={"theta": 2},

--- a/test/unit_tests/braket/parametric/test_free_parameter.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter.py
@@ -94,6 +94,6 @@ def test_valid_names(name):
         "\u33B8",
     ),
 )
-@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_invalid_names(name):
-    FreeParameter(name)
+    with pytest.raises(ValueError):
+        FreeParameter(name)

--- a/test/unit_tests/braket/parametric/test_free_parameter.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter.py
@@ -71,6 +71,7 @@ def test_sub_wrong_param(free_parameter):
         "q",
         "bit",
         "qubit",
+        "_a",
         "\u03B8",
         "a\u03B8",
         "a123",
@@ -88,7 +89,6 @@ def test_valid_names(name):
     (
         "",
         "1",
-        "_a",
         "__a",
         "!",
         "\u33B8",

--- a/test/unit_tests/braket/parametric/test_free_parameter.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter.py
@@ -88,10 +88,7 @@ def test_valid_names(name):
     "name",
     (
         "",
-        "1",
         "__a",
-        "!",
-        "\u33B8",
     ),
 )
 def test_invalid_names(name):

--- a/test/unit_tests/braket/parametric/test_free_parameter.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter.py
@@ -61,3 +61,39 @@ def test_sub_successful(free_parameter):
 
 def test_sub_wrong_param(free_parameter):
     assert free_parameter.subs({"alpha": 1}) == FreeParameter("theta")
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "a",
+        "b",
+        "q",
+        "bit",
+        "qubit",
+        "\u03B8",
+        "a\u03B8",
+        "a123",
+        "z123",
+        "\u03B8\u03B8",
+        "\u03B8a1",
+    ),
+)
+def test_valid_names(name):
+    FreeParameter(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        "",
+        "1",
+        "_a",
+        "__a",
+        "!",
+        "\u33B8",
+    ),
+)
+@pytest.mark.xfail(raises=ValueError, strict=True)
+def test_invalid_names(name):
+    FreeParameter(name)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-braket-sdk-python/issues/603

*Description of changes:*
When generating OpenQASM we decided to use 'b' and 'q' for 'bits' and 'qubits' variables, but this can collide with parameters chosen by customers. I've renamed these to ```__bits__``` and  ```__qubits__``` and have changed our requirements for FreeParameter names so that we exclude names that start with double underlines. I've also updated the verification function for our FreeParameter names to be closer to the identifiers definition from [OpenQASM](https://openqasm.com/language/types.html) to further reduce changes there will be transformation errors (some of which are mentioned in the ticket above).

This check is not exact, so it's possible that we'll allow for FreeParameter names that are not translatable to OpenQASM, since there's a trade-off between performance and upkeep (and keeping track of every reserved word in OpenQASM).



*Testing done:*

- Ran tests and unit tests and did searches. I hope there's nowhere that I've missed a 'b' or 'q' used in this way because they're quite hard to search for.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
