### PR TITLE
Split aq.function into aq.main and aq.subroutine

### DIFF
--- a/examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
+++ b/examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "135014b8",
    "metadata": {},
@@ -11,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "15cdfaee",
    "metadata": {},
    "outputs": [],
@@ -27,12 +28,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d2d7004f",
    "metadata": {},
    "source": [
     "## Build and run a Bell state program\n",
-    "As a hello-world example, we create a Bell state and execute it on the Braket local simulator. The quantum program is defined in the `bell_state` function. The `@aq.function` decorator marks the `bell_state` function as a quantum program and enables AutoQASM syntax in the function scope."
+    "As a hello-world example, we create a Bell state and execute it on the Braket local simulator. The quantum program is defined in the `bell_state` function. The `@aq.main` decorator marks the `bell_state` function as a quantum program and enables AutoQASM syntax in the function scope."
    ]
   },
   {
@@ -42,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@aq.function\n",
+    "@aq.main\n",
     "def bell_state():\n",
     "    h(0)\n",
     "    cnot(0, 1)\n",
@@ -50,6 +52,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2c59985b",
    "metadata": {},
@@ -85,6 +88,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "756d0587",
    "metadata": {},
@@ -139,6 +143,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "658c21ce",
    "metadata": {},

--- a/examples/autoqasm/2_Expressing_classical_control_flow.ipynb
+++ b/examples/autoqasm/2_Expressing_classical_control_flow.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "135014b8",
    "metadata": {},
@@ -28,6 +29,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2cccd8c2",
    "metadata": {},
@@ -35,7 +37,7 @@
     "## Subroutine\n",
     "When your quantum program uses the same logic multiple times, subroutines can be a helpful tool. With subroutines, you can generate a more efficient program representation. Your programs become easier to read and reason about, and less work to maintain.\n",
     "\n",
-    "As an example, we want to prepare two Bell states, each on different qubit pair. Because the gates to prepare Bell states are the same, we can implement them as a subroutine. Similar to a quantum program, a subroutine is marked by the `@aq.function` decorator. Any number of functions in your program can be marked as a quantum program with this decorator, and they can call one another. Here, we define the Bell state preparation as a subroutine."
+    "As an example, we want to prepare two Bell states, each on different qubit pair. Because the gates to prepare Bell states are the same, we can implement them as a subroutine. Similar to a quantum program, a subroutine is marked by the `@aq.subroutine` decorator. Any number of functions in your program can be marked as a quantum program with this decorator, and they can call one another. Here, we define the Bell state preparation as a subroutine."
    ]
   },
   {
@@ -45,13 +47,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@aq.function\n",
+    "@aq.subroutine\n",
     "def bell(q0: int, q1: int) -> None:\n",
     "    h(q0)\n",
     "    cnot(q0, q1)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e2a884e6",
    "metadata": {},
@@ -81,7 +84,7 @@
     }
    ],
    "source": [
-    "@aq.function(num_qubits=4)\n",
+    "@aq.main(num_qubits=4)\n",
     "def two_bell() -> None:\n",
     "    bell(0, 1)\n",
     "    bell(2, 3)\n",
@@ -92,14 +95,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c6c59f55",
    "metadata": {},
    "source": [
-    "With classical control flow, sometimes the number of qubits used could be undetermined before the execution time (i.e., when program is executed on a QPU or a simulator). Therefore, AutoQASM does not know how many qubits the program may need. In cases like subroutine and using variables as qubit indices, we must define the qubit count using the keyword argument `num_qubits` in `@aq.function`."
+    "With classical control flow, sometimes the number of qubits used could be undetermined before the execution time (i.e., when program is executed on a QPU or a simulator). Therefore, AutoQASM does not know how many qubits the program may need. In cases like subroutine and using variables as qubit indices, we must define the qubit count using the keyword argument `num_qubits` in `@aq.main`."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1e86b3d5",
    "metadata": {},
@@ -108,6 +113,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bf201c13",
    "metadata": {},
@@ -122,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@aq.function(num_qubits=5)\n",
+    "@aq.main(num_qubits=5)\n",
     "def conditioned_bell() -> None:\n",
     "    h(0)\n",
     "    if measure(0):\n",
@@ -137,6 +143,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "db483f0e",
    "metadata": {},
@@ -181,6 +188,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c1ded7b8",
    "metadata": {},
@@ -189,6 +197,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "edee6e9c",
    "metadata": {},
@@ -197,6 +206,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ce1da10e",
    "metadata": {},
@@ -230,7 +240,7 @@
     "n_bell = 3\n",
     "\n",
     "\n",
-    "@aq.function(num_qubits=n_bell * 2)\n",
+    "@aq.main(num_qubits=n_bell * 2)\n",
     "def multiple_bell(n_bell) -> None:\n",
     "    for i in aq.range(0, 2 * n_bell, 2):\n",
     "        bell(i, i + 1)\n",
@@ -241,6 +251,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9303a270",
    "metadata": {},
@@ -249,6 +260,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2619f38d",
    "metadata": {},

--- a/examples/autoqasm/3_Iterative_phase_estimation.ipynb
+++ b/examples/autoqasm/3_Iterative_phase_estimation.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "08d77a63",
    "metadata": {},
@@ -30,6 +31,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d471ea9c",
    "metadata": {},
@@ -44,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@aq.function\n",
+    "@aq.main\n",
     "def phase_oracle(ancilla_qubit: int, data_qubit: int) -> None:\n",
     "    \"\"\"Phase oracle that applies phase oracle on q1\n",
     "    conditioned on q0.\n",
@@ -58,6 +60,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f76eb5a3",
    "metadata": {},
@@ -82,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@aq.function(num_qubits=2)\n",
+    "@aq.main(num_qubits=2)\n",
     "def ipe(n_iterations: int):\n",
     "    \"\"\"Iterative phase estimation algorithm.\n",
     "\n",
@@ -127,6 +130,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1184691f",
    "metadata": {},
@@ -171,6 +175,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2b4ff1a9",
    "metadata": {},
@@ -179,6 +184,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "63c39db4",
    "metadata": {},
@@ -188,6 +194,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "26c3bf88",
    "metadata": {},

--- a/examples/autoqasm/3_Iterative_phase_estimation.ipynb
+++ b/examples/autoqasm/3_Iterative_phase_estimation.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@aq.main\n",
+    "@aq.subroutine\n",
     "def phase_oracle(ancilla_qubit: int, data_qubit: int) -> None:\n",
     "    \"\"\"Phase oracle that applies phase oracle on q1\n",
     "    conditioned on q0.\n",

--- a/src/braket/experimental/autoqasm/README.md
+++ b/src/braket/experimental/autoqasm/README.md
@@ -49,14 +49,14 @@ import braket.experimental.autoqasm as aq
 from braket.experimental.autoqasm.instructions import h, cnot, measure
 ```
 
-To create a quantum program using the AutoQASM experience, you decorate a function with `@aq.function`.
+To create a quantum program using the AutoQASM experience, you decorate a function with `@aq.main`.
 This allows AutoQASM to hook into the program definition and generate an output format that is accepted
 by quantum devices.
 
 For instance, we can create a Bell state like so:
 ```
 # A program that generates a maximally entangled state
-@aq.function
+@aq.main
 def bell_state() -> None:
     h(0)
     cnot(0, 1)
@@ -68,7 +68,7 @@ AutoQASM enables users to use more complicated program constructs with a compact
 structure. We can demonstrate this with a program that conditionally prepares multiple Bell states
 on qubit pairs (1, 2) and (3, 4).
 ```
-@aq.function(num_qubits=5)
+@aq.main(num_qubits=5)
 def conditional_multi_bell_states() -> None:
     h(0)
     if measure(0):
@@ -82,7 +82,7 @@ def conditional_multi_bell_states() -> None:
 my_bell_program = conditional_multi_bell_states()
 ```
 
-AutoQASM can support nested subroutines and complex control flow. You can use the Python runtime
+AutoQASM can support subroutines and complex control flow. You can use the Python runtime
 and quantum runtime side-by-side. For the moment, we support only a few quantum operations such as
 `h`, `x`, `cnot`, and `measure`. There are rough edges at the moment, but we're actively smoothing
 them out!
@@ -103,7 +103,7 @@ For more example usage of AutoQASM, visit the [example notebooks](../../../../ex
 ## Architecture
 
 AutoQASM is built on top of the `autograph` component of TensorFlow. A quantum program is
-written as a Python function which includes an `@aq.function` decorator. When calling this
+written as a Python function which is decorated with `@aq.main`. When calling this
 decorated function, the user’s Python function is converted into a transformed Python function
 by `autograph`. This transformed function is then executed to produce an AutoQASM `Program`
 object which can be simulated and/or serialized to OpenQASM.

--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -19,7 +19,7 @@ The basic usage of AutoQASM is as follows:
     import braket.experimental.autoqasm as aq
     from braket.experimental.autoqasm.instructions import h, cnot, measure
 
-    @aq.function
+    @aq.main
     def my_program():
         h(0)
         cnot(0, 1)
@@ -40,7 +40,7 @@ The Python code above outputs the following OpenQASM program:
     result[1] = measure __qubits__[1];
 """
 
-from .api import function, gate  # noqa: F401
+from .api import gate, main, subroutine  # noqa: F401
 from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -229,6 +229,13 @@ def _convert_program(
         to the conversion process. Or, the oqpy variable returned from the converted function,
         if this is a subroutine conversion.
     """
+    if is_subroutine and not aq_program.in_active_program_conversion_context():
+        raise errors.AutoQasmTypeError(
+            "Subroutines shouldn't be called directly. Please define an entry point "
+            "function, decorate it with '@autoqasm.main', and call your subroutine "
+            "from within that function."
+        )
+
     with aq_program.build_program(user_config) as program_conversion_context:
         try:
             with conversion_ctx:

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -235,6 +235,11 @@ def _convert_program(
             "function, decorate it with '@autoqasm.main', and call your subroutine "
             "from within that function."
         )
+    elif not is_subroutine and aq_program.in_active_program_conversion_context():
+        raise errors.AutoQasmTypeError(
+            f"Cannot call main function '{f.__name__}' from another main function. Did you mean "
+            "to use '@autoqasm.subroutine'?"
+        )
 
     with aq_program.build_program(user_config) as program_conversion_context:
         try:

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -104,8 +104,9 @@ def gate(*args) -> Callable[[Any], None]:
 
 
 def _function_wrapper(
-    # Update to use a callback
-    f: Callable, user_config: aq_program.UserConfig, is_subroutine: bool = False
+    f: Callable,
+    user_config: aq_program.UserConfig,
+    is_subroutine: bool = False,
 ) -> Callable[[Any], aq_program.Program]:
     """Wrapping and conversion logic around the user function `f`.
 
@@ -122,6 +123,7 @@ def _function_wrapper(
     if is_autograph_artifact(f):
         return f
 
+    # TODO: (laurecap) Update to accept a callback
     wrapper_factory = _convert_program_wrapper(
         user_config=user_config,
         is_subroutine=is_subroutine,
@@ -157,7 +159,9 @@ def _convert_program_wrapper(
                 user_requested=True,
                 optional_features=_autograph_optional_features(),
             )
-            return _convert_program(f, conversion_ctx, options, user_config, args, kwargs, is_subroutine)
+            return _convert_program(
+                f, conversion_ctx, options, user_config, args, kwargs, is_subroutine
+            )
 
         if inspect.isfunction(f) or inspect.ismethod(f):
             _wrapper = functools.update_wrapper(_wrapper, f)
@@ -226,9 +230,7 @@ def _convert_program(
         try:
             with conversion_ctx:
                 if is_subroutine:
-                    _convert_subroutine(
-                        f, program_conversion_context, options, args, kwargs
-                    )
+                    _convert_subroutine(f, program_conversion_context, options, args, kwargs)
                 else:
                     _convert_main(f, program_conversion_context, options, args, kwargs)
         except Exception as e:
@@ -460,9 +462,7 @@ def _add_qubit_declaration(program_conversion_context: aq_program.ProgramConvers
 
 def _clone_function(f_source: Callable) -> Callable:
     if not hasattr(f_source, "__code__"):
-        raise ValueError(
-            f"AutoQASM encountered a callable that it cannot process: {f_source}."
-        )
+        raise ValueError(f"AutoQASM encountered a callable that it cannot process: {f_source}.")
     f_clone = FunctionType(
         copy.deepcopy(f_source.__code__),
         copy.copy(f_source.__globals__),

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -229,13 +229,13 @@ def _convert_program(
     if is_subroutine and not aq_program.in_active_program_conversion_context():
         raise errors.AutoQasmTypeError(
             "Subroutines shouldn't be called directly. Please define an entry point "
-            "function, decorate it with '@autoqasm.main', and call your subroutine "
+            "function, decorate it with '@aq.main', and call your subroutine "
             "from within that function."
         )
     elif not is_subroutine and aq_program.in_active_program_conversion_context():
         raise errors.AutoQasmTypeError(
             f"Cannot call main function '{f.__name__}' from another main function. Did you mean "
-            "to use '@autoqasm.subroutine'?"
+            "to use '@aq.subroutine'?"
         )
 
     with aq_program.build_program(user_config) as program_conversion_context:

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -113,8 +113,8 @@ def _function_wrapper(
     Args:
         f (Callable): The target function to be converted which represents
             the entry point of the quantum program.
-        user_config (UserConfig): User-specified settings that influence program building
-        TODO
+        user_config (UserConfig): User-specified settings that influence program building.
+        is_subroutine (bool): If the function corresponds to a subroutine or main.
 
     Returns:
         Callable[[Any], Program]: A callable which returns the converted
@@ -140,7 +140,8 @@ def _convert_program_wrapper(
     that returns a Program object containing the quantum program.
 
     Args:
-        user_config (UserConfig): User-specified settings that influence program building
+        user_config (UserConfig): User-specified settings that influence program building.
+        is_subroutine (bool): If the function corresponds to a subroutine or main.
 
     Returns:
         Callable: a decorator that converts the given function into an equivalent
@@ -220,6 +221,8 @@ def _convert_program(
         user_config (UserConfig): User-specified settings that influence program building
         args (List[Any]): Arguments passed to the program when called.
         kwargs (Dict[str, Any]): Keyword arguments passed to the program when called.
+        is_subroutine (bool): If the function corresponds to a subroutine or main.
+
 
     Returns:
         Union[Program, Optional[Var]]: The converted program, if this is a top-level call

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -81,9 +81,6 @@ def subroutine(*args) -> Callable[[Any], aq_program.Program]:
         Callable[[Any], Program]: A callable which returns the converted
         quantum program when called.
     """
-    # TODO: subroutine shouldn't be called directly. This needs to move inside the wrapper.
-    # if not aq_program.in_active_program_conversion_context():
-    #     raise errors.AutoQasmError("TODO")
     return _function_wrapper(*args, user_config=None, is_subroutine=True)
 
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -21,6 +21,10 @@ class AutoQasmError(Exception):
     """Base class for all AutoQASM exceptions."""
 
 
+class AutoQasmTypeError(AutoQasmError):
+    """Generic type error."""
+
+
 class UnsupportedFeatureError(AutoQasmError):
     """AutoQASM unsupported feature."""
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -55,19 +55,6 @@ Specify the number of qubits used by your program by supplying the \
         return self.message
 
 
-class InconsistentNumQubits(AutoQasmError):
-    """Num qubits supplied to main function does not match subroutine."""
-
-    def __init__(self):
-        self.message = """\
-The number of qubits specified by one of your functions does not match the \
-argument supplied elsewhere. Remove the `num_qubits` argument from nested \
-function calls."""
-
-    def __str__(self):
-        return self.message
-
-
 class UnsupportedConditionalExpressionError(AutoQasmError):
     """Conditional expressions which return values are not supported."""
 

--- a/src/braket/experimental/autoqasm/instructions/__init__.py
+++ b/src/braket/experimental/autoqasm/instructions/__init__.py
@@ -18,7 +18,7 @@ Example of using a `h` gate and a `cnot` gate to create a Bell circuit:
 
 .. code-block:: python
 
-    @aq.function
+    @aq.main
     def bell():
         h(0)
         cnot(0, 1)

--- a/src/braket/experimental/autoqasm/instructions/measurements.py
+++ b/src/braket/experimental/autoqasm/instructions/measurements.py
@@ -17,7 +17,7 @@ Example of measuring qubit 0:
 
 .. code-block:: python
 
-    @aq.function
+    @aq.main
     def my_program():
         measure(0)
 """

--- a/src/braket/experimental/autoqasm/program/pragmas.py
+++ b/src/braket/experimental/autoqasm/program/pragmas.py
@@ -18,7 +18,7 @@ Pragmas specify how a program should be compiled or executed. In AutoQASM, we su
 
 .. code-block:: python
 
-    @aq.function
+    @aq.main
     def pragma_example() -> None:
         with aq.Verbatim():
             h(0)

--- a/src/braket/experimental/autoqasm/pulse/__init__.py
+++ b/src/braket/experimental/autoqasm/pulse/__init__.py
@@ -21,7 +21,7 @@ Example of a program that uses only pulse instructions:
 
 .. code-block:: python
 
-    @aq.function
+    @aq.main
     def my_pulse_program():
         pulse.shift_frequency(frame, 123)
         pulse.delay([3, 4], 0.34)

--- a/test/unit_tests/braket/experimental/autoqasm/conftest.py
+++ b/test/unit_tests/braket/experimental/autoqasm/conftest.py
@@ -22,6 +22,22 @@ from braket.experimental.autoqasm.instructions import cnot, h
 
 
 @pytest.fixture
+def empty_subroutine() -> Callable:
+    """Empty subroutine fixture.
+
+    Returns:
+        Callable: the aq program.
+    """
+
+    @aq.subroutine
+    def empty_function() -> None:
+        """A function that does nothing."""
+        pass
+
+    return empty_function
+
+
+@pytest.fixture
 def empty_program() -> Callable:
     """Empty program fixture.
 
@@ -29,12 +45,29 @@ def empty_program() -> Callable:
         Callable: the aq program.
     """
 
-    @aq.function
+    @aq.main
     def empty_function() -> None:
         """A function that does nothing."""
         pass
 
     return empty_function
+
+
+@pytest.fixture
+def bell_state_subroutine() -> Callable:
+    """Bell state preparation subroutine fixture.
+
+    Returns:
+        Callable: the aq program.
+    """
+
+    @aq.subroutine
+    def bell_state() -> None:
+        """A function that generates a two-qubit Bell state."""
+        h(0)
+        cnot(0, 1)
+
+    return bell_state
 
 
 @pytest.fixture
@@ -45,13 +78,30 @@ def bell_state_program() -> Callable:
         Callable: the aq program.
     """
 
-    @aq.function
+    @aq.main
     def bell_state() -> None:
         """A function that generates a two-qubit Bell state."""
         h(0)
         cnot(0, 1)
 
     return bell_state
+
+
+@pytest.fixture
+def physical_bell_subroutine() -> Callable:
+    """Physical bell state preparation program fixture.
+
+    Returns:
+        Callable: the aq program.
+    """
+
+    @aq.subroutine
+    def physical_bell() -> None:
+        """A function that generates a two-qubit Bell state on particular qubits."""
+        h("$0")
+        cnot("$0", "$5")
+
+    return physical_bell
 
 
 @pytest.fixture
@@ -62,7 +112,7 @@ def physical_bell_program() -> Callable:
         Callable: the aq program.
     """
 
-    @aq.function
+    @aq.main
     def physical_bell() -> None:
         """A function that generates a two-qubit Bell state on particular qubits."""
         h("$0")

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -857,7 +857,7 @@ def test_main_return():
 
 
 def test_main_no_return():
-    @aq.main
+    @aq.subroutine
     def tester(x: int) -> int:
         return measure(x)
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -48,21 +48,21 @@ def test_sim_bell_state(bell_state_program) -> None:
     _test_on_local_sim(bell_state_program())
 
 
-def test_multiple_calls(empty_program, bell_state_program) -> None:
-    """Tests multiple calls to a single aq.function to ensure that each resulting
+def test_multiple_calls(empty_subroutine, bell_state_subroutine) -> None:
+    """Tests multiple calls to a single aq.main to ensure that each resulting
     Program object has the expected contents.
     """
 
     def count_function_calls(program: aq.Program, func_name: str) -> int:
         return program.to_ir().count(f"{func_name}();")
 
-    @aq.function
+    @aq.main
     def empty_program_wrapper():
-        empty_program()
+        empty_subroutine()
 
-    @aq.function
+    @aq.main
     def bell_state_program_wrapper():
-        bell_state_program()
+        bell_state_subroutine()
 
     first_program = empty_program_wrapper()
     assert 1 == count_function_calls(first_program, "empty_function")
@@ -77,14 +77,14 @@ def test_multiple_calls(empty_program, bell_state_program) -> None:
     assert 1 == count_function_calls(third_program, "bell_state")
 
 
-def test_subroutines(empty_program, bell_state_program, physical_bell_program):
+def test_subroutines(empty_subroutine, bell_state_subroutine, physical_bell_subroutine):
     """Tests calling several subroutines consecutively."""
 
-    @aq.function
+    @aq.main
     def call_subroutines() -> None:
-        empty_program()
-        bell_state_program()
-        physical_bell_program()
+        empty_subroutine()
+        bell_state_subroutine()
+        physical_bell_subroutine()
 
     expected = """OPENQASM 3.0;
 def empty_function() {
@@ -107,19 +107,19 @@ physical_bell();"""
     _test_on_local_sim(call_subroutines())
 
 
-@aq.function
+@aq.subroutine
 def do_h(q: int):
     h(q)
 
 
-@aq.function(num_qubits=6)
+@aq.subroutine
 def recursive_h(q: int):
     do_h(q)
     if q > 0:
         recursive_h(q - 1)
 
 
-@aq.function(num_qubits=6)
+@aq.main(num_qubits=6)
 def recursive_h_wrapper(q: int):
     recursive_h(q)
 
@@ -145,6 +145,10 @@ def test_sim_recursive_h_wrapper():
 
 
 def test_recursive_h():
+    @aq.main(num_qubits=6)
+    def main(n: int):
+        recursive_h(n)
+
     expected = """OPENQASM 3.0;
 def do_h(int[32] q) {
     h __qubits__[q];
@@ -156,22 +160,18 @@ def recursive_h(int[32] q) {
     }
 }
 qubit[6] __qubits__;
-do_h(5);
 recursive_h(4);"""
-    assert recursive_h(5).to_ir() == expected
+
+    assert main(4).to_ir() == expected
 
 
-def test_sim_recursive_h():
-    _test_on_local_sim(recursive_h(5))
-
-
-@aq.function
+@aq.subroutine
 def bell_state_arbitrary_qubits(q0: int, q1: int) -> None:
     h(q0)
     cnot(q0, q1)
 
 
-@aq.function(num_qubits=4)
+@aq.main(num_qubits=4)
 def double_bell_state() -> None:
     bell_state_arbitrary_qubits(0, 1)
     bell_state_arbitrary_qubits(2, 3)
@@ -193,7 +193,7 @@ def test_sim_double_bell() -> None:
     _test_on_local_sim(double_bell_state())
 
 
-@aq.function
+@aq.main
 def bell_measurement_undeclared() -> None:
     """A function that generates and measures a two-qubit Bell state."""
     h(0)
@@ -218,7 +218,7 @@ def test_sim_bell_measurement_undeclared() -> None:
     _test_on_local_sim(bell_measurement_undeclared())
 
 
-@aq.function
+@aq.main
 def bell_measurement_declared() -> None:
     """A function that generates and measures a two-qubit Bell state."""
     c = aq.BitVar(0, size=2)
@@ -245,7 +245,7 @@ def test_sim_bell_measurement_declared() -> None:
     _test_on_local_sim(bell_measurement_declared())
 
 
-@aq.function
+@aq.main
 def bell_partial_measurement() -> None:
     """A function that generates and measures a two-qubit Bell state."""
     h(0)
@@ -265,7 +265,7 @@ c = __bit_0__;"""
     assert bell_partial_measurement().to_ir() == expected
 
 
-@aq.function
+@aq.main
 def bell_measurement_invalid_declared_type() -> None:
     """A function that generates and measures a two-qubit Bell state. But stores
     reuslt in an variable with invalid type.
@@ -284,7 +284,7 @@ def test_bell_measurement_invalid_declared_type() -> None:
     assert expected_error_message in str(exc_info.value)
 
 
-@aq.function
+@aq.main
 def bell_measurement_invalid_declared_size() -> None:
     """A function that generates and measures a two-qubit Bell state. But stores
     reuslt in an variable with invalid size.
@@ -303,7 +303,7 @@ def test_bell_measurement_invalid_declared_size() -> None:
     assert expected_error_message in str(exc_info.value)
 
 
-@aq.function(num_qubits=5)
+@aq.main(num_qubits=5)
 def ghz_qasm_for_loop() -> None:
     """A function that generates a GHZ state using a QASM for loop."""
     n_qubits = 5
@@ -326,7 +326,7 @@ def test_sim_ghz_qasm_for_loop() -> None:
     _test_on_local_sim(ghz_qasm_for_loop())
 
 
-@aq.function
+@aq.main
 def ghz_py_for_loop() -> None:
     """A function that generates a GHZ state using a Python for loop."""
     n_qubits = 5
@@ -350,7 +350,7 @@ def test_sim_ghz_py_for_loop() -> None:
     _test_on_local_sim(ghz_py_for_loop())
 
 
-@aq.function
+@aq.subroutine
 def qasm_simple_condition(do_cnot: bool) -> bool:
     """A function that contains a QASM conditional statement.
 
@@ -366,7 +366,7 @@ def qasm_simple_condition(do_cnot: bool) -> bool:
     return do_cnot
 
 
-@aq.function
+@aq.main
 def qasm_simple_condition_wrapper(do_cnot: bool):
     qasm_simple_condition(do_cnot)
 
@@ -393,7 +393,7 @@ def test_sim_qasm_simple_condition(do_cnot: bool) -> None:
     _test_on_local_sim(qasm_simple_condition_wrapper(do_cnot))
 
 
-@aq.function
+@aq.main
 def qasm_inline_var_condition() -> aq.BitVar:
     """A function that contains a QASM conditional statement with an inline var condition.
 
@@ -432,7 +432,7 @@ def test_sim_qasm_inline_var_condition() -> None:
     _test_on_local_sim(qasm_inline_var_condition())
 
 
-@aq.function
+@aq.main
 def ground_state_measurements() -> aq.BitVar:
     """Measure a few ground state qubits."""
     return measure([5, 2, 1])
@@ -465,12 +465,17 @@ def test_simple_measurement_return() -> None:
     the measurement results are returned from a subroutine.
     """
 
-    @aq.function
+    @aq.subroutine
+    def ground_state_measurements_subroutine() -> aq.BitVar:
+        """Measure a few ground state qubits."""
+        return measure([5, 2, 1])
+
+    @aq.main
     def ground_state_measurements_wrapper() -> None:
-        ground_state_measurements()
+        ground_state_measurements_subroutine()
 
     expected = """OPENQASM 3.0;
-def ground_state_measurements() -> bit[3] {
+def ground_state_measurements_subroutine() -> bit[3] {
     bit[3] __bit_0__ = "000";
     __bit_0__[0] = measure __qubits__[5];
     __bit_0__[1] = measure __qubits__[2];
@@ -481,11 +486,11 @@ qubit[6] __qubits__;
 """
     # TODO: this should be `bit[3]`, but there's a bug. It's being tracked in an issue.
     expected += """bit __bit_1__;
-__bit_1__ = ground_state_measurements();"""
+__bit_1__ = ground_state_measurements_subroutine();"""
     assert ground_state_measurements_wrapper().to_ir() == expected
 
 
-@aq.function
+@aq.main
 def qasm_measurement_condition() -> aq.BitVar:
     """A function that contains a mid-circuit measurement conditional.
 
@@ -528,16 +533,20 @@ def test_py_int_qubit_decl() -> None:
     assert "\nqubit[5] __qubits__;" in qasm
 
 
-def test_physical_qubit_decl(physical_bell_program) -> None:
+def test_physical_qubit_decl(physical_bell_subroutine) -> None:
     """Tests e.g. h("$0"). Note that physical qubits aren't declared."""
-    qasm = physical_bell_program().to_ir()
-    assert "__qubits__" not in qasm
+
+    @aq.main
+    def main():
+        physical_bell_subroutine()
+
+    assert "__qubits__" not in main().to_ir()
 
 
 def test_invalid_physical_qubit_fails() -> None:
     """Tests invalid physical qubit formatting."""
 
-    @aq.function
+    @aq.main
     def broken() -> None:
         "Uses invalid string for qubit index"
         cnot("$0l", "$O1")
@@ -549,7 +558,7 @@ def test_invalid_physical_qubit_fails() -> None:
 def test_invalid_qubit_label_fails() -> None:
     """Tests random string fails for qubit label."""
 
-    @aq.function
+    @aq.main
     def broken() -> None:
         "Uses invalid string for qubit index"
         h("nope")
@@ -561,7 +570,7 @@ def test_invalid_qubit_label_fails() -> None:
 def test_float_qubit_index_fails() -> None:
     """Tests floats fails for qubit label."""
 
-    @aq.function
+    @aq.main
     def broken() -> None:
         "Uses float for qubit index"
         i = 1
@@ -574,7 +583,7 @@ def test_float_qubit_index_fails() -> None:
 def test_bool_qubit_index_fails() -> None:
     """Tests that an error is raised for boolean qubit type."""
 
-    @aq.function
+    @aq.main
     def broken() -> None:
         "Uses invalid type for qubit index"
         h(True)
@@ -586,7 +595,7 @@ def test_bool_qubit_index_fails() -> None:
 def test_invalid_qubit_type_fails() -> None:
     """Tests that an error is raised for other unusual qubit types."""
 
-    @aq.function
+    @aq.main
     def broken() -> None:
         "Uses invalid type for qubit index"
         h(h)
@@ -598,13 +607,13 @@ def test_invalid_qubit_type_fails() -> None:
 def test_bit_array_name() -> None:
     """Tests that auto declared bits are given a reasonable name."""
 
-    @aq.function
+    @aq.subroutine
     def my_program() -> aq.BitVar:
         """Program which requires generating a bit"""
         h(0)
         return measure(0)
 
-    @aq.function
+    @aq.main
     def my_program_wrapper() -> None:
         my_program()
 
@@ -615,7 +624,7 @@ def test_bit_array_name() -> None:
     assert expected in my_program_wrapper().to_ir()
 
 
-@aq.function
+@aq.main
 def reset() -> None:
     "Reset qubit 0."
     if measure(0):
@@ -653,7 +662,7 @@ def test_program_simple_expr() -> None:
     an error if the user doesn't specify the number of qubits.
     """
 
-    @aq.function
+    @aq.main
     def simple_range() -> None:
         "Uses aq.range iterator for qubit index."
         for i in aq.range(5):
@@ -668,7 +677,7 @@ def test_program_with_expr() -> None:
     an error if the user doesn't specify the number of qubits.
     """
 
-    @aq.function
+    @aq.main
     def qubit_expr() -> None:
         "Uses aq.range iterator for qubit index."
         for i in aq.range(5):
@@ -691,7 +700,7 @@ for int i in [0:5 - 1] {
     h __qubits__[i];
 }"""
 
-    @aq.function(num_qubits=6)
+    @aq.main(num_qubits=6)
     def prog():
         for i in aq.range(3):
             cnot(i, i + 1)
@@ -702,13 +711,13 @@ for int i in [0:5 - 1] {
     assert prog().to_ir() == expected
 
 
-@aq.function
+@aq.subroutine
 def bell(q0: int, q1: int) -> None:
     h(q0)
     cnot(q0, q1)
 
 
-@aq.function(num_qubits=5)
+@aq.main(num_qubits=5)
 def bell_in_for_loop() -> None:
     for i in aq.range(3):
         bell(0, 1)
@@ -729,7 +738,7 @@ for int i in [0:3 - 1] {
     assert bell_in_for_loop().to_ir() == expected
 
 
-@aq.function
+@aq.main
 def classical_variables_types() -> None:
     a = aq.BitVar(0)
     a = aq.BitVar(1)  # noqa: F841
@@ -771,7 +780,7 @@ def test_sim_classical_variables_types():
 
 
 def test_classical_variables_assignment():
-    @aq.function
+    @aq.main
     def prog() -> None:
         a = aq.IntVar(1)  # undeclared target, undeclared value
         a = aq.IntVar(2)  # declared target, undeclared value
@@ -789,7 +798,7 @@ a = b;"""
 
 
 def test_assignment_measurement_results():
-    @aq.function
+    @aq.main
     def prog() -> None:
         a = measure(0)
         b = a  # noqa: F841
@@ -805,21 +814,8 @@ b = a;"""
     assert prog().to_ir() == expected
 
 
-def test_mismatched_qubits():
-    @aq.function(num_qubits=4)
-    def subroutine() -> None:
-        _ = measure(0)
-
-    @aq.function(num_qubits=8)
-    def main() -> None:
-        subroutine()
-
-    with pytest.raises(errors.InconsistentNumQubits):
-        main()
-
-
 def test_nested_function():
-    @aq.function
+    @aq.main
     def make_ghz(n: int) -> None:
         def ghz(n: int):
             if n == 1:
@@ -842,8 +838,8 @@ cnot __qubits__[0], __qubits__[4];"""
 
 
 def test_double_decorated_function():
-    @aq.function
-    @aq.function
+    @aq.main
+    @aq.main
     def empty_program() -> None:
         pass
 
@@ -852,7 +848,7 @@ def test_double_decorated_function():
 
 
 def test_main_return():
-    @aq.function
+    @aq.main
     def main() -> int:
         return 1
 
@@ -861,13 +857,30 @@ def test_main_return():
 
 
 def test_main_no_return():
-    @aq.function
+    @aq.main
     def tester(x: int) -> int:
         return measure(x)
 
-    @aq.function(num_qubits=3)
+    @aq.main(num_qubits=3)
     def main():
         x = 3
         tester(x)
 
     main()
+
+
+# TODO test new functionality
+# subroutine directly, subroutine from subroutine, main from main
+
+# this can't happen anymore but should still be tested (subroutine doesn't take args)
+# def test_mismatched_qubits():
+#     @aq.subroutine(num_qubits=4)
+#     def subroutine() -> None:
+#         _ = measure(0)
+
+#     @aq.main(num_qubits=8)
+#     def main() -> None:
+#         subroutine()
+
+#     with pytest.raises(errors.InconsistentNumQubits):
+#         main()

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -869,18 +869,51 @@ def test_main_no_return():
     main()
 
 
-# TODO test new functionality
-# subroutine directly, subroutine from subroutine, main from main
+def test_subroutine_args():
+    """Test that subroutines will fail if supplied args."""
+    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
 
-# this can't happen anymore but should still be tested (subroutine doesn't take args)
-# def test_mismatched_qubits():
-#     @aq.subroutine(num_qubits=4)
-#     def subroutine() -> None:
-#         _ = measure(0)
+        @aq.subroutine(num_qubits=5)
+        def bell(q0: int, q1: int) -> None:
+            h(q0)
+            cnot(q0, q1)
 
-#     @aq.main(num_qubits=8)
-#     def main() -> None:
-#         subroutine()
 
-#     with pytest.raises(errors.InconsistentNumQubits):
-#         main()
+def test_direct_subroutine_call_w_args():
+    """Shouldn't be able to call a subroutine directly."""
+
+    @aq.subroutine
+    def bell(q0: int, q1: int) -> None:
+        h(q0)
+        cnot(q0, q1)
+
+    with pytest.raises(errors.AutoQasmTypeError):
+        bell()
+
+
+def test_direct_subroutine_call_no_args():
+    """Shouldn't be able to call a subroutine directly."""
+
+    @aq.subroutine
+    def bell() -> None:
+        h(0)
+        cnot(0, 1)
+
+    with pytest.raises(errors.AutoQasmTypeError):
+        bell()
+
+
+def test_main_from_main():
+    """Can't call main from main!"""
+
+    @aq.main
+    def bell(q0: int, q1: int) -> None:
+        h(q0)
+        cnot(q0, q1)
+
+    @aq.main
+    def main():
+        bell(0, 1)
+
+    with pytest.raises(errors.AutoQasmTypeError):
+        main()

--- a/test/unit_tests/braket/experimental/autoqasm/test_converters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_converters.py
@@ -62,7 +62,7 @@ e = a;"""
 
 
 def test_break_for_loop():
-    @aq.function
+    @aq.main
     def main():
         for i in aq.range(3):
             aq.gates.h(i)
@@ -73,7 +73,7 @@ def test_break_for_loop():
 
 
 def test_break_while_loop():
-    @aq.function
+    @aq.main
     def uses_while_w_break():
         while aq.gates.measure(0):
             aq.gates.x(0)

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_decorator.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_decorator.py
@@ -29,7 +29,7 @@ def empty_gate(q: aq.Qubit):
 
 
 def test_empty_gate() -> None:
-    @aq.function
+    @aq.main
     def my_program():
         empty_gate(0)
 
@@ -48,7 +48,7 @@ empty_gate __qubits__[0];"""
 def test_double_gate_decorator() -> None:
     double_decorated = aq.gate(empty_gate)
 
-    @aq.function
+    @aq.main
     def my_program():
         double_decorated(0)
 
@@ -70,7 +70,7 @@ def test_gate_class() -> None:
         def __init__(self, q: aq.Qubit):
             h(q)
 
-    @aq.function
+    @aq.main
     def main():
         MyGate(0)
 
@@ -84,7 +84,7 @@ def test_invalid_symbol() -> None:
         h(q)
         not_a_symbol()  # noqa: F821 # type: ignore
 
-    @aq.function
+    @aq.main
     def main():
         my_gate(0)
 
@@ -101,7 +101,7 @@ def test_duplicate_gate_names() -> None:
     def my_gate(q: aq.Qubit, angle: float):  # noqa: F811
         rx(q, angle)
 
-    @aq.function
+    @aq.main
     def main():
         my_gate(0, np.pi / 4)
 
@@ -119,7 +119,7 @@ my_gate(pi / 4) __qubits__[0];"""
 def test_duplicate_gate_names_in_subroutine() -> None:
     """Verify that gates can only be defined at the top level."""
 
-    @aq.function
+    @aq.subroutine
     def define_gate_in_subroutine():
         @aq.gate
         def my_gate(q: aq.Qubit):
@@ -131,7 +131,7 @@ def test_duplicate_gate_names_in_subroutine() -> None:
     def my_gate(q: aq.Qubit, angle: float):
         rx(q, angle)
 
-    @aq.function
+    @aq.main
     def main():
         my_gate(0, np.pi / 4)
         define_gate_in_subroutine()
@@ -157,7 +157,7 @@ def test_incorrect_arg_count() -> None:
         h(q0)
         x(q1)
 
-    @aq.function
+    @aq.main
     def incorrect_arg_count():
         my_gate(0)
 
@@ -174,7 +174,7 @@ def test_incorrect_arg_types() -> None:
         h(q)
         rx(q, theta)
 
-    @aq.function
+    @aq.main
     def incorrect_arg_types():
         my_gate(0.25, 0)
 
@@ -187,7 +187,7 @@ def test_missing_annotation() -> None:
     def my_gate(a):
         pass
 
-    @aq.function
+    @aq.main
     def my_program():
         my_gate("test")
 
@@ -200,7 +200,7 @@ def test_incorrect_annotation() -> None:
     def my_gate(a: str):
         pass
 
-    @aq.function
+    @aq.main
     def my_program():
         my_gate("test")
 
@@ -213,7 +213,7 @@ def test_no_qubit_args() -> None:
     def not_a_gate(angle: float):
         pass
 
-    @aq.function
+    @aq.main
     def my_program():
         not_a_gate(np.pi)
 
@@ -230,7 +230,7 @@ def test_invalid_qubit_used() -> None:
         h(q)
         x(1)  # invalid
 
-    @aq.function
+    @aq.main
     def my_program():
         my_gate(0)
 
@@ -252,7 +252,7 @@ def test_nested_gates() -> None:
         t(q)
         rx(q, theta)
 
-    @aq.function
+    @aq.main
     def my_program():
         my_gate(0, np.pi / 4)
         my_gate(1, 3 * np.pi / 4)
@@ -285,12 +285,12 @@ def test_gate_called_from_subroutine() -> None:
     def t(q: aq.Qubit):
         rz(q, np.pi / 4)
 
-    @aq.function
+    @aq.subroutine
     def subroutine(q0: int, q1: int):
         t(q0)
         t(q1)
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main():
         subroutine(0, 1)
         subroutine(2, 3)

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -85,7 +85,7 @@ def test_conditional_expressions_py_cond(if_true: dict, if_false: dict) -> None:
 def test_inline_conditional_assignment() -> None:
     """Tests conditional expression where the if and else clauses return different types."""
 
-    @aq.function
+    @aq.main
     def cond_exp_assignment():
         a = aq.IntVar(2) * aq.IntVar(3) if aq.BoolVar(True) else aq.IntVar(4)  # noqa: F841
 
@@ -118,7 +118,7 @@ a = __int_3__;"""
 def test_unsupported_inline_conditional_assignment(else_value) -> None:
     """Tests conditional expression where the if and else clauses return different types."""
 
-    @aq.function
+    @aq.main
     def cond_exp_assignment_different_types():
         a = aq.IntVar(1) if aq.BoolVar(True) else else_value()  # noqa: F841
 
@@ -129,7 +129,7 @@ def test_unsupported_inline_conditional_assignment(else_value) -> None:
 def test_branch_assignment_undeclared() -> None:
     """Tests if-else branch where an undeclared variable is assigned in both branches."""
 
-    @aq.function
+    @aq.main
     def branch_assignment_undeclared():
         if aq.BoolVar(True):
             a = aq.IntVar(1)  # noqa: F841
@@ -151,7 +151,7 @@ if (__bool_0__) {
 def test_branch_assignment_declared() -> None:
     """Tests if-else branch where a declared variable is assigned in both branches."""
 
-    @aq.function
+    @aq.main
     def branch_assignment_declared():
         a = aq.IntVar(5)
         if aq.BoolVar(True):
@@ -441,7 +441,7 @@ def test_slice_bits() -> None:
     """Test that bit var slicing and assignment works when assigning to a
     size 1 bit."""
 
-    @aq.function
+    @aq.main
     def slice():
         a = aq.BitVar(0, size=6)
         b = aq.BitVar(1)
@@ -460,7 +460,7 @@ a[3] = b;"""
 def test_slice_bits_w_measure() -> None:
     """Test assignment of one bit in an array to a measurement result."""
 
-    @aq.function
+    @aq.main
     def measure_to_slice():
         b0 = aq.BitVar(size=10)
         c = measure(0)
@@ -606,7 +606,7 @@ def test_assignment_py(value: Any) -> None:
 def test_py_if_stmt(value: int) -> None:
     """Test Python if branches on true and false conditions."""
 
-    @aq.function
+    @aq.main
     def test_control_flow(a: int):
         "Quick if statement test"
         if a:
@@ -625,7 +625,7 @@ qubit[1] __qubits__;
 def test_py_while() -> None:
     """Test Python while loop."""
 
-    @aq.function
+    @aq.main
     def test_control_flow():
         "Quick while loop test"
         a = 3

--- a/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
@@ -20,7 +20,7 @@ from braket.experimental.autoqasm.instructions import cnot, h
 def test_with_verbatim_box() -> None:
     """Tests the with statement with verbatim box `Verbatim`."""
 
-    @aq.function
+    @aq.main
     def program_func() -> None:
         """User program to test."""
         h(0)

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -69,12 +69,12 @@ def test_to_ir() -> None:
 def test_multiprocessing() -> None:
     """Tests multiprocessing with the aq.Program object."""
 
-    @aq.function
+    @aq.subroutine
     def circuit(angle: float):
         rx(0, angle)
         cnot(0, 1)
 
-    @aq.function
+    @aq.main
     def zne(scale: int, angle: float) -> aq.BitVar:
         for i in aq.range(scale):
             circuit(angle)

--- a/test/unit_tests/braket/experimental/autoqasm/test_pulse.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pulse.py
@@ -41,7 +41,7 @@ WAVEFORM = ArbitraryWaveform([complex(1, 0.4), 0, 0.3, complex(0.1, 0.2)], id="a
 def test_mix_gate_pulse() -> None:
     """Test mixed usage of gates and pulses."""
 
-    @aq.function
+    @aq.main
     def my_program():
         shift_frequency(FRAME1, 0.1234)
         rx(1, 0.1)
@@ -71,7 +71,7 @@ def test_mix_gate_pulse() -> None:
 def test_merge_cal_box() -> None:
     """Test subsequent cal boxes are merged."""
 
-    @aq.function
+    @aq.main
     def my_program():
         barrier(0)
         delay([3, 4], 0.34)

--- a/test/unit_tests/braket/experimental/autoqasm/test_transpiler.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_transpiler.py
@@ -23,10 +23,10 @@ from braket.experimental.autoqasm.autograph.core.ag_ctx import ControlStatusCtx,
 from braket.experimental.autoqasm.instructions import cnot, h, measure, x
 
 
-def test_convert_invalid_object() -> None:
-    """Tests the aq.function decorator on something that is not a function."""
+def test_convert_invalid_main_object() -> None:
+    """Tests the aq.main decorator on something that is not a function."""
 
-    @aq.function
+    @aq.main
     class MyClass:
         pass
 
@@ -34,11 +34,26 @@ def test_convert_invalid_object() -> None:
         MyClass()
 
 
+def test_convert_invalid_subroutine_object() -> None:
+    """Tests the aq.subroutine decorator on something that is not a function."""
+
+    @aq.subroutine
+    class MyClass:
+        pass
+
+    @aq.main
+    def main():
+        MyClass()
+
+    with pytest.raises(ValueError):
+        main()
+
+
 def test_autograph_disabled() -> None:
-    """Tests the aq.function decorator with autograph disabled by control status,
+    """Tests the aq.main decorator with autograph disabled by control status,
     and verifies that the function is not converted."""
 
-    @aq.function
+    @aq.main
     def my_program():
         h(0)
         if measure(0):
@@ -50,13 +65,13 @@ def test_autograph_disabled() -> None:
 
 
 def test_partial_function() -> None:
-    """Tests aq.function decorator application to a partial function."""
+    """Tests aq.main decorator application to a partial function."""
 
     def bell(q0: int, q1: int):
         h(q0)
         cnot(q0, q1)
 
-    @aq.function
+    @aq.main
     def bell_decorated(q0: int, q1: int):
         bell(q0, q1)
 
@@ -65,7 +80,7 @@ qubit[4] __qubits__;
 h __qubits__[1];
 cnot __qubits__[1], __qubits__[3];"""
 
-    bell_partial = aq.function(functools.partial(bell, 1))
+    bell_partial = aq.main(functools.partial(bell, 1))
     assert bell_partial(3).to_ir() == expected
 
     bell_decorated_partial = functools.partial(bell_decorated, 1)
@@ -76,7 +91,7 @@ cnot __qubits__[1], __qubits__[3];"""
 
 
 def test_classmethod() -> None:
-    """Tests aq.function decorator application to a classmethod."""
+    """Tests aq.main decorator application to a classmethod."""
 
     class MyClass:
         @classmethod
@@ -85,7 +100,7 @@ def test_classmethod() -> None:
             cnot(q0, q1)
 
         @classmethod
-        @aq.function
+        @aq.main
         def bell_decorated(self, q0: int, q1: int):
             self.bell(q0, q1)
 
@@ -94,18 +109,18 @@ qubit[4] __qubits__;
 h __qubits__[1];
 cnot __qubits__[1], __qubits__[3];"""
 
-    assert aq.function(MyClass.bell)(1, 3).to_ir() == expected
+    assert aq.main(MyClass.bell)(1, 3).to_ir() == expected
     assert MyClass.bell_decorated(1, 3).to_ir() == expected
 
     a = MyClass()
-    assert aq.function(a.bell)(1, 3).to_ir() == expected
+    assert aq.main(a.bell)(1, 3).to_ir() == expected
     assert a.bell_decorated(1, 3).to_ir() == expected
 
 
 def test_with_verbose_logging() -> None:
-    """Tests aq.function decorator application with verbose logging enabled."""
+    """Tests aq.main decorator application with verbose logging enabled."""
 
-    @aq.function
+    @aq.main
     def nothing():
         pass
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -47,12 +47,12 @@ def test_qasm_range(
 def test_return_bit():
     """Test type discovery of bit return values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> aq.BitVar:
         res = aq.BitVar(1)
         return res
 
-    @aq.function
+    @aq.main
     def main() -> aq.BitVar:
         return ret_test()
 
@@ -71,12 +71,12 @@ __bit_1__ = ret_test();"""
 def test_return_int():
     """Test type discovery of int return values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> int:
         res = aq.IntVar(1)
         return res
 
-    @aq.function
+    @aq.main
     def main() -> int:
         return ret_test()
 
@@ -95,12 +95,12 @@ __int_1__ = ret_test();"""
 def test_return_float():
     """Test type discovery of float return values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> float:
         res = aq.FloatVar(1.0)
         return res
 
-    @aq.function
+    @aq.main
     def main() -> float:
         return ret_test()
 
@@ -119,12 +119,12 @@ __float_1__ = ret_test();"""
 def test_return_bool():
     """Test type discovery of boolean return values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> bool:
         res = aq.BoolVar(True)
         return res
 
-    @aq.function
+    @aq.main
     def main() -> bool:
         return ret_test()
 
@@ -143,11 +143,11 @@ __bool_1__ = ret_test();"""
 def test_return_bin_expr():
     """Test type discovery of int return values from an expression."""
 
-    @aq.function
+    @aq.subroutine
     def add(a: int, b: int) -> int:
         return a + b
 
-    @aq.function
+    @aq.main
     def ret_test() -> int:
         a = aq.IntVar(5)
         b = aq.IntVar(6)
@@ -170,7 +170,7 @@ __int_2__ = add(a, b);"""
 def test_return_none():
     """Test discovery of None return annotation."""
 
-    @aq.function
+    @aq.main
     def ret_test() -> None:
         return None
 
@@ -182,12 +182,12 @@ def test_return_none():
 def test_return_array_int():
     """Test return type discovery of array values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> List[int]:
         res = aq.ArrayVar([1, 2, 3], dimensions=[3])
         return res
 
-    @aq.function
+    @aq.main
     def main() -> List[int]:
         return ret_test()
 
@@ -206,11 +206,11 @@ __arr_1__ = ret_test();"""
 def test_return_python_array():
     """Test returning a python array of ints."""
 
-    @aq.function
+    @aq.subroutine
     def tester(arr: List[int]) -> List[int]:
         return [1, 2, 3]
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main():
         tester()
 
@@ -229,11 +229,11 @@ __arr_1__ = tester();"""
 def test_return_array_unsupported():
     """Test unsupported array type."""
 
-    @aq.function
+    @aq.subroutine
     def tester(arr: List[float]) -> List[float]:
         return [1.2, 2.1]
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main():
         tester([3.3])
 
@@ -244,12 +244,12 @@ def test_return_array_unsupported():
 def test_return_func_call():
     """Test returning the result of another function call."""
 
-    @aq.function
+    @aq.subroutine
     def helper() -> int:
         res = aq.IntVar(1)
         return res
 
-    @aq.function
+    @aq.main
     def ret_test() -> int:
         return helper()
 
@@ -268,11 +268,11 @@ __int_1__ = helper();"""
 def test_map_bool():
     """Test boolean input parameter type."""
 
-    @aq.function
+    @aq.subroutine
     def annotation_test(input: bool):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         annotation_test(True)
 
@@ -287,11 +287,11 @@ annotation_test(true);"""
 def test_map_int():
     """Test integer input parameter type."""
 
-    @aq.function
+    @aq.subroutine
     def annotation_test(input: int):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         annotation_test(1)
 
@@ -306,11 +306,11 @@ annotation_test(1);"""
 def test_map_float():
     """Test float input parameter type."""
 
-    @aq.function
+    @aq.subroutine
     def annotation_test(input: float):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         annotation_test(1.0)
 
@@ -325,11 +325,11 @@ annotation_test(1.0);"""
 def test_map_array():
     """Test array input parameter type."""
 
-    @aq.function
+    @aq.subroutine
     def annotation_test(input: List[int]):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         a = aq.ArrayVar([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dimensions=[10])
         annotation_test(a)
@@ -347,11 +347,11 @@ annotation_test(a);"""
 def test_map_other():
     """Test unexpected input parameter type handling."""
 
-    @aq.function
+    @aq.subroutine
     def annotation_test(input: aq.BitVar):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         a = aq.BitVar(1)
         annotation_test(a)
@@ -369,11 +369,11 @@ annotation_test(a);"""
 def test_map_other_unnamed_arg():
     """Test unexpected input parameter type handling with unnamed arg."""
 
-    @aq.function
+    @aq.subroutine
     def annotation_test(input: aq.BitVar):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         annotation_test(aq.BitVar(1))
 
@@ -389,12 +389,12 @@ annotation_test(__bit_0__);"""
 def test_map_and_assign_arg():
     """Test input parameter handling which is assigned to another variable."""
 
-    @aq.function
+    @aq.subroutine
     def assign_param(c: int) -> None:
         d = aq.IntVar(4)
         c = d  # noqa: F841
 
-    @aq.function
+    @aq.main
     def main():
         c = aq.IntVar(0)
         assign_param(c)
@@ -415,11 +415,11 @@ assign_param(c);"""
 def test_unnamed_retval_python_type() -> None:
     """Tests subroutines which return unnamed Python values."""
 
-    @aq.function
+    @aq.subroutine
     def retval_test() -> int:
         return 1
 
-    @aq.function
+    @aq.main
     def caller() -> int:
         return retval_test()
 
@@ -438,11 +438,11 @@ __int_1__ = retval_test();"""
 def test_unnamed_retval_qasm_type() -> None:
     """Tests subroutines which return unnamed QASM values."""
 
-    @aq.function
+    @aq.subroutine
     def retval_test() -> aq.BitVar:
         return aq.BitVar(1)
 
-    @aq.function
+    @aq.main
     def caller() -> aq.BitVar:
         return retval_test()
 
@@ -461,10 +461,14 @@ __bit_1__ = retval_test();"""
 def test_recursive_unassigned_retval_python_type() -> None:
     """Tests recursive subroutines which do not assign the return value to a variable."""
 
-    @aq.function
+    @aq.subroutine
     def retval_recursive() -> int:
         retval_recursive()
         return 1
+
+    @aq.main
+    def main():
+        retval_recursive()
 
     expected_qasm = """OPENQASM 3.0;
 def retval_recursive() -> int[32] {
@@ -474,21 +478,23 @@ def retval_recursive() -> int[32] {
     retval_ = 1;
     return retval_;
 }
-int[32] retval_;
 int[32] __int_3__;
-__int_3__ = retval_recursive();
-retval_ = 1;"""
+__int_3__ = retval_recursive();"""
 
-    assert retval_recursive().to_ir() == expected_qasm
+    assert main().to_ir() == expected_qasm
 
 
 def test_recursive_assigned_retval_python_type() -> None:
     """Tests recursive subroutines which assign the return value to a variable."""
 
-    @aq.function
+    @aq.subroutine
     def retval_recursive() -> int:
         a = retval_recursive()  # noqa: F841
         return 1
+
+    @aq.main
+    def main():
+        retval_recursive()
 
     expected_qasm = """OPENQASM 3.0;
 def retval_recursive() -> int[32] {
@@ -500,29 +506,25 @@ def retval_recursive() -> int[32] {
     retval_ = 1;
     return retval_;
 }
-int[32] a;
-int[32] retval_;
 int[32] __int_3__;
-__int_3__ = retval_recursive();
-a = __int_3__;
-retval_ = 1;"""
+__int_3__ = retval_recursive();"""
 
-    assert retval_recursive().to_ir() == expected_qasm
+    assert main().to_ir() == expected_qasm
 
 
 def test_recursive_retval_expression_python_type() -> None:
     """Tests recursive subroutines which use the return value in an expression."""
 
-    @aq.function
+    @aq.subroutine
     def retval_constant() -> int:
         return 3
 
-    @aq.function
+    @aq.subroutine
     def retval_recursive() -> float:
         a = 2 * retval_recursive() + (retval_constant() + 2) / 3
         return a
 
-    @aq.function
+    @aq.main
     def caller() -> int:
         return retval_recursive()
 
@@ -548,33 +550,41 @@ __float_4__ = retval_recursive();"""
 def test_recursive_list() -> None:
     """Tests recursive subroutines which return a list."""
 
-    @aq.function
+    @aq.subroutine
     def retval_recursive() -> List[int]:
         retval_recursive()
         return [1]
 
-    assert "-> array[int[32], 10]" in retval_recursive().to_ir()
+    @aq.main
+    def main():
+        retval_recursive()
+
+    assert "-> array[int[32], 10]" in main().to_ir()
 
 
 def test_recursive_oqpy_type() -> None:
     """Tests recursive subroutines which returns an oqpy type."""
 
-    @aq.function
+    @aq.subroutine
     def retval_recursive() -> aq.BitVar:
         retval_recursive()
         return aq.BitVar(0)
 
-    assert "-> bit" in retval_recursive().to_ir()
+    @aq.main
+    def main():
+        retval_recursive()
+
+    assert "-> bit" in main().to_ir()
 
 
 def test_error_for_tuple_param() -> None:
     """Tuples are not supported as parameters."""
 
-    @aq.function
+    @aq.subroutine
     def param_test(input: Tuple):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         param_test(aq.BitVar(1))
 
@@ -585,11 +595,11 @@ def test_error_for_tuple_param() -> None:
 def test_error_for_missing_param_type() -> None:
     """Parameters require type hints."""
 
-    @aq.function
+    @aq.subroutine
     def param_test(input):
         pass
 
-    @aq.function
+    @aq.main
     def main():
         param_test(aq.BitVar(1))
 
@@ -600,11 +610,11 @@ def test_error_for_missing_param_type() -> None:
 def test_ignore_ret_typehint_bool():
     """Test type discovery of boolean return values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> List[int]:
         return True
 
-    @aq.function
+    @aq.main
     def main() -> bool:
         ret_test()
 
@@ -623,11 +633,11 @@ __bool_1__ = ret_test();"""
 def test_ignore_ret_typehint_list():
     """Test type discovery of list return values."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test() -> int:
         return [1, 2, 3]
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main() -> float:
         ret_test()
 
@@ -647,11 +657,11 @@ __arr_1__ = ret_test();"""
 def test_ignore_missing_ret_typehint_list():
     """Test type discovery of return types with no annotations."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test():
         return [1, 2, 3]
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main():
         ret_test()
 
@@ -671,11 +681,11 @@ __arr_1__ = ret_test();"""
 def test_ignore_missing_ret_typehint_float():
     """Test type discovery of return types with no annotations."""
 
-    @aq.function
+    @aq.subroutine
     def ret_test():
         return 1.2
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main():
         ret_test()
 
@@ -695,11 +705,11 @@ __float_1__ = ret_test();"""
 def test_param_array_list_missing_arg():
     """Test list parameter with missing type arg (list rather than list[int])."""
 
-    @aq.function
+    @aq.subroutine
     def param_test(arr: List) -> int:
         return 1
 
-    @aq.function(num_qubits=4)
+    @aq.main(num_qubits=4)
     def main():
         param_test()
 


### PR DESCRIPTION
## Issue #, if available:
https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=35858838

## Description of changes:
Split `aq.function` into `aq.main` and `aq.subroutine`.

I am planning to do a follow up PR to refactor api.py

### Example
input
```
@aq.subroutine
def bell(q0: int, q1: int):
    h(q0)
    cnot(q0, q1)

@aq.subroutine
def ghz_n(n: int):
    if n < 2:
        return
    for i in aq.range(n - 1):
        bell(i, i + 1)

@aq.main(num_qubits=6)
def main():
    ghz_n(6)
```
generated code
```
OPENQASM 3.0;
def bell(int[32] q0, int[32] q1) {
    h __qubits__[q0];
    cnot __qubits__[q0], __qubits__[q1];
}
def ghz_n(int[32] n) {
    if (n < 2) {
    } else {
        for int i in [0:n - 1 - 1] {
            bell(i, i + 1);
        }
    }
}
qubit[6] __qubits__;
ghz_n(6);
```

### Reasoning
**What's allowed at the global scope is not the same as what is allowed within a `subroutine`:** https://openqasm.com/language/scope.html#global-scope

Programming languages (including OpenQASM, Python, C++, Java) distinguish functions from the global scope in some way. For example, in Python:
```
print("Hello, World!")
```
is not the same as:
```
def wont_print():
    print("Hello, World!")
```

The same is true in OpenQASM:
```
h $0;
```
isn't the same as:
```
def subroutine():
    h $0;
```

It turns out, this distinction does matter to us even within AutoQASM. A great example of this is qubit declarations -- qubits are global resources and cannot be defined in subroutines. By separating out `main` from `subroutine`, we *completely eliminate* (!!) a failure mode for our customers. It's no longer possible to write AutoQASM code that declares 10 qubits in one function, but 20 qubits in a nested function call.

This separation also opens the door for us to do more careful error handling and program inspection wrt global scope

## Testing done:
Unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
