### PR TITLE
Move error handling into the context manager

### DIFF
--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -284,6 +284,13 @@ def build_program(user_config: Optional[UserConfig] = None) -> None:
             _get_local().program_conversion_context = ProgramConversionContext(user_config)
             owns_program_conversion_context = True
         yield _get_local().program_conversion_context
+    except Exception as e:
+        if isinstance(e, errors.AutoQasmError):
+            raise
+        elif hasattr(e, "ag_error_metadata"):
+            raise e.ag_error_metadata.to_exception(e)
+        else:
+            raise
     finally:
         if owns_program_conversion_context:
             _get_local().program_conversion_context = None


### PR DESCRIPTION
Doing an AutoQASM `api.py` refactor. Making this as a first, small PR, because it is separable, and a gitdiff with indentation changes and other changes can be confusing.

There are NO code changes beyond de-dentation and moving code

Source: https://vaclavkosar.com/software/Python-Context-Manager-With-Statement-Exception-Handling