### PR TITLE
Use a callback to simplify autoqasm/api logic

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -54,6 +54,7 @@ def main(*args, num_qubits: Optional[int] = None) -> Callable[[Any], aq_program.
     user_config = aq_program.UserConfig(num_qubits=num_qubits)
 
     if not args:
+
         def _function_with_params(f: Callable) -> Callable[[Any], aq_program.Program]:
             return _function_wrapper(f, _convert_main, converter_args={"user_config": user_config})
 

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -17,7 +17,7 @@ import copy
 import functools
 import inspect
 from types import FunctionType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import openqasm3.ast as qasm_ast
 import oqpy.base
@@ -28,7 +28,7 @@ import braket.experimental.autoqasm.program as aq_program
 import braket.experimental.autoqasm.transpiler as aq_transpiler
 import braket.experimental.autoqasm.types as aq_types
 from braket.experimental.autoqasm import errors
-from braket.experimental.autoqasm.autograph.core import ag_ctx, converter
+from braket.experimental.autoqasm.autograph.core import converter
 from braket.experimental.autoqasm.autograph.impl.api_core import (
     autograph_artifact,
     is_autograph_artifact,


### PR DESCRIPTION
Refactor api.py part 2

 - Was able to consolidate duplicated code through a callback function
     - Minus 100 LOC!
 - Also discovered that NullContext doesn't have any affect (used in place of optional context managers: https://docs.python.org/3/library/contextlib.html)

The diff is a bit confusing, so here's a more detailed description:
 - There are three decorators: `main`, `subroutine` and `gate`. Each call `_function_wrapper`
 - There are three decorator converters: `_convert_main`, `_convert_subroutine` and `_convert_gate`
 - `_convert_program_wrapper` and `_convert_gate_wrapper` are merged into `_function_wrapper`
 - `_function_wrapper` accepts a callback, which is one of the `_convert_X` functions
 - `_convert_program` is deleted, and its code is subsumed into `_convert_main` and/or `_convert_subroutine`, as necessary
 - `is_subroutine` is no longer necessary
 - user_config is the only extra argument to the `_convert_X` functions, and only needed by `_convert_main`
 - converter option for `recursive` was always set to `False`, and it defaults to `False`, so I removed it
 - `_add_qubit_declaration` was moved to be local to its caller without code changes
 - moved private functions to follow "step down" ordering -- this means functions are called in closer proximity to where they are defined. This is particularly appropriate here because most of the helper functions are called from only one other function
 - removed unnecessary `_decorator` wrapper which did nothing