### PR TITLE
fix: enforce that AutoQASM gates only contain unitary gate operations

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -413,7 +413,6 @@ def _convert_gate(
 
     # Process the gate definition
     with program_conversion_context.gate_definition(gate_name, gate_args):
-        # TODO - enforce that nothing gets added to the program inside here except gates
         wrapped_f(gate_args._args)
 
     # Add the gate definition to the root-level program if necessary

--- a/src/braket/experimental/autoqasm/instructions/instructions.py
+++ b/src/braket/experimental/autoqasm/instructions/instructions.py
@@ -22,14 +22,20 @@ from braket.experimental.autoqasm import program as aq_program
 from .qubits import QubitIdentifierType, _qubit
 
 
-def _qubit_instruction(name: str, qubits: List[QubitIdentifierType], *args: Any) -> None:
+def _qubit_instruction(
+    name: str, qubits: List[QubitIdentifierType], *args: Any, is_unitary: bool = True
+) -> None:
     # If this is an instruction inside a gate definition, ensure that it only operates on
-    # qubits which are passed as arguments to the gate definition.
+    # qubits and angles which are passed as arguments to the gate definition.
     program_conversion_context = aq_program.get_program_conversion_context()
-    program_conversion_context.validate_target_qubits(qubits)
+    program_conversion_context.validate_gate_targets(qubits, args)
 
     # Add the instruction to the program.
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = (
+        program_conversion_context.get_oqpy_program_unitary()
+        if is_unitary
+        else program_conversion_context.get_oqpy_program()
+    )
     oqpy_program.gate([_qubit(q) for q in qubits], name, *args)
 
 
@@ -39,4 +45,4 @@ def reset(target: QubitIdentifierType) -> None:
     Args:
         target (QubitIdentifierType): The target qubit.
     """
-    _qubit_instruction("reset", [target])
+    _qubit_instruction("reset", [target], is_unitary=False)


### PR DESCRIPTION
*Issue #, if available:*
- [Support gate subroutine as `aq.gate`](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=32539968)

*Description of changes:*
- Enforce that the `oqpy.Program` object is not accessed during a gate definition except to add calls to other gates.

*Testing done:*
- Tests added to verify new constraints.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
