### PR TITLE
test: speed up pulse time trace and add test timing outputs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test=pytest
 xfail_strict = true
 # https://pytest-xdist.readthedocs.io/en/latest/known-limitations.html
 addopts =
-    --verbose -n auto
+    --verbose -n auto --durations=0 --durations-min=1
 testpaths = test/unit_tests
 
 [isort]

--- a/test/unit_tests/braket/pulse/test_pulse_sequence.py
+++ b/test/unit_tests/braket/pulse/test_pulse_sequence.py
@@ -27,7 +27,7 @@ from braket.pulse import (
 
 @pytest.fixture
 def port():
-    return Port(port_id="device_port_x0", dt=1e-9, properties={})
+    return Port(port_id="device_port_x0", dt=1e-3, properties={})
 
 
 @pytest.fixture


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will allow for users to see tests taking a long time. In this context, long is set to 1 second but that value can be reduced or increased using the parameter `--durations-min` within `setup.cfg`.

The pytest port was reduced as [test_pulse_sequence_to_time_trace_program_mutation](https://github.com/aws/amazon-braket-sdk-python/blob/main/test/unit_tests/braket/pulse/test_pulse_sequence.py#L273) is taking considerably longer than other tests. The main driving factor in the increased time is writing to 3 dictionaries 1,000,000 times. From the profiling done:
```
6002791 function calls (6002209 primitive calls) in 8.160 seconds
...
3000000    5.880    0.000    6.715    0.000 time_series.py:42(put)
```
This is done in the [ast](https://github.com/aws/amazon-braket-sdk-python/blob/main/src/braket/pulse/ast/approximation_parser.py#L431-L433). An open question is what improvements should be done to bring this time down outside of the test case.


*Testing done:*
```
tox
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
