### PR TITLE
documentation: removed "-" sign from u gate doc

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -1414,7 +1414,7 @@ class U(TripleAngledGate):
 
         .. math:: \mathtt{U}(\theta, \phi, \lambda) = \begin{bmatrix}
                 \cos{(\theta/2)} & -e^{i \lambda} \sin{(\theta/2)} \\
-                e^{i \phi} \sin{(\theta/2)} & -e^{i (\phi + \lambda)} \cos{(\theta/2)}
+                e^{i \phi} \sin{(\theta/2)} &  e^{i (\phi + \lambda)} \cos{(\theta/2)}
                 \end{bmatrix}.
 
     Args:
@@ -1489,7 +1489,7 @@ class U(TripleAngledGate):
 
             .. math:: \mathtt{U}(\theta, \phi, \lambda) = \begin{bmatrix}
                     \cos{(\theta/2)} & -e^{i \lambda} \sin{(\theta/2)} \\
-                    e^{i \phi} \sin{(\theta/2)} & -e^{i (\phi + \lambda)} \cos{(\theta/2)}
+                    e^{i \phi} \sin{(\theta/2)} & e^{i (\phi + \lambda)} \cos{(\theta/2)}
                     \end{bmatrix}.
 
         Args:


### PR DESCRIPTION
*Issue #, if available:*

#1117

*Description of changes:*

Removed "-" sign from (1,1) element of u gate docstring. 

*Testing done:*

Confirmed signs in function. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
