### PR TITLE
fix: Always include program inputs in from_ir

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1336,10 +1336,10 @@ class Circuit:
             Circuit: Braket Circuit implementing the OpenQASM program.
         """
         if isinstance(source, OpenQasmProgram):
+            inputs_copy = source.inputs.copy() if source.inputs is not None else {}
             if inputs:
-                inputs_copy = source.inputs.copy() if source.inputs is not None else {}
                 inputs_copy.update(inputs)
-                inputs = inputs_copy
+            inputs = inputs_copy
             source = source.source
         from braket.circuits.braket_program_context import BraketProgramContext  # noqa: PLC0415
 

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -2208,6 +2208,24 @@ def test_from_ir_inputs_updated():
     assert Circuit.from_ir(source=openqasm, inputs={"phi": 0.1}) == circuit
 
 
+def test_from_ir_program_inputs_only():
+    circuit = Circuit().rx(0, FreeParameter("theta")).ry(0, 0.3).measure(0)
+    openqasm = OpenQasmProgram(
+        source="\n".join([
+            "OPENQASM 3.0;",
+            "input float theta;",
+            "input float phi;",
+            "bit[1] b;",
+            "qubit[1] q;",
+            "rx(theta) q[0];",
+            "ry(phi) q[0];",
+            "b[0] = measure q[0];",
+        ]),
+        inputs={"phi": 0.3},
+    )
+    assert Circuit.from_ir(source=openqasm) == circuit
+
+
 @pytest.mark.parametrize(
     "expected_circuit, ir",
     [


### PR DESCRIPTION
Fixes a bug where a `Program`'s inputs would be ignored altogether if `inputs` isn't directly passed to `from_ir`.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
