### PR TITLE
fix: entry point module name for py312 and up

### DIFF
--- a/src/braket/jobs/hybrid_job.py
+++ b/src/braket/jobs/hybrid_job.py
@@ -218,7 +218,7 @@ def hybrid_job(
                     "device": device or "local:none/none",
                     "source_module": temp_dir,
                     "entry_point": (
-                        f"{temp_dir}.{entry_point_file_path.stem}:{entry_point.__name__}"
+                        f"{temp_dir_path.name}.{entry_point_file_path.stem}:{entry_point.__name__}"
                     ),
                     "wait_until_complete": wait_until_complete,
                     "job_name": job_name or _generate_default_job_name(func=entry_point),

--- a/test/integ_tests/test_create_local_quantum_job.py
+++ b/test/integ_tests/test_create_local_quantum_job.py
@@ -14,11 +14,13 @@
 import json
 import os
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
 
+from braket.jobs import hybrid_job
 from braket.jobs.local import LocalQuantumJob
 
 
@@ -152,3 +154,14 @@ def test_failed_local_job(aws_session, capsys):
                 assert data in log_data
         finally:
             os.chdir(current_dir)
+
+
+def test_decorator_local_job_invalid_image():
+    @hybrid_job(device=None, image_uri="fake", local=True)
+    def empty_decorator_job():
+        pass
+
+    with pytest.raises(subprocess.CalledProcessError):
+        # Should successfully get all the way to LocalQuantumJob.create,
+        # but docker subprocess call will fail due to invalid image URI.
+        empty_decorator_job()


### PR DESCRIPTION
*Issue #, if available:*
This should fix the error being seen in https://github.com/amazon-braket/amazon-braket-examples/pull/742

https://github.com/amazon-braket/amazon-braket-examples/actions/runs/18149264735/job/51656751915#step:6:1742

The error looks like:
```
ModuleNotFoundError: No module named '/home/runner/work/amazon-braket-examples/amazon-braket-examples/examples/hybrid_jobs/0_Creating_your_first_Hybrid_Job/decorator_job_kcld_4pe'
```

The module name should just be `decorator_job_kcld_4pe`.
Instead, it's using the full path `/home/runner/work/amazon-braket-examples/amazon-braket-examples/examples/hybrid_jobs/0_Creating_your_first_Hybrid_Job/decorator_job_kcld_4pe`

The issue is that starting in Python 3.12, [mkdtemp()](https://docs.python.org/3/library/tempfile.html#tempfile.mkdtemp) now always returns an absolute path, even if dir is relative. That affects this line in particular:
https://github.com/amazon-braket/amazon-braket-sdk-python/blob/3242b8f13a4b7799e8705ca2a1f7cea2ad542adc/src/braket/jobs/hybrid_job.py#L196
and the following code which assumes that `temp_dir` is a relative path (i.e. just the folder name).

*Description of changes:*
Fix the logic that assumes the temporary directory is relative - use only the directory name as the entry point module name, rather than the whole path.

Note this is not currently a user-visible bug, since the `@hybrid_job` decorator is only supported on Python 3.10. However, the integ tests in the examples repo mock out the image tag which allows them to run on all Python versions - so this fix is necessary to get those tests working for Python 3.12 and up (and will be needed eventually when we upgrade our image Python versions).

*Testing done:*
Added integ test which exercises this code path for all Python versions. Confirmed that the test fails on Python 3.13 without the code change, and passes with the code change.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
