### PR TITLE
doc: points to braket doc when using experimental caps

### DIFF
--- a/src/braket/experimental_capabilities/experimental_capability_context.py
+++ b/src/braket/experimental_capabilities/experimental_capability_context.py
@@ -86,8 +86,9 @@ class EnableExperimentalCapability:
 
         warnings.warn(
             (
-                "You are enabling experimental capabilities. To view descriptions and restrictions of "
-                "experimental capabilities, please review Amazon Braket Developer Guide ("
+                "You are enabling experimental capabilities. To view descriptions and "
+                "restrictions of experimental capabilities, please review Amazon Braket "
+                "Developer Guide ("
                 "https://docs.aws.amazon.com/braket/latest/developerguide/braket-experimental-capabilities.html"
                 ")."
             ),


### PR DESCRIPTION
*Description of changes:*
When using experimental capabilities, it is sometimes unclear what limitations the capabilities have. This PR adds a warning to points to the doc page.

`stacklevel` is set to 1 so that the warning only shows up when called the first time. Subsequent calls will not throw warning.

*Testing done:*
tox 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
