### PR TITLE
feat: support barrier in `from_ir` method

### DIFF
--- a/src/braket/circuits/braket_program_context.py
+++ b/src/braket/circuits/braket_program_context.py
@@ -20,6 +20,7 @@ from braket.ir.jaqcd.program_v1 import Results
 from sympy import Expr, Number
 
 from braket.circuits import Circuit, Instruction
+from braket.circuits.compiler_directives import Barrier
 from braket.circuits.gates import Unitary
 from braket.circuits.measure import Measure
 from braket.circuits.noises import Kraus
@@ -29,9 +30,8 @@ from braket.circuits.translations import (
     braket_result_to_result_type,
     one_prob_noise_map,
 )
-from braket.circuits.compiler_directives import Barrier
-from braket.registers.qubit_set import QubitSet, QubitSetInput
 from braket.parametric import FreeParameterExpression
+from braket.registers.qubit_set import QubitSet, QubitSetInput
 
 
 class BraketProgramContext(AbstractProgramContext):
@@ -188,7 +188,7 @@ class BraketProgramContext(AbstractProgramContext):
                 applies barrier to all qubits in the circuit.
         """
         target_qubits = self._circuit.qubits if target is None else QubitSet(target)
-        
+
         if target_qubits:
             instruction = Instruction(Barrier(list(target_qubits)), target=target_qubits)
             self._circuit.add_instruction(instruction)

--- a/src/braket/circuits/braket_program_context.py
+++ b/src/braket/circuits/braket_program_context.py
@@ -29,6 +29,8 @@ from braket.circuits.translations import (
     braket_result_to_result_type,
     one_prob_noise_map,
 )
+from braket.circuits.compiler_directives import Barrier
+from braket.registers.qubit_set import QubitSet, QubitSetInput
 from braket.parametric import FreeParameterExpression
 
 
@@ -177,3 +179,16 @@ class BraketProgramContext(AbstractProgramContext):
 
     def add_verbatim_marker(self, marker: VerbatimBoxDelimiter) -> None:
         self._circuit.add_instruction(Instruction(COMPILER_DIRECTIVES[marker](), target=[]))
+
+    def add_barrier(self, target: QubitSetInput | None = None) -> None:
+        """Add a barrier instruction to the circuit.
+
+        Args:
+            target (QubitSetInput | None): Target qubits for the barrier. If None,
+                applies barrier to all qubits in the circuit.
+        """
+        target_qubits = self._circuit.qubits if target is None else QubitSet(target)
+        
+        if target_qubits:
+            instruction = Instruction(Barrier(list(target_qubits)), target=target_qubits)
+            self._circuit.add_instruction(instruction)

--- a/src/braket/circuits/translations.py
+++ b/src/braket/circuits/translations.py
@@ -30,7 +30,7 @@ from braket.ir.jaqcd.program_v1 import Results
 
 import braket.circuits.gates as braket_gates
 from braket.circuits import Observable, ResultType, noises, observables, result_types
-from braket.circuits.compiler_directives import EndVerbatimBox, StartVerbatimBox, Barrier
+from braket.circuits.compiler_directives import Barrier, EndVerbatimBox, StartVerbatimBox
 from braket.experimental_capabilities.iqm.classical_control import CCPRx, MeasureFF
 
 BRAKET_GATES = {

--- a/src/braket/circuits/translations.py
+++ b/src/braket/circuits/translations.py
@@ -30,7 +30,7 @@ from braket.ir.jaqcd.program_v1 import Results
 
 import braket.circuits.gates as braket_gates
 from braket.circuits import Observable, ResultType, noises, observables, result_types
-from braket.circuits.compiler_directives import EndVerbatimBox, StartVerbatimBox
+from braket.circuits.compiler_directives import EndVerbatimBox, StartVerbatimBox, Barrier
 from braket.experimental_capabilities.iqm.classical_control import CCPRx, MeasureFF
 
 BRAKET_GATES = {
@@ -76,6 +76,7 @@ BRAKET_GATES = {
     "unitary": braket_gates.Unitary,
     "cc_prx": CCPRx,
     "measure_ff": MeasureFF,
+    "barrier": Barrier,
 }
 
 COMPILER_DIRECTIVES = {

--- a/src/braket/circuits/translations.py
+++ b/src/braket/circuits/translations.py
@@ -30,7 +30,7 @@ from braket.ir.jaqcd.program_v1 import Results
 
 import braket.circuits.gates as braket_gates
 from braket.circuits import Observable, ResultType, noises, observables, result_types
-from braket.circuits.compiler_directives import Barrier, EndVerbatimBox, StartVerbatimBox
+from braket.circuits.compiler_directives import EndVerbatimBox, StartVerbatimBox
 from braket.experimental_capabilities.iqm.classical_control import CCPRx, MeasureFF
 
 BRAKET_GATES = {
@@ -76,7 +76,6 @@ BRAKET_GATES = {
     "unitary": braket_gates.Unitary,
     "cc_prx": CCPRx,
     "measure_ff": MeasureFF,
-    "barrier": Barrier,
 }
 
 COMPILER_DIRECTIVES = {

--- a/test/unit_tests/braket/circuits/test_braket_program_context.py
+++ b/test/unit_tests/braket/circuits/test_braket_program_context.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from braket.circuits import Circuit, compiler_directives
+from braket.circuits.braket_program_context import BraketProgramContext
+from braket.circuits.qubit_set import QubitSet
+
+
+@pytest.mark.parametrize(
+    "target, expected_instruction_count",
+    [
+        ([0, 1], 3),
+        ([], 2),
+        (None, 3),
+    ],
+)
+def test_add_barrier(target, expected_instruction_count):
+    """Test BraketProgramContext.add_barrier with various target inputs."""
+    circ = Circuit().h(0).h(1)
+    context = BraketProgramContext(circ)
+    context.add_barrier(target)
+
+    assert len(circ.instructions) == expected_instruction_count
+
+    if expected_instruction_count == 3:
+        barrier_instr = circ.instructions[2]
+        assert isinstance(barrier_instr.operator, compiler_directives.Barrier)
+        if target is None:
+            assert barrier_instr.target == QubitSet([0, 1])
+        else:
+            assert barrier_instr.target == QubitSet(target)

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -984,6 +984,24 @@ def test_from_ir_with_mixed_verbatim_non_verbatim_instr():
     assert actual_circ == expected_circ
 
 
+def test_from_ir_with_barriers():
+    ir = OpenQasmProgram(
+        source="\n".join([
+            "OPENQASM 3.0;",
+            "qubit[3] q;",
+            "h q[0];",
+            "barrier q[0], q[1];",
+            "cnot q[0], q[1];",
+            "barrier;",
+        ]),
+        inputs={},
+    )
+
+    expected_circ = Circuit().h(0).barrier([0, 1]).cnot(0, 1).barrier()
+    actual_circ = Circuit().from_ir(source=ir.source, inputs=ir.inputs)
+    assert actual_circ == expected_circ
+
+
 def test_add_with_instruction_with_default(cnot_instr):
     circ = Circuit().add(cnot_instr)
     assert circ == Circuit().add_instruction(cnot_instr)

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -984,22 +984,39 @@ def test_from_ir_with_mixed_verbatim_non_verbatim_instr():
     assert actual_circ == expected_circ
 
 
-def test_from_ir_with_barriers():
+@pytest.mark.parametrize(
+    "source_lines, expected_circuit",
+    [
+        (
+            [
+                "OPENQASM 3.0;",
+                "qubit[3] q;",
+                "h q[0];",
+                "barrier q[0], q[1];",
+                "cnot q[0], q[1];",
+                "barrier;",
+            ],
+            Circuit().h(0).barrier([0, 1]).cnot(0, 1).barrier(),
+        ),
+        (
+            [
+                "OPENQASM 3.0;",
+                "qubit[2] q;",
+                "h q[0];",
+                "barrier;",
+                "cnot q[0], q[1];",
+            ],
+            Circuit().h(0).barrier().cnot(0, 1),
+        ),
+    ],
+)
+def test_from_ir_with_barriers(source_lines, expected_circuit):
     ir = OpenQasmProgram(
-        source="\n".join([
-            "OPENQASM 3.0;",
-            "qubit[3] q;",
-            "h q[0];",
-            "barrier q[0], q[1];",
-            "cnot q[0], q[1];",
-            "barrier;",
-        ]),
+        source="\n".join(source_lines),
         inputs={},
     )
-
-    expected_circ = Circuit().h(0).barrier([0, 1]).cnot(0, 1).barrier()
     actual_circ = Circuit().from_ir(source=ir.source, inputs=ir.inputs)
-    assert actual_circ == expected_circ
+    assert actual_circ == expected_circuit
 
 
 def test_add_with_instruction_with_default(cnot_instr):


### PR DESCRIPTION
*Description of changes:*
Support barrier in `from_ir` method. `barrier` instructions in a OQ3 program were previously ignore and will not be added to Braket Circuit when calling `Circuit.from_ir()`. This PR fixes this.

- [x] This PR depends on https://github.com/amazon-braket/amazon-braket-default-simulator-python/pull/343, so checks are expected to fail before that PR is merged. Locally, with the interpreter update from simulator repo, all checks passed in tox. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
