### PR TITLE
fix: preserve global barrier semantics

### DIFF
--- a/src/braket/circuits/braket_program_context.py
+++ b/src/braket/circuits/braket_program_context.py
@@ -184,11 +184,8 @@ class BraketProgramContext(AbstractProgramContext):
         """Add a barrier instruction to the circuit.
 
         Args:
-            target (QubitSetInput | None): Target qubits for the barrier. If None,
+            target (QubitSetInput | None): Target qubits for the barrier. If None or empty,
                 applies barrier to all qubits in the circuit.
         """
-        target_qubits = self._circuit.qubits if target is None else QubitSet(target)
-
-        if target_qubits:
-            instruction = Instruction(Barrier(list(target_qubits)), target=target_qubits)
-            self._circuit.add_instruction(instruction)
+        target_qubits = QubitSet() if not target else QubitSet(target)
+        self._circuit.add_instruction(Instruction(Barrier(list(target_qubits)), target_qubits))

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -741,22 +741,25 @@ class Circuit:
 
         Args:
             target (QubitSetInput | None): Target qubits for the barrier.
-            If None, applies to all qubits in the circuit.
+            If None, applies to all qubits in the circuit (including qubits added later).
 
         Returns:
             Circuit: self
+
+        Raises:
+            ValueError: If target is None or empty and circuit has no qubits.
 
         Examples:
             >>> circ = Circuit().h(0).barrier([0, 1]).cnot(0, 1)
             >>> circ = Circuit().h(0).h(1).barrier()  # barrier on all qubits
         """
-        target_qubits = self.qubits if target is None else QubitSet(target)
-
-        if target_qubits:
-            self.add_instruction(
-                Instruction(compiler_directives.Barrier(list(target_qubits)), target=target_qubits)
-            )
-            self._has_compiler_directives = True
+        if not target and not self.qubits:
+            raise ValueError("Cannot add global barrier to empty circuit")
+        target_qubits = QubitSet() if not target else QubitSet(target)
+        self.add_instruction(
+            Instruction(compiler_directives.Barrier(list(target_qubits)), target_qubits)
+        )
+        self._has_compiler_directives = True
         return self
 
     def measure(self, target_qubits: QubitSetInput) -> Circuit:

--- a/test/unit_tests/braket/circuits/test_braket_program_context.py
+++ b/test/unit_tests/braket/circuits/test_braket_program_context.py
@@ -22,7 +22,7 @@ from braket.circuits.qubit_set import QubitSet
     "target, expected_instruction_count",
     [
         ([0, 1], 3),
-        ([], 2),
+        ([], 3),
         (None, 3),
     ],
 )
@@ -37,7 +37,7 @@ def test_add_barrier(target, expected_instruction_count):
     if expected_instruction_count == 3:
         barrier_instr = circ.instructions[2]
         assert isinstance(barrier_instr.operator, compiler_directives.Barrier)
-        if target is None:
-            assert barrier_instr.target == QubitSet([0, 1])
+        if target is None or target == []:
+            assert barrier_instr.target == QubitSet()
         else:
             assert barrier_instr.target == QubitSet(target)

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -3761,18 +3761,24 @@ def test_barrier_all_qubits():
     assert len(circ.instructions) == 3
     barrier_instr = circ.instructions[2]
     assert isinstance(barrier_instr.operator, compiler_directives.Barrier)
-    assert barrier_instr.target == QubitSet([0, 1])
+    assert barrier_instr.target == QubitSet()
+
+
+def test_barrier_applies_to_qubits_added_after():
+    circ = Circuit().rx(0, 3.14).barrier().rx(0, 3.14).rx(1, 3.14)
+    barrier_instr = circ.instructions[1]
+    assert barrier_instr.target == QubitSet()
 
 
 def test_barrier_empty_circuit():
-    circ = Circuit().barrier()
-    assert len(circ.instructions) == 0  # No barrier added to empty circuit
+    with pytest.raises(ValueError, match="Cannot add global barrier to empty circuit"):
+        Circuit().barrier()
 
 
 def test_barrier_none_target():
     circ = Circuit().h(0).h(2).barrier(None)
     barrier_instr = circ.instructions[2]
-    assert barrier_instr.target == QubitSet([0, 2])
+    assert barrier_instr.target == QubitSet()
 
 
 def test_barrier_openqasm_export_specific_qubits():
@@ -3784,7 +3790,7 @@ def test_barrier_openqasm_export_specific_qubits():
 def test_barrier_openqasm_export_all_qubits():
     circ = Circuit().h(0).h(1).barrier().cnot(0, 1)
     qasm = circ.to_ir(IRType.OPENQASM).source
-    assert "barrier q[0], q[1];" in qasm
+    assert "barrier;" in qasm
 
 
 def test_barrier_jaqcd_export_fails():


### PR DESCRIPTION
Changes:
- circuit.py: barrier() stores empty QubitSet for global barriers, raises ValueError on empty circuit
- braket_program_context.py: add_barrier() preserves empty target from OpenQASM
- Updated tests to reflect new behavior

*Issue #, if available:* resolves #1202

*Description of changes:*

Previously, global barriers (barrier with no target) were expanded to specific qubits at creation time, breaking round-trip serialization:
- Circuit().h(0).barrier() exported as 'barrier q[0];' instead of 'barrier;'
- Importing 'barrier;' from OpenQASM would expand to current circuit qubits

This change preserves global barrier semantics:
- Global barriers now store empty QubitSet instead of expanding to circuit qubits
- Export produces 'barrier;' for global barriers
- Import preserves empty target for global barriers
- Round-trip: Circuit -> OpenQASM -> Circuit maintains barrier type

Breaking change: Circuit().barrier() on empty circuit now raises ValueError since a global barrier on zero qubits has no semantic meaning.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)


#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
