### PR TITLE
fix: add barrier gate to BRAKET_GATES

### DIFF
--- a/src/braket/circuits/translations.py
+++ b/src/braket/circuits/translations.py
@@ -30,7 +30,7 @@ from braket.ir.jaqcd.program_v1 import Results
 
 import braket.circuits.gates as braket_gates
 from braket.circuits import Observable, ResultType, noises, observables, result_types
-from braket.circuits.compiler_directives import EndVerbatimBox, StartVerbatimBox
+from braket.circuits.compiler_directives import Barrier, EndVerbatimBox, StartVerbatimBox
 from braket.experimental_capabilities.iqm.classical_control import CCPRx, MeasureFF
 
 BRAKET_GATES = {
@@ -76,6 +76,7 @@ BRAKET_GATES = {
     "unitary": braket_gates.Unitary,
     "cc_prx": CCPRx,
     "measure_ff": MeasureFF,
+    "barrier": Barrier,
 }
 
 COMPILER_DIRECTIVES = {

--- a/test/unit_tests/braket/aws/test_aws_device.py
+++ b/test/unit_tests/braket/aws/test_aws_device.py
@@ -2441,7 +2441,7 @@ MOCK_RIGETTI_QPU_CAPABILITIES_1 = {
     },
     "paradigm": {
         "qubitCount": 3,
-        "nativeGateSet": ["cz", "prx", "cphaseshift"],
+        "nativeGateSet": ["cz", "prx", "cphaseshift", "barrier"],
         "connectivity": {
             "fullyConnected": False,
             "connectivityGraph": {"0": ["1", "2"], "1": ["0"], "2": ["0"]},

--- a/test/unit_tests/braket/emulation/test_local_emulator.py
+++ b/test/unit_tests/braket/emulation/test_local_emulator.py
@@ -176,7 +176,7 @@ def customized_emulator():
 
     device_emu_propertis = DeviceEmulatorProperties(
         qubitCount=2,
-        nativeGateSet=["prx", "cz", "barrier"],
+        nativeGateSet=["prx", "cz"],
         connectivityGraph={},
         oneQubitProperties={
             "0": OneQubitProperties.parse_obj(f1q),
@@ -216,11 +216,3 @@ def test_two_qubit_depolarizing_rate(customized_emulator):
     assert abs(TARGET_F2Q - prob_00) < NUM_SIGMA / np.sqrt(num_samples)
     # If this unit test failed, it could be statistical fluctuation [with 1/370 probability],
     # please retry again.
-
-
-def test_barrier_with_emulator(customized_emulator):
-    circ = Circuit().cz(0, 1).barrier()
-    circ = Circuit().add_verbatim_box(circ)
-    num_samples = NUM_SHOTS
-    result = customized_emulator.run(circ, shots=num_samples).result()
-    assert result is not None

--- a/test/unit_tests/braket/emulation/test_local_emulator.py
+++ b/test/unit_tests/braket/emulation/test_local_emulator.py
@@ -176,7 +176,7 @@ def customized_emulator():
 
     device_emu_propertis = DeviceEmulatorProperties(
         qubitCount=2,
-        nativeGateSet=["prx", "cz"],
+        nativeGateSet=["prx", "cz", "barrier"],
         connectivityGraph={},
         oneQubitProperties={
             "0": OneQubitProperties.parse_obj(f1q),
@@ -216,3 +216,11 @@ def test_two_qubit_depolarizing_rate(customized_emulator):
     assert abs(TARGET_F2Q - prob_00) < NUM_SIGMA / np.sqrt(num_samples)
     # If this unit test failed, it could be statistical fluctuation [with 1/370 probability],
     # please retry again.
+
+
+def test_barrier_with_emulator(customized_emulator):
+    circ = Circuit().cz(0, 1).barrier()
+    circ = Circuit().add_verbatim_box(circ)
+    num_samples = NUM_SHOTS
+    result = customized_emulator.run(circ, shots=num_samples).result()
+    assert result is not None


### PR DESCRIPTION
*Issue #, if available:* resolves #1205

*Description of changes:*
Emulator fails when running circuits with barriers because Barrier was missing from the BRAKET_GATES translation dictionary.

Minimal example to trigger the error:
```
from braket.devices import Devices
from braket.aws import AwsDevice

ankaa = AwsDevice(Devices.Rigetti.Ankaa3)
ankaa.emulator()
```

*Testing done:* 
- added test that would fail without change

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
