### PR TITLE
fix: Accept qubit 0 as valid Barrier target

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -781,7 +781,7 @@ class Circuit:
         """
         if not target and not self.qubits:
             raise ValueError("Cannot add global barrier to empty circuit")
-        target_qubits = QubitSet() if not target else QubitSet(target)
+        target_qubits = QubitSet(target)
         self.add_instruction(
             Instruction(compiler_directives.Barrier(list(target_qubits)), target=target_qubits)
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`QubitSet(None)` creates a `QubitSet([])`, so we do not need the current logic. Additionally the current logic results in `barrier(0)` to be treated as `barrier()` which is incorrect.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
