### PR TITLE
fix: Print statement was altering the circuit

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -781,7 +781,7 @@ class Circuit:
         """
         if not target and not self.qubits:
             raise ValueError("Cannot add global barrier to empty circuit")
-        target_qubits = QubitSet() if not target else QubitSet(target)
+        target_qubits = QubitSet(target)
         self.add_instruction(
             Instruction(compiler_directives.Barrier(list(target_qubits)), target=target_qubits)
         )

--- a/src/braket/circuits/text_diagram_builders/text_circuit_diagram_utils.py
+++ b/src/braket/circuits/text_diagram_builders/text_circuit_diagram_utils.py
@@ -135,7 +135,7 @@ def _get_compiler_directive_qubit_range(item: Instruction, circuit_qubits: Qubit
     if item.operator.name == "Barrier":
         if not item.target or len(item.target) == 0:
             return circuit_qubits
-        return item.target
+        return QubitSet(item.target)
     return circuit_qubits
 
 


### PR DESCRIPTION
*Issue #, if available:*
#1212 
*Description of changes:*

When printing a circuit diagram, the diagram generation code was
mutating barrier instruction targets by storing a direct reference
instead of a copy. This caused incorrect OpenQASM output when the
circuit was printed before calling to_ir().

Root cause: The _get_compiler_directive_qubit_range() function in
text_circuit_diagram_utils.py returned item.target directly. This
reference was stored in the grouping data structure and later
mutated when other instructions in the same time slice were added.

Fix: Return QubitSet(item.target) to create a copy instead of
returning the direct reference.

*Testing done:*

Added test: test_barrier_target_not_mutated_by_diagram() verifies
that printing a circuit doesn't mutate barrier targets and that
OpenQASM output remains correct."

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
