### PR TITLE
fix: Remove unnecessary configuration from S3 bucket creation

### DIFF
--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -576,36 +576,7 @@ class AwsSession:
                 self.s3_client.create_bucket(
                     Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
                 )
-            self.s3_client.put_public_access_block(
-                Bucket=bucket_name,
-                PublicAccessBlockConfiguration={
-                    "BlockPublicAcls": True,
-                    "IgnorePublicAcls": True,
-                    "BlockPublicPolicy": True,
-                    "RestrictPublicBuckets": True,
-                },
-            )
-            self.s3_client.put_bucket_policy(
-                Bucket=bucket_name,
-                Policy=f"""{{
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {{
-                            "Effect": "Allow",
-                            "Principal": {{
-                                "Service": [
-                                    "braket.amazonaws.com"
-                                ]
-                            }},
-                            "Action": "s3:*",
-                            "Resource": [
-                                "arn:aws:s3:::{bucket_name}",
-                                "arn:aws:s3:::{bucket_name}/*"
-                            ]
-                        }}
-                    ]
-                }}""",
-            )
+
         except ClientError as e:
             error_code = e.response["Error"]["Code"]
             message = e.response["Error"]["Message"]

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -1189,15 +1189,6 @@ def test_create_s3_bucket_if_it_does_not_exist(aws_session, region, account_id):
     if region == "us-east-1":
         del kwargs["CreateBucketConfiguration"]
     aws_session._s3.create_bucket.assert_called_with(**kwargs)
-    aws_session._s3.put_public_access_block.assert_called_with(
-        Bucket=bucket,
-        PublicAccessBlockConfiguration={
-            "BlockPublicAcls": True,
-            "IgnorePublicAcls": True,
-            "BlockPublicPolicy": True,
-            "RestrictPublicBuckets": True,
-        },
-    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
S3 buckets block public access by default, making the `put_public_access_block` call redundant. The bucket policy granting Braket service access is not required for the service to function, so the `put_bucket_policy` call is also removed.

### Changes
- Removed `s3_client.put_public_access_block()` from `_create_s3_bucket_if_it_does_not_exist()`
- Removed `s3_client.put_bucket_policy()` from `_create_s3_bucket_if_it_does_not_exist()`
- Updated corresponding unit tests