### PR TITLE
fix: rename Devices.Rigetti.Cepheus1 to Cepheus1108Q to match device name

### DIFF
--- a/src/braket/devices/devices.py
+++ b/src/braket/devices/devices.py
@@ -57,7 +57,7 @@ class Devices:
         _AspenM3 = "arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-3"
         _Ankaa2 = "arn:aws:braket:us-west-1::device/qpu/rigetti/Ankaa-2"
         Ankaa3 = "arn:aws:braket:us-west-1::device/qpu/rigetti/Ankaa-3"
-        Cepheus1 = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
+        Cepheus1108Q = "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
 
     class _Xanadu(StrEnum):
         _Borealis = "arn:aws:braket:us-east-1::device/qpu/xanadu/Borealis"


### PR DESCRIPTION
## Description

Renames the `Devices.Rigetti.Cepheus1` enum member to `Devices.Rigetti.Cepheus1108Q` to match the actual device name `Cepheus-1-108Q`.

The previous name `Cepheus1` was inconsistent with the device ARN (`rigetti/Cepheus-1-108Q`) and the naming convention used by other devices in the SDK.

## Testing

- [x] Linters pass (`tox -e linters`)
- [x] Unit tests pass (34 device tests, 221 emulation tests)
- [x] No tests reference the enum by name — all test fixtures use ARN strings directly