### PR TITLE
fix: FreeParameterExpression.subs() crash when expression is a plain Number

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -90,6 +90,9 @@ class FreeParameterExpression:
             FreeParameterExpression | Number | Expr: A numerical value if there are no
             symbols left in the expression otherwise returns a new FreeParameterExpression.
         """
+        if isinstance(self._expression, Number):
+            return self._expression
+
         new_parameter_values = {}
         for key, val in parameter_values.items():
             if issubclass(type(key), FreeParameterExpression):

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -3479,6 +3479,13 @@ def test_make_bound_circuit_bad_value():
         circ.make_bound_circuit({"theta": input_val})
 
 
+def test_make_bound_circuit_with_numeric_free_parameter_expression():
+    circ = Circuit().rz(0, FreeParameterExpression(3.0))
+    bound = circ.make_bound_circuit({})
+    expected = Circuit().rz(0, 3.0)
+    assert bound == expected
+
+
 def test_circuit_with_expr():
     theta = FreeParameter("theta")
     alpha = FreeParameter("alpha")

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -141,6 +141,12 @@ def test_neg():
     assert -expr == expected_expr and -(-expr) == expr
 
 
+@pytest.mark.parametrize("value", [3.0, 5, 0, -2.5])
+def test_subs_numeric_expression(value):
+    expr = FreeParameterExpression(value)
+    assert expr.subs({"anything": 42}) == value
+
+
 def test_sub_string():
     theta = FreeParameter("theta")
     expr = theta + 1


### PR DESCRIPTION
## Problem

Calling `make_bound_circuit` on a circuit whose gate angle is a `FreeParameterExpression` wrapping a plain numeric value (e.g. `FreeParameterExpression(3.0)`) raises an `AttributeError`:

```
AttributeError: 'float' object has no attribute 'subs'
```

Repro:
```python
fp = FreeParameterExpression(3.0)
circuit = Circuit().rz(0, fp)
circuit.make_bound_circuit({})  # raises AttributeError
```

## Root Cause

`FreeParameterExpression.__init__` stores a raw Python `Number` (float/int) as `_expression` when the input is numeric. However, `subs()` unconditionally calls `self._expression.subs(...)`, which only exists on `sympy.Expr` objects, not on plain Python numbers.

## Fix

Added an early return in `FreeParameterExpression.subs()` that checks if `_expression` is a `Number`. If so, there are no symbolic parameters to substitute, so the value is returned directly.

## Testing

- Added parametrized unit test `test_subs_numeric_expression` covering float, int, zero, and negative values.
- Added end-to-end test `test_make_bound_circuit_with_numeric_free_parameter_expression` verifying the original bug scenario through `Circuit.make_bound_circuit`.