### PR TITLE
feature: simplify verbatim box APIs

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -152,6 +152,44 @@ class Circuit:
         if addable is not None:
             self.add(addable, *args, **kwargs)
 
+    def _reset(self) -> None:
+        self._moments = Moments()
+        self._result_types = {}
+        self._qubit_observable_mapping = {}
+        self._qubit_observable_target_mapping = {}
+        self._qubit_observable_set = set()
+        self._parameters = set()
+        self._observables_simultaneously_measurable = True
+        self._requires_physical_qubits = False
+        self._measure_targets = None
+
+    def _replace_instructions(self, instructions: Iterable[Instruction]) -> None:
+        result_types = self.result_types
+        self._reset()
+        for instruction in instructions:
+            self.add_instruction(instruction)
+        for result_type in result_types:
+            self.add_result_type(result_type)
+
+    @staticmethod
+    def _verbatim_box_ranges(instructions: list[Instruction]) -> list[tuple[int, int]]:
+        ranges = []
+        start_index = None
+        for index, instruction in enumerate(instructions):
+            if isinstance(instruction.operator, compiler_directives.StartVerbatimBox):
+                if start_index is not None:
+                    raise ValueError("Already in verbatim box.")
+                start_index = index
+            elif isinstance(instruction.operator, compiler_directives.EndVerbatimBox):
+                if start_index is None:
+                    raise ValueError("Already outside of verbatim box.")
+                ranges.append((start_index, index))
+                start_index = None
+
+        if start_index is not None:
+            raise ValueError("No end verbatim box found for the circuit.")
+        return ranges
+
     @property
     def depth(self) -> int:
         """int: Get the circuit depth."""
@@ -692,15 +730,17 @@ class Circuit:
 
     def add_verbatim_box(
         self,
-        verbatim_circuit: Circuit,
+        verbatim_circuit: Circuit | None = None,
         target: QubitSetInput | None = None,
         target_mapping: dict[QubitInput, QubitInput] | None = None,
     ) -> Circuit:
-        """Add a verbatim `Circuit` to `self`, ensuring that the circuit is not modified in
-        any way by the compiler.
+        """Add a verbatim box to `self`, ensuring that the circuit is not modified in
+        any way by the compiler. If `verbatim_circuit` is not supplied, wrap the instructions
+        currently in `self` in a verbatim box.
 
         Args:
-            verbatim_circuit (Circuit): Circuit to add into self.
+            verbatim_circuit (Circuit | None): Circuit to add into self. If `None`, wrap the
+                instructions currently in `self` in a verbatim box. Default = `None`.
             target (QubitSetInput | None): Target qubits for the
                 supplied circuit. This is a macro over `target_mapping`; `target` is converted to
                 a `target_mapping` by zipping together a sorted `circuit.qubits` and `target`.
@@ -713,10 +753,18 @@ class Circuit:
             Circuit: self
 
         Raises:
-            TypeError: If both `target_mapping` and `target` are supplied.
+            TypeError: If both `target_mapping` and `target` are supplied, or if `target` or
+                `target_mapping` are supplied when `verbatim_circuit` is `None`.
             ValueError: If `circuit` has result types attached
 
         Examples:
+            >>> circ = Circuit().h(0).h(1).add_verbatim_box()
+            >>> print(list(circ.instructions))
+            [Instruction('operator': StartVerbatimBox, 'target': QubitSet([])),
+             Instruction('operator': H('qubit_count': 1), 'target': QubitSet([Qubit(0)])),
+             Instruction('operator': H('qubit_count': 1), 'target': QubitSet([Qubit(1)])),
+             Instruction('operator': EndVerbatimBox, 'target': QubitSet([]))]
+
             >>> widget = Circuit().h(0).h(1)
             >>> circ = Circuit().add_verbatim_box(widget)
             >>> print(list(circ.instructions))
@@ -743,6 +791,10 @@ class Circuit:
         """
         if target_mapping and target is not None:
             raise TypeError("Only one of 'target_mapping' or 'target' can be supplied.")
+
+        if verbatim_circuit is None:
+            return self._add_current_verbatim_box(target, target_mapping)
+
         if target is not None:
             keys = sorted(verbatim_circuit.qubits)
             values = target
@@ -760,6 +812,68 @@ class Circuit:
                 self.add_instruction(instruction, target_mapping=target_mapping)
             self.add_instruction(Instruction(compiler_directives.EndVerbatimBox()))
             self._requires_physical_qubits = True
+        return self
+
+    def _add_current_verbatim_box(
+        self,
+        target: QubitSetInput | None = None,
+        target_mapping: dict[QubitInput, QubitInput] | None = None,
+    ) -> Circuit:
+        if target is not None or target_mapping is not None:
+            raise TypeError(
+                "'target' and 'target_mapping' cannot be supplied when 'verbatim_circuit' is None."
+            )
+        if self.result_types:
+            raise ValueError("Verbatim subcircuit is not measured and cannot have result types")
+        if self._measure_targets:
+            raise ValueError("cannot measure a subcircuit inside a verbatim box.")
+
+        verbatim_instructions = self.instructions
+        if verbatim_instructions:
+            self._replace_instructions([
+                Instruction(compiler_directives.StartVerbatimBox()),
+                *verbatim_instructions,
+                Instruction(compiler_directives.EndVerbatimBox()),
+            ])
+        return self
+
+    def remove_verbatim_boxes(self, box_index: int | None = None) -> Circuit:
+        """Remove verbatim box delimiters from `self`.
+
+        Args:
+            box_index (int | None): Zero-based verbatim box index to remove. If `None`, remove all
+                verbatim box delimiters. Default = `None`.
+
+        Returns:
+            Circuit: self
+
+        Raises:
+            ValueError: If `box_index` is negative, or if verbatim box delimiters are unbalanced.
+            IndexError: If `box_index` does not identify a verbatim box.
+
+        Examples:
+            >>> circ = Circuit().add_verbatim_box(Circuit().h(0)).remove_verbatim_boxes()
+            >>> print(list(circ.instructions))
+            [Instruction('operator': H('qubit_count': 1), 'target': QubitSet([Qubit(0)]))]
+        """
+        if box_index is not None and box_index < 0:
+            raise ValueError("'box_index' must be non-negative.")
+
+        current_instructions = self.instructions
+        verbatim_box_ranges = self._verbatim_box_ranges(current_instructions)
+        if box_index is not None and box_index >= len(verbatim_box_ranges):
+            raise IndexError(f"No verbatim box exists at index {box_index}.")
+
+        ranges_to_remove = (
+            verbatim_box_ranges if box_index is None else [verbatim_box_ranges[box_index]]
+        )
+        delimiter_indices = {index for box_range in ranges_to_remove for index in box_range}
+        instructions = [
+            instruction
+            for index, instruction in enumerate(current_instructions)
+            if index not in delimiter_indices
+        ]
+        self._replace_instructions(instructions)
         return self
 
     def barrier(self, target: QubitSetInput | None = None) -> Circuit:

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -551,6 +551,25 @@ def test_add_verbatim_box_empty():
     assert not circuit.qubits_frozen
 
 
+def test_add_verbatim_box_defaults_to_self():
+    circ = Circuit().h(0).cnot(0, 1).add_verbatim_box()
+    expected = (
+        Circuit()
+        .add_instruction(Instruction(compiler_directives.StartVerbatimBox()))
+        .add_instruction(Instruction(gates.H(), 0))
+        .add_instruction(Instruction(gates.CNot(), [0, 1]))
+        .add_instruction(Instruction(compiler_directives.EndVerbatimBox()))
+    )
+    assert circ == expected
+    assert circ.qubits_frozen
+
+
+def test_add_verbatim_box_self_empty():
+    circuit = Circuit().add_verbatim_box()
+    assert circuit == Circuit()
+    assert not circuit.qubits_frozen
+
+
 def test_add_verbatim_box_with_mapping(cnot):
     circ = Circuit().add_verbatim_box(cnot, target_mapping={0: 10, 1: 11})
     expected = (
@@ -578,10 +597,108 @@ def test_add_verbatim_box_with_target_and_mapping(h):
         Circuit().add_verbatim_box(h, target=[10], target_mapping={0: 10})
 
 
+def test_add_verbatim_box_self_with_target_raises():
+    with pytest.raises(TypeError, match="'target' and 'target_mapping' cannot be supplied"):
+        Circuit().h(0).add_verbatim_box(target=[1])
+
+
 def test_add_verbatim_box_result_types():
     with pytest.raises(ValueError):
         Circuit().h(0).add_verbatim_box(
             Circuit().cnot(0, 1).expectation(observable=observables.X(), target=0)
+        )
+
+
+def test_add_verbatim_box_self_result_types():
+    with pytest.raises(ValueError):
+        Circuit().h(0).expectation(observable=observables.X(), target=0).add_verbatim_box()
+
+
+def test_remove_verbatim_boxes_all():
+    circ = (
+        Circuit()
+        .add_verbatim_box(Circuit().h(0))
+        .x(1)
+        .add_verbatim_box(Circuit().cnot(0, 1))
+        .remove_verbatim_boxes()
+    )
+    expected = (
+        Circuit()
+        .add_instruction(Instruction(gates.H(), 0))
+        .add_instruction(Instruction(gates.X(), 1))
+        .add_instruction(Instruction(gates.CNot(), [0, 1]))
+    )
+    assert circ == expected
+    assert not circ.qubits_frozen
+
+
+def test_remove_verbatim_boxes_by_index():
+    circ = (
+        Circuit()
+        .add_verbatim_box(Circuit().h(0))
+        .x(1)
+        .add_verbatim_box(Circuit().cnot(0, 1))
+        .remove_verbatim_boxes(box_index=1)
+    )
+    expected = (
+        Circuit()
+        .add_instruction(Instruction(compiler_directives.StartVerbatimBox()))
+        .add_instruction(Instruction(gates.H(), 0))
+        .add_instruction(Instruction(compiler_directives.EndVerbatimBox()))
+        .add_instruction(Instruction(gates.X(), 1))
+        .add_instruction(Instruction(gates.CNot(), [0, 1]))
+    )
+    assert circ == expected
+    assert circ.qubits_frozen
+
+
+def test_remove_verbatim_boxes_preserves_result_types():
+    circ = (
+        Circuit()
+        .add_verbatim_box(Circuit().h(0))
+        .expectation(observable=observables.X(), target=0)
+        .remove_verbatim_boxes()
+    )
+    expected = (
+        Circuit()
+        .add_instruction(Instruction(gates.H(), 0))
+        .add_result_type(result_types.Expectation(observable=observables.X(), target=0))
+    )
+    assert circ == expected
+
+
+def test_remove_verbatim_boxes_missing_index():
+    with pytest.raises(IndexError, match="No verbatim box exists at index 1"):
+        Circuit().add_verbatim_box(Circuit().h(0)).remove_verbatim_boxes(box_index=1)
+
+
+def test_remove_verbatim_boxes_negative_index():
+    with pytest.raises(ValueError, match="'box_index' must be non-negative"):
+        Circuit().add_verbatim_box(Circuit().h(0)).remove_verbatim_boxes(box_index=-1)
+
+
+def test_remove_verbatim_boxes_end_without_start():
+    with pytest.raises(ValueError, match="Already outside of verbatim box"):
+        Circuit().add_instruction(
+            Instruction(compiler_directives.EndVerbatimBox())
+        ).remove_verbatim_boxes()
+
+
+def test_remove_verbatim_boxes_start_without_end():
+    with pytest.raises(ValueError, match="No end verbatim box found for the circuit"):
+        Circuit().add_instruction(
+            Instruction(compiler_directives.StartVerbatimBox())
+        ).remove_verbatim_boxes()
+
+
+def test_remove_verbatim_boxes_nested_start():
+    with pytest.raises(ValueError, match="Already in verbatim box"):
+        (
+            Circuit()
+            .add_instruction(Instruction(compiler_directives.StartVerbatimBox()))
+            .add_instruction(Instruction(compiler_directives.StartVerbatimBox()))
+            .add_instruction(Instruction(compiler_directives.EndVerbatimBox()))
+            .remove_verbatim_boxes()
         )
 
 


### PR DESCRIPTION
## Summary
- allow `Circuit.add_verbatim_box()` to wrap the receiver's current instructions
- add `Circuit.remove_verbatim_boxes()` with optional zero-based `box_index`
- preserve enclosed operations and result types while removing only verbatim delimiters

Fixes #1236

## Validation
- `uv run --python 3.12 --with ruff ruff check src`
- `uv run --python 3.12 --with ruff ruff format --check src/braket/circuits/circuit.py test/unit_tests/braket/circuits/test_circuit.py`
- `uv run --python 3.12 --extra test pytest test/unit_tests/braket/circuits/test_circuit.py -q`