### PR TITLE
feat: add Circuit instruction counting

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -171,6 +171,30 @@ class Circuit:
         """Iterable[Instruction]: Get an `iterable` of instructions in the circuit."""
         return list(self._moments.values())
 
+    def count(self, operator: str | None = None) -> int | Counter[str]:
+        """Count circuit instructions by operator name.
+
+        Args:
+            operator (str | None): Optional operator name to count. Matching is case-insensitive.
+                If not provided, returns counts for all operator names.
+
+        Returns:
+            int | Counter[str]: The count for ``operator`` if provided, otherwise a ``Counter``
+            keyed by operator name.
+
+        Examples:
+            >>> circuit = Circuit().h(0).cnot(0, 1).cnot(1, 2)
+            >>> circuit.count("cnot")
+            2
+            >>> circuit.count()
+            Counter({'CNot': 2, 'H': 1})
+        """
+        counts = Counter(instruction.operator.name for instruction in self.instructions)
+        if operator is None:
+            return counts
+
+        return sum(count for name, count in counts.items() if name.lower() == operator.lower())
+
     @property
     def result_types(self) -> list[ResultType]:
         """list[ResultType]: Get a list of requested result types in the circuit."""

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -3242,6 +3242,21 @@ def test_instructions_setter(h, h_instr):
         h.instructions = [h_instr]
 
 
+def test_count_all_instructions():
+    circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).rx(2, 0.2)
+
+    assert circ.count() == {"H": 1, "CNot": 2, "Rx": 1}
+
+
+def test_count_instruction_by_name_case_insensitive():
+    circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).measure([0, 1])
+
+    assert circ.count("cnot") == 2
+    assert circ.count("CNOT") == 2
+    assert circ.count("measure") == 2
+    assert circ.count("x") == 0
+
+
 def test_moments_getter(h):
     assert h.moments is h._moments
 


### PR DESCRIPTION
## Summary
- Add `Circuit.count()` to return a `Counter` of instruction operator names.
- Support `Circuit.count("cnot")` style lookup with case-insensitive operator matching.
- Add regression coverage for all-counts and named-count behavior, including measurement instructions.

## Validation
- `python -m pytest test/unit_tests/braket/circuits/test_circuit.py -q -k "count_instruction or count_all" -o addopts=""`
- `python -m pytest test/unit_tests/braket/circuits/test_circuit.py -q -o addopts=""`
- `ruff check src/braket/circuits/circuit.py`
- `ruff format --check src/braket/circuits/circuit.py test/unit_tests/braket/circuits/test_circuit.py`
- `git diff --check`

## AI assistance disclosure
I used OpenAI Codex to help inspect the relevant code paths, implement this small utility, and run validation. I reviewed the generated changes and test results before submitting.

Closes #1235
