### PR TITLE
fix: accept division in FreeParameterExpression strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes and Other Changes
 
+ * accept division in `FreeParameterExpression` string constructor
  * raise DiscretizationError when rydbergLocal params missing
 
 ## v1.117.3 (2026-05-14)

--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -54,6 +54,7 @@ class FreeParameterExpression:
             ast.Add: self.__add__,
             ast.Sub: self.__sub__,
             ast.Mult: self.__mul__,
+            ast.Div: self.__truediv__,
             ast.Pow: self.__pow__,
             ast.USub: self.__neg__,
         }

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -54,7 +54,7 @@ def test_equality_str():
 
 @pytest.mark.xfail(raises=ValueError)
 def test_unsupported_bin_op_str():
-    FreeParameterExpression("theta/1")
+    FreeParameterExpression("theta//1")
 
 
 @pytest.mark.xfail(raises=ValueError)
@@ -109,6 +109,26 @@ def test_truediv():
         FreeParameter("alpha")
     )
     assert truediv_expr == expected
+
+
+def test_truediv_str():
+    truediv_expr = FreeParameterExpression("theta/alpha")
+    expected = FreeParameter("theta") / FreeParameter("alpha")
+    assert truediv_expr == expected
+
+
+@pytest.mark.parametrize(
+    ("string_expression", "operator_expression"),
+    [
+        ("theta+alpha", FreeParameter("theta") + FreeParameter("alpha")),
+        ("theta-alpha", FreeParameter("theta") - FreeParameter("alpha")),
+        ("theta*alpha", FreeParameter("theta") * FreeParameter("alpha")),
+        ("theta/alpha", FreeParameter("theta") / FreeParameter("alpha")),
+        ("theta**alpha", FreeParameter("theta") ** FreeParameter("alpha")),
+    ],
+)
+def test_basic_binary_operator_strings_match_operator_path(string_expression, operator_expression):
+    assert FreeParameterExpression(string_expression) == operator_expression
 
 
 def test_r_truediv():


### PR DESCRIPTION
## What changed
- Added `ast.Div` to the `FreeParameterExpression` string parser operator map.
- Added regression coverage proving `FreeParameterExpression("theta/alpha")` matches `FreeParameter("theta") / FreeParameter("alpha")`.
- Kept unsupported binary-operator coverage by moving that xfail to `//`.
- Added a changelog bug-fix entry.

Fixes #1251.

## Validation
- `uv run --python 3.12 --extra test pytest -o addopts="" test/unit_tests/braket/parametric/test_free_parameter_expression.py -v` -> 32 passed, 4 xfailed
- `uvx --from ruff==0.14.0 ruff check src/braket/parametric/free_parameter_expression.py` -> passed
- `uvx --from ruff==0.14.0 ruff format --check src/braket/parametric/free_parameter_expression.py test/unit_tests/braket/parametric/test_free_parameter_expression.py` -> passed
- `python3.12 -m compileall -q src/braket/parametric/free_parameter_expression.py test/unit_tests/braket/parametric/test_free_parameter_expression.py` -> passed
- `git diff --check` -> passed