### PR TITLE
fix: Accept `/` in `FreeParameterExpression` string constructor

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -56,6 +56,7 @@ class FreeParameterExpression:
             ast.Mult: self.__mul__,
             ast.Pow: self.__pow__,
             ast.USub: self.__neg__,
+            ast.Div: self.__truediv__,
         }
         if isinstance(expression, FreeParameterExpression):
             self._expression = expression.expression

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -52,9 +52,10 @@ def test_equality_str():
     assert hasattr(expr_1.expression, "free_symbols") and hasattr(expr_2.expression, "free_symbols")
 
 
-@pytest.mark.xfail(raises=ValueError)
-def test_unsupported_bin_op_str():
-    FreeParameterExpression("theta/1")
+def test_truediv_str():
+    expr_1 = FreeParameterExpression("alpha/beta")
+    expr_2 = FreeParameter("alpha") / FreeParameter("beta")
+    assert expr_1 == expr_2
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -52,6 +52,10 @@ def test_equality_str():
     assert hasattr(expr_1.expression, "free_symbols") and hasattr(expr_2.expression, "free_symbols")
 
 
+def test_truediv_str_with_constant():
+    assert FreeParameterExpression("theta/1") == FreeParameter("theta") / 1
+
+
 def test_truediv_str():
     expr_1 = FreeParameterExpression("alpha/beta")
     expr_2 = FreeParameter("alpha") / FreeParameter("beta")

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -63,6 +63,11 @@ def test_truediv_str():
 
 
 @pytest.mark.xfail(raises=ValueError)
+def test_unsupported_bin_op_str():
+    FreeParameterExpression("theta % 1")
+
+
+@pytest.mark.xfail(raises=ValueError)
 def test_unsupported_un_op_str():
     FreeParameterExpression("~theta")
 


### PR DESCRIPTION
**fix: Accept `/` in `FreeParameterExpression` string constructor**
This PR aim to resolve issue #1251  and introduces a fix that allows for `FreeParameterExpression("alpha/beta")` to work just as `FreeParameter("alpha") / FreeParameter("beta")`

*Description of changes:*

Changes were made to `src\braket\parametric\free_parameter_expression.py` with addition of `    ast.Div: self.__truediv__,` on line 59

*Testing done:*
`tox -e unit-tests -- test/unit_tests/braket/parametric/test_free_parameter_expression.py -v`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
