### PR TITLE
feature: add interactive Plotly circuit visualization

### DIFF
--- a/examples/plotly_circuit_visualization.py
+++ b/examples/plotly_circuit_visualization.py
@@ -11,11 +11,22 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from braket.circuits.graphical_diagram_builders.matplotlib_circuit_diagram import (
-    MatplotlibCircuitDiagram,
-)
-from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (
-    PlotlyCircuitDiagram,
+from braket.circuits import Circuit
+
+circuit = (
+    Circuit()
+    .h(0)
+    .cnot(0, 1)
+    .add_verbatim_box(Circuit().rx(0, 0.25).cz(0, 1))
+    .probability(target=[0, 1])
 )
 
-__all__ = ["MatplotlibCircuitDiagram", "PlotlyCircuitDiagram"]
+device_metadata = {
+    "H": {"fidelity": 0.9991},
+    "CNot": {"fidelity": 0.982, "duration": "120 ns"},
+    "Rx": {"fidelity": 0.998},
+    "CZ": {"fidelity": 0.985, "duration": "140 ns"},
+}
+
+figure = circuit.show("interactive", device_metadata=device_metadata)
+figure.write_html("plotly_circuit_visualization.html", include_plotlyjs="cdn")

--- a/examples/plotly_circuit_visualization.py
+++ b/examples/plotly_circuit_visualization.py
@@ -28,5 +28,5 @@ device_metadata = {
     "CZ": {"fidelity": 0.985, "duration": "140 ns"},
 }
 
-figure = circuit.show("interactive", device_metadata=device_metadata)
+figure = circuit.to_plotly(device_metadata=device_metadata)
 figure.write_html("plotly_circuit_visualization.html", include_plotlyjs="cdn")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 test = [
     "botocore",
     "jsonschema==3.2.0",
+    "plotly",
     "pytest",
     "pytest-cov",
     # https://github.com/pytest-dev/pytest-rerunfailures/issues/302
@@ -57,6 +58,9 @@ docs = [
     "sphinx-rtd-theme",
     "sphinxcontrib-apidoc",
     "sphinx-autodoc-typehints",
+]
+interactive = [
+    "plotly",
 ]
 
 [project.urls]

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1312,6 +1312,29 @@ class Circuit:
         """
         return circuit_diagram_class.build_diagram(self)
 
+    def to_plotly(
+        self,
+        *,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> object:
+        """Build and return an interactive Plotly figure for this circuit.
+
+        Args:
+            device_metadata: Optional gate metadata to include in Plotly hover text.
+
+        Returns:
+            A ``plotly.graph_objects.Figure``.
+
+        Raises:
+            ImportError: If the interactive Plotly renderer is requested without Plotly
+                installed.
+        """
+        from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (  # noqa: PLC0415
+            PlotlyCircuitDiagram,
+        )
+
+        return PlotlyCircuitDiagram.build_diagram(self, device_metadata=device_metadata)
+
     def to_ir(
         self,
         ir_type: IRType = IRType.JAQCD,
@@ -1661,21 +1684,16 @@ class Circuit:
         circuit_diagram_class: type | str = MatplotlibCircuitDiagram,
         *,
         device_metadata: Mapping[str, Any] | None = None,
-    ) -> object | None:
-        """Build a graphical diagram for this circuit.
+    ) -> None:
+        """Display a graphical diagram for this circuit.
 
         Args:
             circuit_diagram_class: Diagram builder class, or one of the built-in aliases
                 ``"matplotlib"``, ``"interactive"``, or ``"plotly"``. The ``"interactive"``
-                and ``"plotly"`` aliases return a Plotly figure and require Plotly to be
-                installed.
+                and ``"plotly"`` aliases display a Plotly figure and require Plotly to be
+                installed. Use :meth:`to_plotly` to get the Figure object directly.
             device_metadata: Optional gate metadata to include in interactive Plotly hover text.
                 Only supported by the ``"interactive"`` and ``"plotly"`` aliases.
-
-        Returns:
-            A Plotly figure for ``"interactive"`` and ``"plotly"``. The default matplotlib
-            path and custom diagram builders preserve the existing side-effect-only behavior
-            and return ``None``.
 
         Raises:
             ValueError: If a string alias is not supported, or if ``device_metadata`` is
@@ -1691,11 +1709,8 @@ class Circuit:
                     )
                 circuit_diagram_class = MatplotlibCircuitDiagram
             elif circuit_diagram_class in {"interactive", "plotly"}:
-                from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (  # noqa: PLC0415
-                    PlotlyCircuitDiagram,
-                )
-
-                return PlotlyCircuitDiagram.build_diagram(self, device_metadata=device_metadata)
+                self.to_plotly(device_metadata=device_metadata).show()
+                return
             else:
                 raise ValueError(
                     "circuit_diagram_class must be a diagram class, 'matplotlib', "
@@ -1704,7 +1719,7 @@ class Circuit:
         if device_metadata is not None:
             raise ValueError("device_metadata is only supported with 'interactive' or 'plotly'")
         circuit_diagram_class.build_diagram(self)
-        return None
+        return
 
     @property
     def qubits_frozen(self) -> bool:

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from numbers import Number
 from typing import Any, TypeVar
 
@@ -162,9 +162,9 @@ class Circuit:
 
     @property
     def global_phase(self) -> float:
-        """float: Get the global phase of the circuit."""
+        """float: Get the effective global phase of the circuit, including gate powers."""
         return sum(
-            instr.operator.angle
+            instr.operator.angle * instr.power
             for moment, instr in self._moments.items()
             if moment.moment_type == MomentType.GLOBAL_PHASE
         )
@@ -1656,8 +1656,55 @@ class Circuit:
             return calculate_unitary_big_endian(self.instructions, qubits)
         return np.zeros(0, dtype=complex)
 
-    def show(self, circuit_diagram_class: type = MatplotlibCircuitDiagram) -> None:
+    def show(
+        self,
+        circuit_diagram_class: type | str = MatplotlibCircuitDiagram,
+        *,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> object | None:
+        """Build a graphical diagram for this circuit.
+
+        Args:
+            circuit_diagram_class: Diagram builder class, or one of the built-in aliases
+                ``"matplotlib"``, ``"interactive"``, or ``"plotly"``. The ``"interactive"``
+                and ``"plotly"`` aliases return a Plotly figure and require Plotly to be
+                installed.
+            device_metadata: Optional gate metadata to include in interactive Plotly hover text.
+                Only supported by the ``"interactive"`` and ``"plotly"`` aliases.
+
+        Returns:
+            A Plotly figure for ``"interactive"`` and ``"plotly"``. The default matplotlib
+            path and custom diagram builders preserve the existing side-effect-only behavior
+            and return ``None``.
+
+        Raises:
+            ValueError: If a string alias is not supported, or if ``device_metadata`` is
+                provided for a renderer that cannot display it.
+            ImportError: If the interactive Plotly renderer is requested without Plotly
+                installed.
+        """
+        if isinstance(circuit_diagram_class, str):
+            if circuit_diagram_class == "matplotlib":
+                if device_metadata is not None:
+                    raise ValueError(
+                        "device_metadata is only supported with 'interactive' or 'plotly'"
+                    )
+                circuit_diagram_class = MatplotlibCircuitDiagram
+            elif circuit_diagram_class in {"interactive", "plotly"}:
+                from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (  # noqa: PLC0415
+                    PlotlyCircuitDiagram,
+                )
+
+                return PlotlyCircuitDiagram.build_diagram(self, device_metadata=device_metadata)
+            else:
+                raise ValueError(
+                    "circuit_diagram_class must be a diagram class, 'matplotlib', "
+                    "'interactive', or 'plotly'"
+                )
+        if device_metadata is not None:
+            raise ValueError("device_metadata is only supported with 'interactive' or 'plotly'")
         circuit_diagram_class.build_diagram(self)
+        return None
 
     @property
     def qubits_frozen(self) -> bool:

--- a/src/braket/circuits/graphical_diagram_builders/graphical_circuit_diagram.py
+++ b/src/braket/circuits/graphical_diagram_builders/graphical_circuit_diagram.py
@@ -136,6 +136,7 @@ class GraphicalCircuitDiagram(CircuitDiagram):
         emits dataclass primitives instead of characters.
         """
         symbols: dict[Qubit, str | None] = dict.fromkeys(circuit_qubits)
+        gate_box_metadata: dict[Qubit, tuple[str | None, str | None]] = {}
         connections: dict[Qubit, str] = dict.fromkeys(circuit_qubits, "none")
 
         # Track per-item qubit ranges for emitting separate Connection elements
@@ -164,9 +165,12 @@ class GraphicalCircuitDiagram(CircuitDiagram):
                 map_control_qubit_states,
                 item,
                 symbols,
+                gate_box_metadata,
             )
 
-        cls._emit_symbol_elements(col, circuit_qubits, qubit_index, symbols, elements)
+        cls._emit_symbol_elements(
+            col, circuit_qubits, qubit_index, symbols, gate_box_metadata, elements
+        )
 
         # Emit connections - one per item so independent gates don't bridge
         for row_start, row_end in item_qubit_ranges:
@@ -184,27 +188,29 @@ class GraphicalCircuitDiagram(CircuitDiagram):
         map_control_qubit_states: dict,
         item: Instruction | ResultType,
         symbols: dict[Qubit, str | None],
+        gate_box_metadata: dict[Qubit, tuple[str | None, str | None]],
     ) -> None:
         """Assign a symbol string to each qubit involved in an item."""
+        metadata_key = cls._gate_box_metadata_key(item)
         for qubit in qubits:
             if qubit in target_qubits:
                 item_qubit_index = next(
                     index for index, q in enumerate(target_qubits) if q == qubit
                 )
+                ascii_symbol = ascii_symbols[item_qubit_index]
+                if ascii_symbol is None:
+                    continue
                 power_string = (
                     f"^{power}"
-                    if (
-                        (power := getattr(item, "power", 1)) != 1
-                        and ascii_symbols[item_qubit_index] != "C"
-                    )
+                    if ((power := getattr(item, "power", 1)) != 1 and ascii_symbol != "C")
                     else ""
                 )
-                symbol = (
-                    f"{ascii_symbols[item_qubit_index]}{power_string}"
-                    if power_string
-                    else ascii_symbols[item_qubit_index]
-                )
+                symbol = f"{ascii_symbol}{power_string}" if power_string else ascii_symbol
                 symbols[qubit] = symbol
+                gate_box_metadata[qubit] = (
+                    metadata_key,
+                    cls._gate_parameter_text(item, symbol),
+                )
             elif qubit in control_qubits:
                 symbols[qubit] = "C" if map_control_qubit_states[qubit] else "N"
             # Qubits inside the gate span but not involved (pass-through) are
@@ -219,6 +225,7 @@ class GraphicalCircuitDiagram(CircuitDiagram):
         circuit_qubits: QubitSet,
         qubit_index: dict[Qubit, int],
         symbols: dict[Qubit, str | None],
+        gate_box_metadata: dict[Qubit, tuple[str | None, str | None]],
         elements: list,
     ) -> None:
         """Convert symbols into layout primitives."""
@@ -233,7 +240,43 @@ class GraphicalCircuitDiagram(CircuitDiagram):
             elif symbol == "SWAP":
                 elements.append(SwapMarker(col=col, row=row))
             elif symbol != "||":
-                elements.append(GateBox(col=col, row=row, label=symbol))
+                metadata_key, parameter_text = gate_box_metadata.get(qubit, (None, None))
+                elements.append(
+                    GateBox(
+                        col=col,
+                        row=row,
+                        label=symbol,
+                        metadata_key=metadata_key,
+                        parameter_text=parameter_text,
+                    )
+                )
+
+    @staticmethod
+    def _gate_box_metadata_key(item: Instruction | ResultType) -> str | None:
+        if not (isinstance(item, Instruction) and isinstance(item.operator, Gate)):
+            return None
+        return item.operator.name
+
+    @classmethod
+    def _gate_parameter_text(cls, item: Instruction | ResultType, label: str) -> str | None:
+        if not (isinstance(item, Instruction) and isinstance(item.operator, Gate)):
+            return None
+        parameters = getattr(item.operator, "parameters", None)
+        if not parameters:
+            return "None"
+        return cls._parameter_text_from_label(label) or ", ".join(
+            str(parameter) for parameter in parameters
+        )
+
+    @staticmethod
+    def _parameter_text_from_label(label: str) -> str | None:
+        _, separator, raw_parameters = label.partition("(")
+        if not separator:
+            return None
+        end = raw_parameters.rfind(")")
+        if end == -1:
+            return None
+        return raw_parameters[:end] or "None"
 
     @classmethod
     def _emit_barrier_elements(

--- a/src/braket/circuits/graphical_diagram_builders/graphical_diagram_utils.py
+++ b/src/braket/circuits/graphical_diagram_builders/graphical_diagram_utils.py
@@ -36,6 +36,8 @@ class GateBox:
     col: int
     row: int
     label: str
+    metadata_key: str | None = None
+    parameter_text: str | None = None
 
 
 @dataclass
@@ -90,7 +92,7 @@ def _compute_moment_global_phase(
     global_phase: float | None, items: list[Instruction]
 ) -> float | None:
     moment_phase = sum(
-        item.operator.angle
+        item.operator.angle * item.power
         for item in items
         if (
             isinstance(item, Instruction)

--- a/src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py
+++ b/src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py
@@ -1,0 +1,802 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import braket.circuits.circuit as cir
+from braket.circuits.graphical_diagram_builders.graphical_circuit_diagram import (
+    GraphicalCircuitDiagram,
+)
+from braket.circuits.graphical_diagram_builders.graphical_diagram_utils import (
+    BarrierMarker,
+    CircuitLayout,
+    Connection,
+    ControlDot,
+    GateBox,
+    SwapMarker,
+)
+from braket.circuits.moments import MomentType
+
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
+
+
+class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
+    """Renders circuit diagrams as interactive Plotly figures.
+
+    Examples:
+        >>> from braket.circuits import Circuit
+        >>> fig = Circuit().h(0).cnot(0, 1).show("interactive")
+
+    The returned figure includes hover tooltips and, for verbatim boxes, buttons to switch
+    between collapsed and expanded views.
+
+    The collapse path is intentionally range-based: the renderer detects nestable column
+    ranges, draws a synthetic collapsed layout, and keeps the expanded layout behind the same
+    toggle. Future ``box`` or ``scope`` circuit structures can reuse this path by contributing
+    their own ranges and collapsed labels once the SDK exposes them in the layout.
+    The current verbatim control is one global ``updatemenus`` toggle for the figure.
+    """
+
+    COL_WIDTH = 1.4
+    COL_GAP = 0.2
+    ROW_HEIGHT = 0.8
+    WIRE_EXTEND = 0.5
+
+    GATE_BOX_HEIGHT = 0.5
+    GATE_BOX_MIN_WIDTH = 0.6
+    GATE_BOX_PADDING = 0.3
+    GATE_FONT_SIZE = 12
+    GATE_FILL_COLOR = "#D4E6F1"
+    GATE_EDGE_COLOR = "black"
+    GATE_TEXT_COLOR = "black"
+
+    WIRE_COLOR = "#333333"
+    WIRE_WIDTH = 1
+    CONNECTION_COLOR = "black"
+    CONNECTION_WIDTH = 2
+
+    CONTROL_DOT_SIZE = 12
+    SWAP_MARKER_SIZE = 13
+
+    BARRIER_COLOR = "#888888"
+    BARRIER_FILL_COLOR = "#DDDDDD"
+    BARRIER_WIDTH = 0.25
+    BARRIER_HEIGHT_FRAC = 0.6
+
+    QUBIT_LABEL_FONT_SIZE = 12
+    MOMENT_LABEL_FONT_SIZE = 10
+    FOOTER_FONT_SIZE = 10
+
+    @staticmethod
+    def build_diagram(
+        circuit: cir.Circuit,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> go.Figure:
+        """Build a Plotly Figure for *circuit*.
+
+        Args:
+            circuit: The circuit to visualise.
+            device_metadata: Optional metadata to include in gate hover text. Keys may be
+                rendered gate labels (for example, ``"Rx(theta)"``) or source operator names
+                (for example, ``"CNot"``); values may be scalars or mappings such as
+                ``{"fidelity": 0.997}``.
+
+        Returns:
+            A ``plotly.graph_objects.Figure``.
+
+        Raises:
+            ImportError: If Plotly is not installed.
+
+        Examples:
+            >>> from braket.circuits import Circuit
+            >>> fig = Circuit().h(0).cnot(0, 1).show("interactive")
+        """
+        go = PlotlyCircuitDiagram._get_plotly()
+
+        if not circuit.instructions:
+            fig = go.Figure()
+            PlotlyCircuitDiagram._add_center_annotation(fig, "(empty circuit)")
+            PlotlyCircuitDiagram._configure_empty_figure(fig, width=260, height=140)
+            return fig
+
+        if all(m.moment_type == MomentType.GLOBAL_PHASE for m in circuit._moments):
+            fig = go.Figure()
+            PlotlyCircuitDiagram._add_center_annotation(
+                fig, f"Global phase: {circuit.global_phase}"
+            )
+            PlotlyCircuitDiagram._configure_empty_figure(fig, width=340, height=140)
+            return fig
+
+        layout = PlotlyCircuitDiagram._compute_layout(circuit)
+        return PlotlyCircuitDiagram._render_layout(layout, device_metadata)
+
+    @staticmethod
+    def _get_plotly() -> Any:
+        try:
+            import plotly.graph_objects as go  # noqa: PLC0415
+        except ImportError as exc:
+            raise ImportError(
+                "Plotly is required for PlotlyCircuitDiagram. Install it with "
+                "`pip install amazon-braket-sdk[interactive]` or `pip install plotly`."
+            ) from exc
+        return go
+
+    @classmethod
+    def _gate_box_width(cls, label: str) -> float:
+        char_width = cls.GATE_FONT_SIZE * 0.012
+        text_width = len(label) * char_width
+        return max(cls.GATE_BOX_MIN_WIDTH, text_width + cls.GATE_BOX_PADDING)
+
+    @classmethod
+    def _compute_column_x(cls, layout: CircuitLayout) -> tuple[list[float], list[float]]:
+        n_cols = max(layout.num_moments, 1)
+        widths = [cls.COL_WIDTH] * n_cols
+        for elem in layout.elements:
+            if isinstance(elem, GateBox):
+                widths[elem.col] = max(
+                    widths[elem.col], cls._gate_box_width(elem.label) + cls.COL_GAP
+                )
+
+        centers: list[float] = []
+        cursor = 0.0
+        for width in widths:
+            centers.append(cursor + width / 2)
+            cursor += width
+        return centers, widths
+
+    @classmethod
+    def _render_layout(
+        cls,
+        layout: CircuitLayout,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> go.Figure:
+        verbatim_ranges = cls._find_verbatim_ranges(layout)
+        if verbatim_ranges:
+            collapsed_layout = cls._collapse_verbatim_layout(layout, verbatim_ranges)
+            collapsed_fig = cls._render_base_layout(collapsed_layout, device_metadata)
+            expanded_fig = cls._render_base_layout(layout, device_metadata)
+            return cls._add_verbatim_toggle(collapsed_fig, expanded_fig)
+        return cls._render_base_layout(layout, device_metadata)
+
+    @classmethod
+    def _render_base_layout(
+        cls,
+        layout: CircuitLayout,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> go.Figure:
+        go = cls._get_plotly()
+        fig = go.Figure()
+        n_rows = max(layout.num_qubits, 1)
+
+        col_x, col_w = cls._compute_column_x(layout)
+        total_width = sum(col_w)
+        left_wire = col_x[0] - col_w[0] / 2 - cls.WIRE_EXTEND
+        right_wire = total_width + cls.WIRE_EXTEND
+
+        label_y_top = cls.ROW_HEIGHT * 0.8
+        label_y_bottom = -(n_rows - 1) * cls.ROW_HEIGHT - cls.ROW_HEIGHT * 0.8
+
+        cls._draw_qubit_wires(fig, layout, left_wire, right_wire)
+        cls._draw_moment_labels(fig, layout, col_x, label_y_top, label_y_bottom)
+        cls._draw_elements(fig, layout, col_x, device_metadata)
+
+        footer_lines = cls._build_footer_lines(layout)
+        if footer_lines:
+            cls._draw_footer(fig, footer_lines, left_wire, label_y_bottom)
+
+        cls._configure_axes(fig, left_wire, right_wire, label_y_top, label_y_bottom, footer_lines)
+        return fig
+
+    @classmethod
+    def _find_verbatim_ranges(cls, layout: CircuitLayout) -> list[tuple[int, int]]:
+        starts = {
+            elem.col
+            for elem in layout.elements
+            if isinstance(elem, GateBox) and elem.label == "StartVerbatim"
+        }
+        ends = {
+            elem.col
+            for elem in layout.elements
+            if isinstance(elem, GateBox) and elem.label == "EndVerbatim"
+        }
+
+        ranges: list[tuple[int, int]] = []
+        outer_start: int | None = None
+        depth = 0
+        for col in range(layout.num_moments):
+            if col in starts:
+                if depth == 0:
+                    outer_start = col
+                depth += 1
+            if col in ends and depth:
+                depth -= 1
+                if depth == 0 and outer_start is not None:
+                    ranges.append((outer_start, col))
+                    outer_start = None
+        return ranges
+
+    @classmethod
+    def _collapse_verbatim_layout(
+        cls, layout: CircuitLayout, verbatim_ranges: list[tuple[int, int]]
+    ) -> CircuitLayout:
+        col_map: dict[int, int] = {}
+        collapsed_elements: list = []
+        collapsed_moment_labels: list[str] = []
+        new_col = 0
+        col = 0
+        while col < layout.num_moments:
+            verbatim_range = next(
+                ((start, end) for start, end in verbatim_ranges if start == col),
+                None,
+            )
+            if verbatim_range:
+                start, end = verbatim_range
+                for source_col in range(start, end + 1):
+                    col_map[source_col] = new_col
+                collapsed_moment_labels.append("Verbatim")
+                collapsed_elements.extend(
+                    cls._build_collapsed_verbatim_elements(layout, start, end, new_col)
+                )
+                new_col += 1
+                col = end + 1
+            else:
+                col_map[col] = new_col
+                collapsed_moment_labels.append(layout.moment_labels[col])
+                new_col += 1
+                col += 1
+
+        for elem in layout.elements:
+            if cls._is_in_verbatim_range(elem.col, verbatim_ranges):
+                continue
+            collapsed_elements.append(cls._clone_element_with_col(elem, col_map[elem.col]))
+
+        return CircuitLayout(
+            num_qubits=layout.num_qubits,
+            num_moments=new_col,
+            qubit_labels=layout.qubit_labels,
+            moment_labels=collapsed_moment_labels,
+            elements=collapsed_elements,
+            global_phase=layout.global_phase,
+            additional_result_types=layout.additional_result_types,
+            unassigned_parameters=layout.unassigned_parameters,
+        )
+
+    @classmethod
+    def _build_collapsed_verbatim_elements(
+        cls, layout: CircuitLayout, start: int, end: int, col: int
+    ) -> list:
+        rows: set[int] = set()
+        for elem in layout.elements:
+            if start <= elem.col <= end:
+                rows.update(cls._element_rows(elem))
+
+        if not rows:
+            rows = set(range(layout.num_qubits))
+
+        elements: list = [GateBox(col=col, row=row, label="Verbatim") for row in sorted(rows)]
+        if len(rows) > 1:
+            elements.append(Connection(col=col, row_start=min(rows), row_end=max(rows)))
+        return elements
+
+    @staticmethod
+    def _element_rows(elem: object) -> set[int]:
+        if isinstance(elem, Connection):
+            return set(range(elem.row_start, elem.row_end + 1))
+        if isinstance(elem, GateBox | ControlDot | SwapMarker | BarrierMarker):
+            return {elem.row}
+        return set()
+
+    @staticmethod
+    def _is_in_verbatim_range(col: int, verbatim_ranges: list[tuple[int, int]]) -> bool:
+        return any(start <= col <= end for start, end in verbatim_ranges)
+
+    @staticmethod
+    def _clone_element_with_col(elem: object, col: int) -> object:
+        if isinstance(elem, GateBox):
+            return GateBox(
+                col=col,
+                row=elem.row,
+                label=elem.label,
+                metadata_key=elem.metadata_key,
+                parameter_text=elem.parameter_text,
+            )
+        if isinstance(elem, ControlDot):
+            return ControlDot(col=col, row=elem.row, filled=elem.filled)
+        if isinstance(elem, SwapMarker):
+            return SwapMarker(col=col, row=elem.row)
+        if isinstance(elem, Connection):
+            return Connection(col=col, row_start=elem.row_start, row_end=elem.row_end)
+        if isinstance(elem, BarrierMarker):
+            return BarrierMarker(col=col, row=elem.row)
+        return elem
+
+    @classmethod
+    def _add_verbatim_toggle(cls, collapsed_fig: go.Figure, expanded_fig: go.Figure) -> go.Figure:
+        collapsed_trace_count = len(collapsed_fig.data)
+        expanded_trace_count = len(expanded_fig.data)
+
+        for trace in expanded_fig.data:
+            trace.visible = False
+            collapsed_fig.add_trace(trace)
+
+        collapsed_shapes = cls._visible_layout_items(collapsed_fig.layout.shapes, visible=True)
+        expanded_shapes = cls._visible_layout_items(expanded_fig.layout.shapes, visible=False)
+        collapsed_annotations = cls._visible_layout_items(
+            collapsed_fig.layout.annotations, visible=True
+        )
+        expanded_annotations = cls._visible_layout_items(
+            expanded_fig.layout.annotations, visible=False
+        )
+        collapsed_fig.update_layout(
+            shapes=collapsed_shapes + expanded_shapes,
+            annotations=collapsed_annotations + expanded_annotations,
+            updatemenus=[
+                {
+                    "type": "buttons",
+                    "direction": "right",
+                    "x": 1,
+                    "xanchor": "right",
+                    "y": 1.08,
+                    "yanchor": "top",
+                    "buttons": [
+                        {
+                            "label": "Collapse verbatim",
+                            "method": "update",
+                            "args": [
+                                {
+                                    "visible": [True] * collapsed_trace_count
+                                    + [False] * expanded_trace_count
+                                },
+                                cls._verbatim_layout_update(
+                                    collapsed_fig,
+                                    expanded_fig,
+                                    collapsed_shapes,
+                                    expanded_shapes,
+                                    collapsed_annotations,
+                                    expanded_annotations,
+                                    expand=False,
+                                ),
+                            ],
+                        },
+                        {
+                            "label": "Expand verbatim",
+                            "method": "update",
+                            "args": [
+                                {
+                                    "visible": [False] * collapsed_trace_count
+                                    + [True] * expanded_trace_count
+                                },
+                                cls._verbatim_layout_update(
+                                    collapsed_fig,
+                                    expanded_fig,
+                                    collapsed_shapes,
+                                    expanded_shapes,
+                                    collapsed_annotations,
+                                    expanded_annotations,
+                                    expand=True,
+                                ),
+                            ],
+                        },
+                    ],
+                }
+            ],
+        )
+        return collapsed_fig
+
+    @staticmethod
+    def _visible_layout_items(items: tuple, visible: bool) -> list[dict]:
+        visible_items = []
+        for item in items:
+            item_dict = item.to_plotly_json()
+            item_dict["visible"] = visible
+            visible_items.append(item_dict)
+        return visible_items
+
+    @staticmethod
+    def _verbatim_layout_update(
+        collapsed_fig: go.Figure,
+        expanded_fig: go.Figure,
+        collapsed_shapes: list[dict],
+        expanded_shapes: list[dict],
+        collapsed_annotations: list[dict],
+        expanded_annotations: list[dict],
+        *,
+        expand: bool,
+    ) -> dict:
+        active_fig = expanded_fig if expand else collapsed_fig
+        return {
+            "shapes": [{**shape, "visible": not expand} for shape in collapsed_shapes]
+            + [{**shape, "visible": expand} for shape in expanded_shapes],
+            "annotations": [
+                {**annotation, "visible": not expand} for annotation in collapsed_annotations
+            ]
+            + [{**annotation, "visible": expand} for annotation in expanded_annotations],
+            "xaxis": active_fig.layout.xaxis.to_plotly_json(),
+            "yaxis": active_fig.layout.yaxis.to_plotly_json(),
+            "width": active_fig.layout.width,
+            "height": active_fig.layout.height,
+        }
+
+    @classmethod
+    def _draw_qubit_wires(
+        cls, fig: go.Figure, layout: CircuitLayout, left_wire: float, right_wire: float
+    ) -> None:
+        for row_idx, label in enumerate(layout.qubit_labels):
+            y = -row_idx * cls.ROW_HEIGHT
+            fig.add_shape(
+                type="line",
+                x0=left_wire,
+                x1=right_wire,
+                y0=y,
+                y1=y,
+                line={"color": cls.WIRE_COLOR, "width": cls.WIRE_WIDTH},
+            )
+            fig.add_annotation(
+                x=left_wire - 0.15,
+                y=y,
+                text=f"{label} :",
+                showarrow=False,
+                xanchor="right",
+                yanchor="middle",
+                font={"family": "monospace", "size": cls.QUBIT_LABEL_FONT_SIZE},
+            )
+
+    @classmethod
+    def _draw_moment_labels(
+        cls,
+        fig: go.Figure,
+        layout: CircuitLayout,
+        col_x: list[float],
+        label_y_top: float,
+        label_y_bottom: float,
+    ) -> None:
+        moment_col_ranges: list[tuple[str, int, int]] = []
+        for col_idx, label in enumerate(layout.moment_labels):
+            if moment_col_ranges and moment_col_ranges[-1][0] == label:
+                moment_col_ranges[-1] = (label, moment_col_ranges[-1][1], col_idx)
+            else:
+                moment_col_ranges.append((label, col_idx, col_idx))
+
+        for label, col_start, col_end in moment_col_ranges:
+            cx = (col_x[col_start] + col_x[col_end]) / 2
+            for y_pos in (label_y_top, label_y_bottom):
+                fig.add_annotation(
+                    x=cx,
+                    y=y_pos,
+                    text=label,
+                    showarrow=False,
+                    xanchor="center",
+                    yanchor="middle",
+                    font={
+                        "family": "monospace",
+                        "size": cls.MOMENT_LABEL_FONT_SIZE,
+                        "color": "#555555",
+                    },
+                )
+
+    @classmethod
+    def _draw_elements(
+        cls,
+        fig: go.Figure,
+        layout: CircuitLayout,
+        col_x: list[float],
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        for elem in layout.elements:
+            if isinstance(elem, GateBox):
+                cls._draw_gate_box(fig, elem, col_x[elem.col], layout, device_metadata)
+            elif isinstance(elem, ControlDot):
+                cls._draw_control_dot(fig, elem, col_x[elem.col], layout)
+            elif isinstance(elem, SwapMarker):
+                cls._draw_swap_marker(fig, elem, col_x[elem.col], layout)
+            elif isinstance(elem, Connection):
+                cls._draw_connection(fig, elem, col_x[elem.col], layout)
+            elif isinstance(elem, BarrierMarker):
+                cls._draw_barrier(fig, elem, col_x[elem.col], layout)
+
+    @classmethod
+    def _draw_gate_box(
+        cls,
+        fig: go.Figure,
+        elem: GateBox,
+        x: float,
+        layout: CircuitLayout,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        y = -elem.row * cls.ROW_HEIGHT
+        box_width = cls._gate_box_width(elem.label)
+        fig.add_shape(
+            type="rect",
+            x0=x - box_width / 2,
+            x1=x + box_width / 2,
+            y0=y - cls.GATE_BOX_HEIGHT / 2,
+            y1=y + cls.GATE_BOX_HEIGHT / 2,
+            fillcolor=cls.GATE_FILL_COLOR,
+            line={"color": cls.GATE_EDGE_COLOR, "width": 1.2},
+            layer="above",
+        )
+        fig.add_annotation(
+            x=x,
+            y=y,
+            text=elem.label,
+            showarrow=False,
+            xanchor="center",
+            yanchor="middle",
+            font={
+                "family": "monospace",
+                "size": cls.GATE_FONT_SIZE,
+                "color": cls.GATE_TEXT_COLOR,
+            },
+        )
+        cls._add_hover_marker(
+            fig,
+            x,
+            y,
+            cls._gate_hover_text(
+                elem.label,
+                layout.qubit_labels[elem.row],
+                metadata_key=elem.metadata_key,
+                parameter_text=elem.parameter_text,
+                device_metadata=device_metadata,
+            ),
+        )
+
+    @classmethod
+    def _gate_hover_text(
+        cls,
+        label: str,
+        qubit_label: str,
+        *,
+        metadata_key: str | None = None,
+        parameter_text: str | None = None,
+        device_metadata: Mapping[str, Any] | None = None,
+    ) -> str:
+        if parameter_text is None:
+            parameter_text = cls._parameter_text_from_label(label) or "None"
+
+        return (
+            f"Gate: {label}"
+            f"<br>Qubit: {qubit_label}"
+            f"<br>Parameters: {parameter_text}"
+            "<br>Device metadata: "
+            f"{cls._device_metadata_text(label, metadata_key, device_metadata)}"
+        )
+
+    @classmethod
+    def _device_metadata_text(
+        cls,
+        label: str,
+        metadata_key: str | None,
+        device_metadata: Mapping[str, Any] | None,
+    ) -> str:
+        if not device_metadata:
+            return "N/A (not attached)"
+
+        label_name, _, _ = label.partition("(")
+        for key in (metadata_key, label, label_name):
+            if key and key in device_metadata:
+                return cls._format_device_metadata(device_metadata[key])
+        return "N/A (not attached)"
+
+    @staticmethod
+    def _format_device_metadata(metadata: Any) -> str:
+        if metadata is None:
+            return "N/A (not attached)"
+        if isinstance(metadata, Mapping):
+            if not metadata:
+                return "N/A (not attached)"
+            return ", ".join(f"{key}: {value}" for key, value in metadata.items())
+        return str(metadata)
+
+    @classmethod
+    def _draw_control_dot(
+        cls, fig: go.Figure, elem: ControlDot, x: float, layout: CircuitLayout
+    ) -> None:
+        y = -elem.row * cls.ROW_HEIGHT
+        fill = "black" if elem.filled else "white"
+        fig.add_trace(
+            cls._get_plotly().Scatter(
+                x=[x],
+                y=[y],
+                mode="markers",
+                marker={
+                    "symbol": "circle",
+                    "size": cls.CONTROL_DOT_SIZE,
+                    "color": fill,
+                    "line": {"color": "black", "width": 2},
+                },
+                hovertemplate=(
+                    f"{'Control' if elem.filled else 'Anti-control'}"
+                    f"<br>Qubit: {layout.qubit_labels[elem.row]}<extra></extra>"
+                ),
+                showlegend=False,
+            )
+        )
+
+    @classmethod
+    def _draw_swap_marker(
+        cls, fig: go.Figure, elem: SwapMarker, x: float, layout: CircuitLayout
+    ) -> None:
+        y = -elem.row * cls.ROW_HEIGHT
+        fig.add_trace(
+            cls._get_plotly().Scatter(
+                x=[x],
+                y=[y],
+                mode="markers",
+                marker={
+                    "symbol": "x",
+                    "size": cls.SWAP_MARKER_SIZE,
+                    "color": cls.CONNECTION_COLOR,
+                    "line": {"width": 2},
+                },
+                hovertemplate=f"SWAP<br>Qubit: {layout.qubit_labels[elem.row]}<extra></extra>",
+                showlegend=False,
+            )
+        )
+
+    @classmethod
+    def _draw_connection(
+        cls, fig: go.Figure, elem: Connection, x: float, layout: CircuitLayout
+    ) -> None:
+        y_start = -elem.row_start * cls.ROW_HEIGHT
+        y_end = -elem.row_end * cls.ROW_HEIGHT
+        fig.add_shape(
+            type="line",
+            x0=x,
+            x1=x,
+            y0=y_start,
+            y1=y_end,
+            line={"color": cls.CONNECTION_COLOR, "width": cls.CONNECTION_WIDTH},
+        )
+        cls._add_hover_marker(
+            fig,
+            x,
+            (y_start + y_end) / 2,
+            (
+                "Connection"
+                f"<br>From: {layout.qubit_labels[elem.row_start]}"
+                f"<br>To: {layout.qubit_labels[elem.row_end]}"
+            ),
+        )
+
+    @classmethod
+    def _draw_barrier(
+        cls, fig: go.Figure, elem: BarrierMarker, x: float, layout: CircuitLayout
+    ) -> None:
+        y = -elem.row * cls.ROW_HEIGHT
+        half_h = cls.ROW_HEIGHT * cls.BARRIER_HEIGHT_FRAC / 2
+        half_w = cls.BARRIER_WIDTH / 2
+        fig.add_shape(
+            type="rect",
+            x0=x - half_w,
+            x1=x + half_w,
+            y0=y - half_h,
+            y1=y + half_h,
+            fillcolor=cls.BARRIER_FILL_COLOR,
+            line={"color": cls.BARRIER_COLOR, "width": 1},
+        )
+        fig.add_annotation(
+            x=x,
+            y=y,
+            text="/",
+            showarrow=False,
+            xanchor="center",
+            yanchor="middle",
+            font={"size": cls.GATE_FONT_SIZE, "color": cls.BARRIER_COLOR},
+        )
+        cls._add_hover_marker(fig, x, y, f"Barrier<br>Qubit: {layout.qubit_labels[elem.row]}")
+
+    @classmethod
+    def _add_hover_marker(cls, fig: go.Figure, x: float, y: float, text: str) -> None:
+        fig.add_trace(
+            cls._get_plotly().Scatter(
+                x=[x],
+                y=[y],
+                mode="markers",
+                marker={"size": 24, "color": "rgba(0,0,0,0)"},
+                hovertemplate=f"{text}<extra></extra>",
+                showlegend=False,
+            )
+        )
+
+    @classmethod
+    def _build_footer_lines(cls, layout: CircuitLayout) -> list[str]:
+        footer_lines: list[str] = []
+        if layout.global_phase:
+            footer_lines.append(f"Global phase: {layout.global_phase}")
+        if layout.additional_result_types:
+            footer_lines.append(
+                f"Additional result types: {', '.join(layout.additional_result_types)}"
+            )
+        if layout.unassigned_parameters:
+            footer_lines.append(f"Unassigned parameters: {', '.join(layout.unassigned_parameters)}")
+        return footer_lines
+
+    @classmethod
+    def _draw_footer(
+        cls, fig: go.Figure, footer_lines: list[str], left_wire: float, label_y_bottom: float
+    ) -> None:
+        footer_y = label_y_bottom - cls.ROW_HEIGHT * 0.7
+        for idx, line in enumerate(footer_lines):
+            fig.add_annotation(
+                x=left_wire,
+                y=footer_y - idx * cls.ROW_HEIGHT * 0.5,
+                text=line,
+                showarrow=False,
+                xanchor="left",
+                yanchor="top",
+                font={"family": "monospace", "size": cls.FOOTER_FONT_SIZE, "color": "#333333"},
+            )
+
+    @classmethod
+    def _configure_axes(
+        cls,
+        fig: go.Figure,
+        left_wire: float,
+        right_wire: float,
+        label_y_top: float,
+        label_y_bottom: float,
+        footer_lines: list[str],
+    ) -> None:
+        y_top = label_y_top + 0.4
+        y_bottom = label_y_bottom - 0.4
+        if footer_lines:
+            y_bottom -= len(footer_lines) * cls.ROW_HEIGHT * 0.5
+
+        width = max(500, int((right_wire - left_wire + 2) * 95))
+        height = max(220, int((y_top - y_bottom + 1) * 95))
+        fig.update_layout(
+            width=width,
+            height=height,
+            margin={"l": 20, "r": 20, "t": 20, "b": 20},
+            plot_bgcolor="white",
+            paper_bgcolor="white",
+            hovermode="closest",
+            showlegend=False,
+        )
+        fig.update_xaxes(
+            range=[left_wire - 1.5, right_wire + 0.5],
+            visible=False,
+            scaleanchor="y",
+            scaleratio=1,
+        )
+        fig.update_yaxes(range=[y_bottom, y_top], visible=False)
+
+    @staticmethod
+    def _add_center_annotation(fig: go.Figure, text: str) -> None:
+        fig.add_annotation(
+            x=0.5,
+            y=0.5,
+            xref="paper",
+            yref="paper",
+            text=text,
+            showarrow=False,
+            font={"size": 14},
+        )
+
+    @staticmethod
+    def _configure_empty_figure(fig: go.Figure, width: int, height: int) -> None:
+        fig.update_layout(
+            width=width,
+            height=height,
+            margin={"l": 20, "r": 20, "t": 20, "b": 20},
+            plot_bgcolor="white",
+            paper_bgcolor="white",
+            xaxis={"visible": False},
+            yaxis={"visible": False},
+            showlegend=False,
+        )

--- a/src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py
+++ b/src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py
@@ -14,7 +14,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import braket.circuits.circuit as cir
 from braket.circuits.graphical_diagram_builders.graphical_circuit_diagram import (
@@ -34,21 +35,49 @@ if TYPE_CHECKING:
     import plotly.graph_objects as go
 
 
+class _VerbatimTraceGroup(NamedTuple):
+    start: int
+    end: int
+    collapsed_indices: list[int]
+    expanded_indices: list[int]
+
+
+@dataclass
+class _TraceParts:
+    gate_x: list[float | None] = field(default_factory=list)
+    gate_y: list[float | None] = field(default_factory=list)
+    gate_text_x: list[float] = field(default_factory=list)
+    gate_text_y: list[float] = field(default_factory=list)
+    gate_text: list[str] = field(default_factory=list)
+    barrier_x: list[float | None] = field(default_factory=list)
+    barrier_y: list[float | None] = field(default_factory=list)
+    barrier_text_x: list[float] = field(default_factory=list)
+    barrier_text_y: list[float] = field(default_factory=list)
+    connection_x: list[float | None] = field(default_factory=list)
+    connection_y: list[float | None] = field(default_factory=list)
+    hover_x: list[float] = field(default_factory=list)
+    hover_y: list[float] = field(default_factory=list)
+    hover_text: list[str] = field(default_factory=list)
+    filled_control_x: list[float] = field(default_factory=list)
+    filled_control_y: list[float] = field(default_factory=list)
+    filled_control_hover: list[str] = field(default_factory=list)
+    open_control_x: list[float] = field(default_factory=list)
+    open_control_y: list[float] = field(default_factory=list)
+    open_control_hover: list[str] = field(default_factory=list)
+    swap_x: list[float] = field(default_factory=list)
+    swap_y: list[float] = field(default_factory=list)
+    swap_hover: list[str] = field(default_factory=list)
+
+
 class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
     """Renders circuit diagrams as interactive Plotly figures.
 
     Examples:
         >>> from braket.circuits import Circuit
-        >>> fig = Circuit().h(0).cnot(0, 1).show("interactive")
+        >>> fig = Circuit().h(0).cnot(0, 1).to_plotly()
 
     The returned figure includes hover tooltips and, for verbatim boxes, buttons to switch
-    between collapsed and expanded views.
-
-    The collapse path is intentionally range-based: the renderer detects nestable column
-    ranges, draws a synthetic collapsed layout, and keeps the expanded layout behind the same
-    toggle. Future ``box`` or ``scope`` circuit structures can reuse this path by contributing
-    their own ranges and collapsed labels once the SDK exposes them in the layout.
-    The current verbatim control is one global ``updatemenus`` toggle for the figure.
+    individual boxes between collapsed and expanded views.
     """
 
     COL_WIDTH = 1.4
@@ -103,7 +132,7 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
 
         Examples:
             >>> from braket.circuits import Circuit
-            >>> fig = Circuit().h(0).cnot(0, 1).show("interactive")
+            >>> fig = Circuit().h(0).cnot(0, 1).to_plotly()
         """
         go = PlotlyCircuitDiagram._get_plotly()
 
@@ -122,7 +151,7 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
             return fig
 
         layout = PlotlyCircuitDiagram._compute_layout(circuit)
-        return PlotlyCircuitDiagram._render_layout(layout, device_metadata)
+        return PlotlyCircuitDiagram._render_layout(layout, device_metadata, go)
 
     @staticmethod
     def _get_plotly() -> Any:
@@ -163,22 +192,26 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
         cls,
         layout: CircuitLayout,
         device_metadata: Mapping[str, Any] | None = None,
+        plotly_module: Any | None = None,
     ) -> go.Figure:
         verbatim_ranges = cls._find_verbatim_ranges(layout)
-        if verbatim_ranges:
-            collapsed_layout = cls._collapse_verbatim_layout(layout, verbatim_ranges)
-            collapsed_fig = cls._render_base_layout(collapsed_layout, device_metadata)
-            expanded_fig = cls._render_base_layout(layout, device_metadata)
-            return cls._add_verbatim_toggle(collapsed_fig, expanded_fig)
-        return cls._render_base_layout(layout, device_metadata)
+        return cls._render_base_layout(
+            layout,
+            device_metadata,
+            plotly_module=plotly_module,
+            verbatim_ranges=verbatim_ranges,
+        )
 
     @classmethod
     def _render_base_layout(
         cls,
         layout: CircuitLayout,
         device_metadata: Mapping[str, Any] | None = None,
+        *,
+        plotly_module: Any | None = None,
+        verbatim_ranges: list[tuple[int, int]] | None = None,
     ) -> go.Figure:
-        go = cls._get_plotly()
+        go = plotly_module or cls._get_plotly()
         fig = go.Figure()
         n_rows = max(layout.num_qubits, 1)
 
@@ -192,13 +225,21 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
 
         cls._draw_qubit_wires(fig, layout, left_wire, right_wire)
         cls._draw_moment_labels(fig, layout, col_x, label_y_top, label_y_bottom)
-        cls._draw_elements(fig, layout, col_x, device_metadata)
+        trace_groups = cls._draw_elements(
+            fig,
+            layout,
+            col_x,
+            device_metadata,
+            plotly_module=go,
+            verbatim_ranges=verbatim_ranges or [],
+        )
 
         footer_lines = cls._build_footer_lines(layout)
         if footer_lines:
             cls._draw_footer(fig, footer_lines, left_wire, label_y_bottom)
 
         cls._configure_axes(fig, left_wire, right_wire, label_y_top, label_y_bottom, footer_lines)
+        cls._add_verbatim_toggles(fig, trace_groups, col_x, left_wire, right_wire)
         return fig
 
     @classmethod
@@ -230,52 +271,6 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
         return ranges
 
     @classmethod
-    def _collapse_verbatim_layout(
-        cls, layout: CircuitLayout, verbatim_ranges: list[tuple[int, int]]
-    ) -> CircuitLayout:
-        col_map: dict[int, int] = {}
-        collapsed_elements: list = []
-        collapsed_moment_labels: list[str] = []
-        new_col = 0
-        col = 0
-        while col < layout.num_moments:
-            verbatim_range = next(
-                ((start, end) for start, end in verbatim_ranges if start == col),
-                None,
-            )
-            if verbatim_range:
-                start, end = verbatim_range
-                for source_col in range(start, end + 1):
-                    col_map[source_col] = new_col
-                collapsed_moment_labels.append("Verbatim")
-                collapsed_elements.extend(
-                    cls._build_collapsed_verbatim_elements(layout, start, end, new_col)
-                )
-                new_col += 1
-                col = end + 1
-            else:
-                col_map[col] = new_col
-                collapsed_moment_labels.append(layout.moment_labels[col])
-                new_col += 1
-                col += 1
-
-        for elem in layout.elements:
-            if cls._is_in_verbatim_range(elem.col, verbatim_ranges):
-                continue
-            collapsed_elements.append(cls._clone_element_with_col(elem, col_map[elem.col]))
-
-        return CircuitLayout(
-            num_qubits=layout.num_qubits,
-            num_moments=new_col,
-            qubit_labels=layout.qubit_labels,
-            moment_labels=collapsed_moment_labels,
-            elements=collapsed_elements,
-            global_phase=layout.global_phase,
-            additional_result_types=layout.additional_result_types,
-            unassigned_parameters=layout.unassigned_parameters,
-        )
-
-    @classmethod
     def _build_collapsed_verbatim_elements(
         cls, layout: CircuitLayout, start: int, end: int, col: int
     ) -> list:
@@ -304,133 +299,6 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
     def _is_in_verbatim_range(col: int, verbatim_ranges: list[tuple[int, int]]) -> bool:
         return any(start <= col <= end for start, end in verbatim_ranges)
 
-    @staticmethod
-    def _clone_element_with_col(elem: object, col: int) -> object:
-        if isinstance(elem, GateBox):
-            return GateBox(
-                col=col,
-                row=elem.row,
-                label=elem.label,
-                metadata_key=elem.metadata_key,
-                parameter_text=elem.parameter_text,
-            )
-        if isinstance(elem, ControlDot):
-            return ControlDot(col=col, row=elem.row, filled=elem.filled)
-        if isinstance(elem, SwapMarker):
-            return SwapMarker(col=col, row=elem.row)
-        if isinstance(elem, Connection):
-            return Connection(col=col, row_start=elem.row_start, row_end=elem.row_end)
-        if isinstance(elem, BarrierMarker):
-            return BarrierMarker(col=col, row=elem.row)
-        return elem
-
-    @classmethod
-    def _add_verbatim_toggle(cls, collapsed_fig: go.Figure, expanded_fig: go.Figure) -> go.Figure:
-        collapsed_trace_count = len(collapsed_fig.data)
-        expanded_trace_count = len(expanded_fig.data)
-
-        for trace in expanded_fig.data:
-            trace.visible = False
-            collapsed_fig.add_trace(trace)
-
-        collapsed_shapes = cls._visible_layout_items(collapsed_fig.layout.shapes, visible=True)
-        expanded_shapes = cls._visible_layout_items(expanded_fig.layout.shapes, visible=False)
-        collapsed_annotations = cls._visible_layout_items(
-            collapsed_fig.layout.annotations, visible=True
-        )
-        expanded_annotations = cls._visible_layout_items(
-            expanded_fig.layout.annotations, visible=False
-        )
-        collapsed_fig.update_layout(
-            shapes=collapsed_shapes + expanded_shapes,
-            annotations=collapsed_annotations + expanded_annotations,
-            updatemenus=[
-                {
-                    "type": "buttons",
-                    "direction": "right",
-                    "x": 1,
-                    "xanchor": "right",
-                    "y": 1.08,
-                    "yanchor": "top",
-                    "buttons": [
-                        {
-                            "label": "Collapse verbatim",
-                            "method": "update",
-                            "args": [
-                                {
-                                    "visible": [True] * collapsed_trace_count
-                                    + [False] * expanded_trace_count
-                                },
-                                cls._verbatim_layout_update(
-                                    collapsed_fig,
-                                    expanded_fig,
-                                    collapsed_shapes,
-                                    expanded_shapes,
-                                    collapsed_annotations,
-                                    expanded_annotations,
-                                    expand=False,
-                                ),
-                            ],
-                        },
-                        {
-                            "label": "Expand verbatim",
-                            "method": "update",
-                            "args": [
-                                {
-                                    "visible": [False] * collapsed_trace_count
-                                    + [True] * expanded_trace_count
-                                },
-                                cls._verbatim_layout_update(
-                                    collapsed_fig,
-                                    expanded_fig,
-                                    collapsed_shapes,
-                                    expanded_shapes,
-                                    collapsed_annotations,
-                                    expanded_annotations,
-                                    expand=True,
-                                ),
-                            ],
-                        },
-                    ],
-                }
-            ],
-        )
-        return collapsed_fig
-
-    @staticmethod
-    def _visible_layout_items(items: tuple, visible: bool) -> list[dict]:
-        visible_items = []
-        for item in items:
-            item_dict = item.to_plotly_json()
-            item_dict["visible"] = visible
-            visible_items.append(item_dict)
-        return visible_items
-
-    @staticmethod
-    def _verbatim_layout_update(
-        collapsed_fig: go.Figure,
-        expanded_fig: go.Figure,
-        collapsed_shapes: list[dict],
-        expanded_shapes: list[dict],
-        collapsed_annotations: list[dict],
-        expanded_annotations: list[dict],
-        *,
-        expand: bool,
-    ) -> dict:
-        active_fig = expanded_fig if expand else collapsed_fig
-        return {
-            "shapes": [{**shape, "visible": not expand} for shape in collapsed_shapes]
-            + [{**shape, "visible": expand} for shape in expanded_shapes],
-            "annotations": [
-                {**annotation, "visible": not expand} for annotation in collapsed_annotations
-            ]
-            + [{**annotation, "visible": expand} for annotation in expanded_annotations],
-            "xaxis": active_fig.layout.xaxis.to_plotly_json(),
-            "yaxis": active_fig.layout.yaxis.to_plotly_json(),
-            "width": active_fig.layout.width,
-            "height": active_fig.layout.height,
-        }
-
     @classmethod
     def _draw_qubit_wires(
         cls, fig: go.Figure, layout: CircuitLayout, left_wire: float, right_wire: float
@@ -444,6 +312,7 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
                 y0=y,
                 y1=y,
                 line={"color": cls.WIRE_COLOR, "width": cls.WIRE_WIDTH},
+                layer="below",
             )
             fig.add_annotation(
                 x=left_wire - 0.15,
@@ -495,65 +364,455 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
         layout: CircuitLayout,
         col_x: list[float],
         device_metadata: Mapping[str, Any] | None = None,
-    ) -> None:
-        for elem in layout.elements:
-            if isinstance(elem, GateBox):
-                cls._draw_gate_box(fig, elem, col_x[elem.col], layout, device_metadata)
-            elif isinstance(elem, ControlDot):
-                cls._draw_control_dot(fig, elem, col_x[elem.col], layout)
-            elif isinstance(elem, SwapMarker):
-                cls._draw_swap_marker(fig, elem, col_x[elem.col], layout)
-            elif isinstance(elem, Connection):
-                cls._draw_connection(fig, elem, col_x[elem.col], layout)
-            elif isinstance(elem, BarrierMarker):
-                cls._draw_barrier(fig, elem, col_x[elem.col], layout)
+        *,
+        plotly_module: Any,
+        verbatim_ranges: list[tuple[int, int]],
+    ) -> list[_VerbatimTraceGroup]:
+        if not verbatim_ranges:
+            cls._draw_element_batch(
+                fig,
+                layout,
+                col_x,
+                layout.elements,
+                device_metadata,
+                plotly_module=plotly_module,
+                visible=True,
+            )
+            return []
+
+        always_elements = [
+            elem
+            for elem in layout.elements
+            if not cls._is_in_verbatim_range(elem.col, verbatim_ranges)
+        ]
+        cls._draw_element_batch(
+            fig,
+            layout,
+            col_x,
+            always_elements,
+            device_metadata,
+            plotly_module=plotly_module,
+            visible=True,
+        )
+
+        trace_groups: list[_VerbatimTraceGroup] = []
+        for start, end in verbatim_ranges:
+            expanded_elements = [elem for elem in layout.elements if start <= elem.col <= end]
+            expanded_indices = cls._draw_element_batch(
+                fig,
+                layout,
+                col_x,
+                expanded_elements,
+                device_metadata,
+                plotly_module=plotly_module,
+                visible=False,
+            )
+
+            collapsed_col_x = col_x.copy()
+            collapsed_col_x[start] = (col_x[start] + col_x[end]) / 2
+            collapsed_elements = cls._build_collapsed_verbatim_elements(
+                layout,
+                start,
+                end,
+                start,
+            )
+            collapsed_indices = cls._draw_element_batch(
+                fig,
+                layout,
+                collapsed_col_x,
+                collapsed_elements,
+                device_metadata,
+                plotly_module=plotly_module,
+                visible=True,
+            )
+            trace_groups.append(
+                _VerbatimTraceGroup(
+                    start=start,
+                    end=end,
+                    collapsed_indices=collapsed_indices,
+                    expanded_indices=expanded_indices,
+                )
+            )
+        return trace_groups
 
     @classmethod
-    def _draw_gate_box(
+    def _draw_element_batch(
         cls,
         fig: go.Figure,
-        elem: GateBox,
-        x: float,
         layout: CircuitLayout,
+        col_x: list[float],
+        elements: list[object],
         device_metadata: Mapping[str, Any] | None = None,
-    ) -> None:
-        y = -elem.row * cls.ROW_HEIGHT
-        box_width = cls._gate_box_width(elem.label)
-        fig.add_shape(
-            type="rect",
-            x0=x - box_width / 2,
-            x1=x + box_width / 2,
-            y0=y - cls.GATE_BOX_HEIGHT / 2,
-            y1=y + cls.GATE_BOX_HEIGHT / 2,
-            fillcolor=cls.GATE_FILL_COLOR,
-            line={"color": cls.GATE_EDGE_COLOR, "width": 1.2},
-            layer="above",
-        )
-        fig.add_annotation(
-            x=x,
-            y=y,
-            text=elem.label,
-            showarrow=False,
-            xanchor="center",
-            yanchor="middle",
-            font={
-                "family": "monospace",
-                "size": cls.GATE_FONT_SIZE,
-                "color": cls.GATE_TEXT_COLOR,
-            },
-        )
-        cls._add_hover_marker(
+        *,
+        plotly_module: Any,
+        visible: bool,
+    ) -> list[int]:
+        parts = _TraceParts()
+        for elem in elements:
+            cls._collect_element_trace_parts(parts, elem, layout, col_x, device_metadata)
+
+        return cls._flush_element_traces(
             fig,
+            plotly_module,
+            visible=visible,
+            parts=parts,
+        )
+
+    @classmethod
+    def _collect_element_trace_parts(
+        cls,
+        parts: _TraceParts,
+        elem: object,
+        layout: CircuitLayout,
+        col_x: list[float],
+        device_metadata: Mapping[str, Any] | None,
+    ) -> None:
+        if isinstance(elem, GateBox):
+            cls._collect_gate_box_trace_parts(parts, elem, layout, col_x, device_metadata)
+        elif isinstance(elem, ControlDot):
+            cls._collect_control_trace_parts(parts, elem, layout, col_x)
+        elif isinstance(elem, SwapMarker):
+            x = col_x[elem.col]
+            y = -elem.row * cls.ROW_HEIGHT
+            parts.swap_x.append(x)
+            parts.swap_y.append(y)
+            parts.swap_hover.append(f"SWAP<br>Qubit: {layout.qubit_labels[elem.row]}")
+        elif isinstance(elem, Connection):
+            x = col_x[elem.col]
+            y_start = -elem.row_start * cls.ROW_HEIGHT
+            y_end = -elem.row_end * cls.ROW_HEIGHT
+            parts.connection_x.extend([x, x, None])
+            parts.connection_y.extend([y_start, y_end, None])
+            parts.hover_x.append(x)
+            parts.hover_y.append((y_start + y_end) / 2)
+            parts.hover_text.append(
+                "Connection"
+                f"<br>From: {layout.qubit_labels[elem.row_start]}"
+                f"<br>To: {layout.qubit_labels[elem.row_end]}"
+            )
+        elif isinstance(elem, BarrierMarker):
+            x = col_x[elem.col]
+            y = -elem.row * cls.ROW_HEIGHT
+            cls._append_rect(
+                parts.barrier_x,
+                parts.barrier_y,
+                x,
+                y,
+                cls.BARRIER_WIDTH,
+                cls.ROW_HEIGHT * cls.BARRIER_HEIGHT_FRAC,
+            )
+            parts.barrier_text_x.append(x)
+            parts.barrier_text_y.append(y)
+            parts.hover_x.append(x)
+            parts.hover_y.append(y)
+            parts.hover_text.append(f"Barrier<br>Qubit: {layout.qubit_labels[elem.row]}")
+
+    @classmethod
+    def _collect_gate_box_trace_parts(
+        cls,
+        parts: _TraceParts,
+        elem: GateBox,
+        layout: CircuitLayout,
+        col_x: list[float],
+        device_metadata: Mapping[str, Any] | None,
+    ) -> None:
+        x = col_x[elem.col]
+        y = -elem.row * cls.ROW_HEIGHT
+        cls._append_rect(
+            parts.gate_x,
+            parts.gate_y,
             x,
             y,
+            cls._gate_box_width(elem.label),
+            cls.GATE_BOX_HEIGHT,
+        )
+        parts.gate_text_x.append(x)
+        parts.gate_text_y.append(y)
+        parts.gate_text.append(elem.label)
+        parts.hover_x.append(x)
+        parts.hover_y.append(y)
+        parts.hover_text.append(
             cls._gate_hover_text(
                 elem.label,
                 layout.qubit_labels[elem.row],
                 metadata_key=elem.metadata_key,
                 parameter_text=elem.parameter_text,
                 device_metadata=device_metadata,
-            ),
+            )
         )
+
+    @classmethod
+    def _collect_control_trace_parts(
+        cls,
+        parts: _TraceParts,
+        elem: ControlDot,
+        layout: CircuitLayout,
+        col_x: list[float],
+    ) -> None:
+        x = col_x[elem.col]
+        y = -elem.row * cls.ROW_HEIGHT
+        text = (
+            f"{'Control' if elem.filled else 'Anti-control'}"
+            f"<br>Qubit: {layout.qubit_labels[elem.row]}"
+        )
+        if elem.filled:
+            parts.filled_control_x.append(x)
+            parts.filled_control_y.append(y)
+            parts.filled_control_hover.append(text)
+        else:
+            parts.open_control_x.append(x)
+            parts.open_control_y.append(y)
+            parts.open_control_hover.append(text)
+
+    @staticmethod
+    def _append_rect(
+        x_values: list[float | None],
+        y_values: list[float | None],
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+    ) -> None:
+        x0 = x - width / 2
+        x1 = x + width / 2
+        y0 = y - height / 2
+        y1 = y + height / 2
+        x_values.extend([x0, x1, x1, x0, x0, None])
+        y_values.extend([y0, y0, y1, y1, y0, None])
+
+    @classmethod
+    def _flush_element_traces(
+        cls,
+        fig: go.Figure,
+        plotly_module: Any,
+        *,
+        visible: bool,
+        parts: _TraceParts,
+    ) -> list[int]:
+        trace_indices: list[int] = []
+        if parts.connection_x:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.connection_x,
+                        y=parts.connection_y,
+                        mode="lines",
+                        line={"color": cls.CONNECTION_COLOR, "width": cls.CONNECTION_WIDTH},
+                        hoverinfo="skip",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        if parts.gate_x:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.gate_x,
+                        y=parts.gate_y,
+                        mode="lines",
+                        fill="toself",
+                        fillcolor=cls.GATE_FILL_COLOR,
+                        line={"color": cls.GATE_EDGE_COLOR, "width": 1.2},
+                        hoverinfo="skip",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        if parts.barrier_x:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.barrier_x,
+                        y=parts.barrier_y,
+                        mode="lines",
+                        fill="toself",
+                        fillcolor=cls.BARRIER_FILL_COLOR,
+                        line={"color": cls.BARRIER_COLOR, "width": 1},
+                        hoverinfo="skip",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        trace_indices.extend(
+            cls._add_control_traces(
+                fig,
+                plotly_module,
+                visible=visible,
+                parts=parts,
+            )
+        )
+        if parts.swap_x:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.swap_x,
+                        y=parts.swap_y,
+                        text=parts.swap_hover,
+                        mode="markers",
+                        marker={
+                            "symbol": "x",
+                            "size": cls.SWAP_MARKER_SIZE,
+                            "color": cls.CONNECTION_COLOR,
+                            "line": {"width": 2},
+                        },
+                        hovertemplate="%{text}<extra></extra>",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        if parts.gate_text:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.gate_text_x,
+                        y=parts.gate_text_y,
+                        text=parts.gate_text,
+                        mode="text",
+                        textfont={
+                            "family": "monospace",
+                            "size": cls.GATE_FONT_SIZE,
+                            "color": cls.GATE_TEXT_COLOR,
+                        },
+                        hoverinfo="skip",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        if parts.barrier_text_x:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.barrier_text_x,
+                        y=parts.barrier_text_y,
+                        text=["/"] * len(parts.barrier_text_x),
+                        mode="text",
+                        textfont={"size": cls.GATE_FONT_SIZE, "color": cls.BARRIER_COLOR},
+                        hoverinfo="skip",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        if parts.hover_x:
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=parts.hover_x,
+                        y=parts.hover_y,
+                        text=parts.hover_text,
+                        mode="markers",
+                        marker={"size": 24, "color": "rgba(0,0,0,0)"},
+                        hovertemplate="%{text}<extra></extra>",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        return trace_indices
+
+    @classmethod
+    def _add_control_traces(
+        cls,
+        fig: go.Figure,
+        plotly_module: Any,
+        *,
+        visible: bool,
+        parts: _TraceParts,
+    ) -> list[int]:
+        trace_indices: list[int] = []
+        for x_values, y_values, hover_values, fill in (
+            (parts.filled_control_x, parts.filled_control_y, parts.filled_control_hover, "black"),
+            (parts.open_control_x, parts.open_control_y, parts.open_control_hover, "white"),
+        ):
+            if not x_values:
+                continue
+            trace_indices.append(
+                cls._add_trace(
+                    fig,
+                    plotly_module.Scatter(
+                        x=x_values,
+                        y=y_values,
+                        text=hover_values,
+                        mode="markers",
+                        marker={
+                            "symbol": "circle",
+                            "size": cls.CONTROL_DOT_SIZE,
+                            "color": fill,
+                            "line": {"color": "black", "width": 2},
+                        },
+                        hovertemplate="%{text}<extra></extra>",
+                        showlegend=False,
+                        visible=visible,
+                    ),
+                )
+            )
+        return trace_indices
+
+    @staticmethod
+    def _add_trace(fig: go.Figure, trace: Any) -> int:
+        fig.add_trace(trace)
+        return len(fig.data) - 1
+
+    @classmethod
+    def _add_verbatim_toggles(
+        cls,
+        fig: go.Figure,
+        trace_groups: list[_VerbatimTraceGroup],
+        col_x: list[float],
+        left_wire: float,
+        right_wire: float,
+    ) -> None:
+        if not trace_groups:
+            return
+
+        x_min = left_wire - 1.5
+        x_max = right_wire + 0.5
+        x_span = x_max - x_min
+        updatemenus = []
+        for index, trace_group in enumerate(trace_groups, start=1):
+            trace_indices = trace_group.collapsed_indices + trace_group.expanded_indices
+            collapsed_visibility = [True] * len(trace_group.collapsed_indices) + [False] * len(
+                trace_group.expanded_indices
+            )
+            expanded_visibility = [False] * len(trace_group.collapsed_indices) + [True] * len(
+                trace_group.expanded_indices
+            )
+            group_center = (col_x[trace_group.start] + col_x[trace_group.end]) / 2
+            updatemenus.append({
+                "type": "buttons",
+                "direction": "right",
+                "showactive": True,
+                "active": 0,
+                "x": min(max((group_center - x_min) / x_span, 0), 1),
+                "xanchor": "center",
+                "y": 1.08 + (index - 1) * 0.08,
+                "yanchor": "top",
+                "buttons": [
+                    {
+                        "label": f"Collapse verbatim {index}",
+                        "method": "restyle",
+                        "args": [{"visible": collapsed_visibility}, trace_indices],
+                    },
+                    {
+                        "label": f"Expand verbatim {index}",
+                        "method": "restyle",
+                        "args": [{"visible": expanded_visibility}, trace_indices],
+                    },
+                ],
+            })
+        fig.update_layout(updatemenus=updatemenus)
 
     @classmethod
     def _gate_hover_text(
@@ -601,117 +860,6 @@ class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
                 return "N/A (not attached)"
             return ", ".join(f"{key}: {value}" for key, value in metadata.items())
         return str(metadata)
-
-    @classmethod
-    def _draw_control_dot(
-        cls, fig: go.Figure, elem: ControlDot, x: float, layout: CircuitLayout
-    ) -> None:
-        y = -elem.row * cls.ROW_HEIGHT
-        fill = "black" if elem.filled else "white"
-        fig.add_trace(
-            cls._get_plotly().Scatter(
-                x=[x],
-                y=[y],
-                mode="markers",
-                marker={
-                    "symbol": "circle",
-                    "size": cls.CONTROL_DOT_SIZE,
-                    "color": fill,
-                    "line": {"color": "black", "width": 2},
-                },
-                hovertemplate=(
-                    f"{'Control' if elem.filled else 'Anti-control'}"
-                    f"<br>Qubit: {layout.qubit_labels[elem.row]}<extra></extra>"
-                ),
-                showlegend=False,
-            )
-        )
-
-    @classmethod
-    def _draw_swap_marker(
-        cls, fig: go.Figure, elem: SwapMarker, x: float, layout: CircuitLayout
-    ) -> None:
-        y = -elem.row * cls.ROW_HEIGHT
-        fig.add_trace(
-            cls._get_plotly().Scatter(
-                x=[x],
-                y=[y],
-                mode="markers",
-                marker={
-                    "symbol": "x",
-                    "size": cls.SWAP_MARKER_SIZE,
-                    "color": cls.CONNECTION_COLOR,
-                    "line": {"width": 2},
-                },
-                hovertemplate=f"SWAP<br>Qubit: {layout.qubit_labels[elem.row]}<extra></extra>",
-                showlegend=False,
-            )
-        )
-
-    @classmethod
-    def _draw_connection(
-        cls, fig: go.Figure, elem: Connection, x: float, layout: CircuitLayout
-    ) -> None:
-        y_start = -elem.row_start * cls.ROW_HEIGHT
-        y_end = -elem.row_end * cls.ROW_HEIGHT
-        fig.add_shape(
-            type="line",
-            x0=x,
-            x1=x,
-            y0=y_start,
-            y1=y_end,
-            line={"color": cls.CONNECTION_COLOR, "width": cls.CONNECTION_WIDTH},
-        )
-        cls._add_hover_marker(
-            fig,
-            x,
-            (y_start + y_end) / 2,
-            (
-                "Connection"
-                f"<br>From: {layout.qubit_labels[elem.row_start]}"
-                f"<br>To: {layout.qubit_labels[elem.row_end]}"
-            ),
-        )
-
-    @classmethod
-    def _draw_barrier(
-        cls, fig: go.Figure, elem: BarrierMarker, x: float, layout: CircuitLayout
-    ) -> None:
-        y = -elem.row * cls.ROW_HEIGHT
-        half_h = cls.ROW_HEIGHT * cls.BARRIER_HEIGHT_FRAC / 2
-        half_w = cls.BARRIER_WIDTH / 2
-        fig.add_shape(
-            type="rect",
-            x0=x - half_w,
-            x1=x + half_w,
-            y0=y - half_h,
-            y1=y + half_h,
-            fillcolor=cls.BARRIER_FILL_COLOR,
-            line={"color": cls.BARRIER_COLOR, "width": 1},
-        )
-        fig.add_annotation(
-            x=x,
-            y=y,
-            text="/",
-            showarrow=False,
-            xanchor="center",
-            yanchor="middle",
-            font={"size": cls.GATE_FONT_SIZE, "color": cls.BARRIER_COLOR},
-        )
-        cls._add_hover_marker(fig, x, y, f"Barrier<br>Qubit: {layout.qubit_labels[elem.row]}")
-
-    @classmethod
-    def _add_hover_marker(cls, fig: go.Figure, x: float, y: float, text: str) -> None:
-        fig.add_trace(
-            cls._get_plotly().Scatter(
-                x=[x],
-                y=[y],
-                mode="markers",
-                marker={"size": 24, "color": "rgba(0,0,0,0)"},
-                hovertemplate=f"{text}<extra></extra>",
-                showlegend=False,
-            )
-        )
 
     @classmethod
     def _build_footer_lines(cls, layout: CircuitLayout) -> list[str]:

--- a/src/braket/circuits/text_diagram_builders/ascii_circuit_diagram.py
+++ b/src/braket/circuits/text_diagram_builders/ascii_circuit_diagram.py
@@ -18,10 +18,12 @@ from typing import Literal
 
 import braket.circuits.circuit as cir
 from braket.circuits.compiler_directive import CompilerDirective
-from braket.circuits.gate import Gate
 from braket.circuits.instruction import Instruction
 from braket.circuits.result_type import ResultType
 from braket.circuits.text_diagram_builders.text_circuit_diagram import TextCircuitDiagram
+from braket.circuits.text_diagram_builders.text_circuit_diagram_utils import (
+    _is_global_phase_instruction,
+)
 from braket.registers.qubit_set import QubitSet
 
 
@@ -122,11 +124,7 @@ class AsciiCircuitDiagram(TextCircuitDiagram):
                 ascii_symbols = [ascii_symbol, *after]
             control_qubits = QubitSet()
             map_control_qubit_states = None
-        elif (
-            isinstance(item, Instruction)
-            and isinstance(item.operator, Gate)
-            and item.operator.name == "GPhase"
-        ):
+        elif _is_global_phase_instruction(item):
             target_qubits = circuit_qubits
             control_qubits = QubitSet()
             target_and_control = QubitSet()
@@ -180,6 +178,7 @@ class AsciiCircuitDiagram(TextCircuitDiagram):
                     # when a user has a gate genuinely named C, but
                     # is necessary to enable proper printing of custom
                     # gates with built-in control qubits
+                    and not _is_global_phase_instruction(item)
                     and ascii_symbols[item_qubit_index] != "C"
                 )
                 else ""

--- a/src/braket/circuits/text_diagram_builders/text_circuit_diagram_utils.py
+++ b/src/braket/circuits/text_diagram_builders/text_circuit_diagram_utils.py
@@ -27,6 +27,14 @@ from braket.circuits.result_type import ResultType
 from braket.registers.qubit_set import QubitSet
 
 
+def _is_global_phase_instruction(item: Instruction | ResultType) -> bool:
+    return (
+        isinstance(item, Instruction)
+        and isinstance(item.operator, Gate)
+        and item.operator.name == "GPhase"
+    )
+
+
 def _add_footers(
     lines: list,
     circuit: cir.Circuit,
@@ -121,24 +129,14 @@ def _compute_moment_global_phase(
         float | None: The updated integrated phase.
     """
     moment_phase = sum(
-        item.operator.angle
-        for item in items
-        if (
-            isinstance(item, Instruction)
-            and isinstance(item.operator, Gate)
-            and item.operator.name == "GPhase"
-        )
+        item.operator.angle * item.power for item in items if _is_global_phase_instruction(item)
     )
     return global_phase + moment_phase if global_phase is not None else None
 
 
 def _get_qubit_range_for_item(item: Instruction | ResultType, circuit_qubits: QubitSet) -> QubitSet:
     """Get the qubit range for a given item."""
-    if (
-        isinstance(item, Instruction)
-        and isinstance(item.operator, Gate)
-        and item.operator.name == "GPhase"
-    ):
+    if _is_global_phase_instruction(item):
         return QubitSet()
 
     if isinstance(item, ResultType) and not item.target:

--- a/src/braket/circuits/text_diagram_builders/unicode_circuit_diagram.py
+++ b/src/braket/circuits/text_diagram_builders/unicode_circuit_diagram.py
@@ -18,10 +18,12 @@ from typing import Literal
 
 import braket.circuits.circuit as cir
 from braket.circuits.compiler_directive import CompilerDirective
-from braket.circuits.gate import Gate
 from braket.circuits.instruction import Instruction
 from braket.circuits.result_type import ResultType
 from braket.circuits.text_diagram_builders.text_circuit_diagram import TextCircuitDiagram
+from braket.circuits.text_diagram_builders.text_circuit_diagram_utils import (
+    _is_global_phase_instruction,
+)
 from braket.registers.qubit import Qubit
 from braket.registers.qubit_set import QubitSet
 
@@ -148,6 +150,7 @@ class UnicodeCircuitDiagram(TextCircuitDiagram):
                             # when a user has a gate genuinely named C, but
                             # is necessary to enable proper printing of custom
                             # gates with built-in control qubits
+                            and not _is_global_phase_instruction(item)
                             and ascii_symbols[item_qubit_index] != "C"
                         )
                         else ""
@@ -199,11 +202,7 @@ class UnicodeCircuitDiagram(TextCircuitDiagram):
                 qubits = circuit_qubits
                 ascii_symbols = [item.ascii_symbols[0]] * len(qubits)
                 cls._update_connections(qubits, connections)
-        elif (
-            isinstance(item, Instruction)
-            and isinstance(item.operator, Gate)
-            and item.operator.name == "GPhase"
-        ):
+        elif _is_global_phase_instruction(item):
             target_qubits = circuit_qubits
             control_qubits = QubitSet()
             qubits = circuit_qubits

--- a/test/unit_tests/braket/circuits/test_ascii_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_ascii_circuit_diagram.py
@@ -92,6 +92,13 @@ def test_one_gate_with_global_phase(target):
     _assert_correct_diagram(circ, expected)
 
 
+def test_powered_global_phase_after_gate_does_not_draw_powered_gate():
+    diagram = AsciiCircuitDiagram.build_diagram(Circuit().h(0).gphase(0.5, power=2))
+
+    assert "Global phase: 1.0" in diagram
+    assert "-^2" not in diagram
+
+
 def test_one_gate_with_zero_global_phase():
     circ = Circuit().gphase(-0.15).x(target=0).gphase(0.15)
     expected = (

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -2517,8 +2517,27 @@ def test_to_unitary_with_global_phase():
 def test_show_invokes_build_diagram():
     diagram_cls = Mock()
     circ = Circuit().h(0)
-    circ.show(circuit_diagram_class=diagram_cls)
+    result = circ.show(circuit_diagram_class=diagram_cls)
+    assert result is None
     diagram_cls.build_diagram.assert_called_once_with(circ)
+
+
+def test_show_matplotlib_alias_preserves_none_return():
+    assert Circuit().h(0).show("matplotlib") is None
+
+
+def test_show_rejects_device_metadata_for_matplotlib_alias():
+    with pytest.raises(ValueError, match="device_metadata"):
+        Circuit().h(0).show("matplotlib", device_metadata={"H": "native"})
+
+
+def test_show_rejects_device_metadata_for_custom_diagram():
+    diagram_cls = Mock()
+
+    with pytest.raises(ValueError, match="device_metadata"):
+        Circuit().h(0).show(circuit_diagram_class=diagram_cls, device_metadata={"H": "native"})
+
+    diagram_cls.build_diagram.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -3745,6 +3764,11 @@ def test_circuit_with_global_phase():
         "x $0;",
         "b[0] = measure $0;",
     ])
+
+
+def test_circuit_with_powered_global_phase():
+    circuit = Circuit().gphase(0.15, power=2).x(0)
+    assert circuit.global_phase == pytest.approx(0.3)
 
 
 def test_from_ir_round_trip_transformation_with_targeted_measurements():

--- a/test/unit_tests/braket/circuits/test_matplotlib_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_matplotlib_circuit_diagram.py
@@ -74,7 +74,7 @@ def test_one_gate_one_qubit():
     assert layout.num_moments == 1
     gates = _elements_of_type(layout, GateBox)
     assert len(gates) == 1
-    assert gates[0] == GateBox(col=0, row=0, label="H")
+    assert gates[0] == GateBox(col=0, row=0, label="H", metadata_key="H", parameter_text="None")
     assert isinstance(_fig(Circuit().h(0)), Figure)
 
 

--- a/test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py
@@ -1,0 +1,426 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests for PlotlyCircuitDiagram."""
+
+# ruff: noqa: ANN001, ANN201, S101
+
+import builtins
+
+import numpy as np
+import pytest
+
+from braket.circuits import Circuit, FreeParameter, Observable
+from braket.circuits.graphical_diagram_builders.graphical_diagram_utils import (
+    BarrierMarker,
+    CircuitLayout,
+    GateBox,
+)
+from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (
+    PlotlyCircuitDiagram,
+)
+
+go = pytest.importorskip("plotly.graph_objects")
+
+
+def _fig(circ: Circuit) -> go.Figure:
+    return PlotlyCircuitDiagram.build_diagram(circ)
+
+
+def _annotation_text(fig: go.Figure) -> list[str]:
+    return [annotation.text for annotation in fig.layout.annotations]
+
+
+def _visible_annotation_text(fig: go.Figure) -> list[str]:
+    return [
+        annotation.text
+        for annotation in fig.layout.annotations
+        if annotation.visible is None or annotation.visible
+    ]
+
+
+def _hover_templates(fig: go.Figure) -> list[str]:
+    return [trace.hovertemplate for trace in fig.data if trace.hovertemplate]
+
+
+def test_empty_circuit_returns_plotly_figure():
+    fig = _fig(Circuit())
+    assert isinstance(fig, go.Figure)
+    assert "(empty circuit)" in _annotation_text(fig)
+
+
+def test_only_gphase_circuit_returns_plotly_figure():
+    fig = _fig(Circuit().gphase(0.1))
+    assert isinstance(fig, go.Figure)
+    assert "Global phase: 0.1" in _annotation_text(fig)
+
+
+def test_one_gate_one_qubit_renders_gate_annotation_and_hover():
+    fig = _fig(Circuit().h(0))
+    assert isinstance(fig, go.Figure)
+    assert "H" in _annotation_text(fig)
+    assert any(
+        "Gate: H<br>Qubit: q0<br>Parameters: None"
+        "<br>Device metadata: N/A (not attached)" in template
+        for template in _hover_templates(fig)
+    )
+    assert any(shape.type == "rect" for shape in fig.layout.shapes)
+
+
+def test_multi_qubit_gate_renders_control_and_connection_hover():
+    fig = _fig(Circuit().cnot(0, 1))
+    hover_templates = _hover_templates(fig)
+    assert any("Control<br>Qubit: q0" in template for template in hover_templates)
+    assert any("Gate: X<br>Qubit: q1" in template for template in hover_templates)
+    assert any("Connection<br>From: q0<br>To: q1" in template for template in hover_templates)
+
+
+def test_parameterized_gate_footer_lists_unassigned_parameter():
+    theta = FreeParameter("theta")
+    fig = _fig(Circuit().rx(angle=theta, target=0))
+    assert "Rx(theta)" in _annotation_text(fig)
+    assert "Unassigned parameters: theta" in _annotation_text(fig)
+    assert any("Parameters: theta" in template for template in _hover_templates(fig))
+    assert any(
+        "Device metadata: N/A (not attached)" in template for template in _hover_templates(fig)
+    )
+
+
+def test_device_metadata_mapping_populates_gate_hover_from_operator_name():
+    fig = PlotlyCircuitDiagram.build_diagram(
+        Circuit().cnot(0, 1),
+        device_metadata={"CNot": {"fidelity": 0.997, "duration": "35 ns"}},
+    )
+
+    assert any(
+        "Gate: X<br>Qubit: q1<br>Parameters: None"
+        "<br>Device metadata: fidelity: 0.997, duration: 35 ns" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_device_metadata_mapping_populates_gate_hover_from_rendered_label():
+    theta = FreeParameter("theta")
+    fig = PlotlyCircuitDiagram.build_diagram(
+        Circuit().rx(angle=theta, target=0),
+        device_metadata={"Rx(theta)": "calibrated"},
+    )
+
+    assert any(
+        "Gate: Rx(theta)<br>Qubit: q0<br>Parameters: theta"
+        "<br>Device metadata: calibrated" in template
+        for template in _hover_templates(fig)
+    )
+
+
+@pytest.mark.parametrize("alias", ["interactive", "plotly"])
+def test_circuit_show_forwards_device_metadata_to_plotly_alias(alias):
+    fig = (
+        Circuit()
+        .cnot(0, 1)
+        .show(
+            alias,
+            device_metadata={"CNot": {"fidelity": 0.997, "duration": "35 ns"}},
+        )
+    )
+
+    assert isinstance(fig, go.Figure)
+    assert any(
+        "Gate: X<br>Qubit: q1<br>Parameters: None"
+        "<br>Device metadata: fidelity: 0.997, duration: 35 ns" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_parameterized_gate_hover_uses_rendered_float_format():
+    fig = _fig(Circuit().rx(0, 0.5))
+
+    assert any(
+        "Gate: Rx(0.50)<br>Qubit: q0<br>Parameters: 0.50" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_multi_parameter_gate_hover_uses_rendered_float_format():
+    fig = _fig(Circuit().u(0, 0.1, 0.2, 0.3))
+
+    assert any(
+        "Gate: U(0.10, 0.20, 0.30)<br>Qubit: q0<br>Parameters: 0.10, 0.20, 0.30" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_powered_parameterized_gate_hover_uses_rendered_float_format():
+    fig = _fig(Circuit().rx(0, 0.5, power=2))
+
+    assert any(
+        "Gate: Rx(0.50)^2<br>Qubit: q0<br>Parameters: 0.50" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_powered_gphase_after_gate_does_not_render_none_label():
+    fig = _fig(Circuit().h(0).gphase(0.5, power=2))
+
+    assert "Global phase: 1.0" in _annotation_text(fig)
+    assert "None^2" not in _annotation_text(fig)
+    assert not any("Gate: None^2" in template for template in _hover_templates(fig))
+
+
+def test_device_metadata_name_fallback_matches_parameterized_gate():
+    fig = PlotlyCircuitDiagram.build_diagram(
+        Circuit().rx(0, 0.5),
+        device_metadata={"Rx": "native calibrated gate"},
+    )
+
+    assert any(
+        "Gate: Rx(0.50)<br>Qubit: q0<br>Parameters: 0.50"
+        "<br>Device metadata: native calibrated gate" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_device_metadata_empty_mapping_renders_not_attached():
+    fig = PlotlyCircuitDiagram.build_diagram(Circuit().h(0), device_metadata={"H": {}})
+
+    assert any(
+        "Gate: H<br>Qubit: q0<br>Parameters: None"
+        "<br>Device metadata: N/A (not attached)" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_additional_result_types_footer():
+    fig = _fig(Circuit().h(0).state_vector().amplitude(["0"]))
+    annotation_text = _annotation_text(fig)
+    assert any(
+        text == "Additional result types: StateVector, Amplitude(0)" for text in annotation_text
+    )
+
+
+def test_barrier_renders_shape_and_hover():
+    fig = _fig(Circuit().x(0).barrier(target=[0]).h(1))
+    assert any("Barrier<br>Qubit: q0" in template for template in _hover_templates(fig))
+    assert any(
+        shape.type == "rect" and shape.fillcolor == PlotlyCircuitDiagram.BARRIER_FILL_COLOR
+        for shape in fig.layout.shapes
+    )
+
+
+def test_swap_renders_hover_marker():
+    fig = _fig(Circuit().swap(0, 2).x(1))
+    hover_templates = _hover_templates(fig)
+    assert sum("SWAP<br>Qubit:" in template for template in hover_templates) == 2
+
+
+def test_controlled_swap_renders_controls_swaps_and_connection():
+    fig = _fig(Circuit().cswap(0, 1, 2))
+    hover_templates = _hover_templates(fig)
+
+    assert any("Control<br>Qubit: q0" in template for template in hover_templates)
+    assert sum("SWAP<br>Qubit:" in template for template in hover_templates) == 2
+    assert any("Connection<br>From: q0<br>To: q2" in template for template in hover_templates)
+
+
+def test_measure_renders_gate_hover():
+    fig = _fig(Circuit().h(0).measure(0))
+
+    assert "M" in _annotation_text(fig)
+    assert any(
+        "Gate: M<br>Qubit: q0<br>Parameters: None" in template for template in _hover_templates(fig)
+    )
+
+
+def test_unitary_renders_generic_gate_hover():
+    fig = _fig(Circuit().unitary(matrix=np.array([[0, 1], [1, 0]]), targets=[0]))
+
+    assert "U" in _annotation_text(fig)
+    assert any(
+        "Gate: U<br>Qubit: q0<br>Parameters: None" in template for template in _hover_templates(fig)
+    )
+
+
+def test_observable_result_type_hover_uses_observable_parameter_text():
+    fig = _fig(Circuit().h(0).expectation(observable=Observable.X(), target=0))
+
+    assert "Expectation(X)" in _annotation_text(fig)
+    assert any(
+        "Gate: Expectation(X)<br>Qubit: q0<br>Parameters: X" in template
+        for template in _hover_templates(fig)
+    )
+
+
+def test_render_layout_ignores_unknown_element():
+    class UnknownElement:
+        col = 0
+        row = 0
+
+    layout = CircuitLayout(
+        num_qubits=1,
+        num_moments=1,
+        qubit_labels=["q0"],
+        moment_labels=["0"],
+        elements=[GateBox(col=0, row=0, label="H"), UnknownElement()],
+        global_phase=None,
+        additional_result_types=[],
+        unassigned_parameters=[],
+    )
+    fig = PlotlyCircuitDiagram._render_layout(layout)
+    assert isinstance(fig, go.Figure)
+    assert "H" in _annotation_text(fig)
+
+
+def test_circuit_show_accepts_plotly_alias():
+    fig = Circuit().h(0).show("plotly")
+    assert isinstance(fig, go.Figure)
+
+
+def test_circuit_show_accepts_interactive_alias():
+    fig = Circuit().h(0).show("interactive")
+    assert isinstance(fig, go.Figure)
+
+
+def test_circuit_show_rejects_unknown_diagram_alias():
+    with pytest.raises(ValueError, match="interactive"):
+        Circuit().h(0).show("unknown")
+
+
+def test_missing_plotly_raises_helpful_error(monkeypatch):
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "plotly.graph_objects":
+            raise ImportError("No module named plotly")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    with pytest.raises(ImportError, match=r"amazon-braket-sdk\[interactive\]"):
+        PlotlyCircuitDiagram._get_plotly()
+
+
+def test_global_phase_footer_in_rendered_layout():
+    fig = _fig(Circuit().h(0).gphase(0.25))
+    assert "Global phase: 0.25" in _annotation_text(fig)
+
+
+def test_explicit_barrier_layout_element_renders():
+    layout = CircuitLayout(
+        num_qubits=1,
+        num_moments=1,
+        qubit_labels=["q0"],
+        moment_labels=["0"],
+        elements=[BarrierMarker(col=0, row=0)],
+        global_phase=None,
+        additional_result_types=[],
+        unassigned_parameters=[],
+    )
+    fig = PlotlyCircuitDiagram._render_layout(layout)
+    assert any("Barrier<br>Qubit: q0" in template for template in _hover_templates(fig))
+
+
+def test_verbatim_block_collapses_by_default_and_can_expand():
+    fig = _fig(Circuit().h(0).add_verbatim_box(Circuit().h(0).cnot(0, 1)).x(1))
+    annotation_text = _visible_annotation_text(fig)
+    assert "Verbatim" in annotation_text
+    assert "StartVerbatim" not in annotation_text
+    assert "EndVerbatim" not in annotation_text
+    assert len(fig.layout.updatemenus) == 1
+    assert [button.label for button in fig.layout.updatemenus[0].buttons] == [
+        "Collapse verbatim",
+        "Expand verbatim",
+    ]
+    expanded_annotations = fig.layout.updatemenus[0].buttons[1].args[1]["annotations"]
+    visible_expanded_annotations = [
+        annotation["text"] for annotation in expanded_annotations if annotation["visible"]
+    ]
+    assert "StartVerbatim" in visible_expanded_annotations
+    assert "EndVerbatim" in visible_expanded_annotations
+
+
+def test_verbatim_range_detection_deduplicates_multirow_boundaries():
+    layout = PlotlyCircuitDiagram._compute_layout(
+        Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1))
+    )
+    assert PlotlyCircuitDiagram._find_verbatim_ranges(layout) == [(0, 3)]
+
+
+def test_verbatim_range_detection_handles_nested_and_adjacent_blocks():
+    nested_layout = PlotlyCircuitDiagram._compute_layout(
+        Circuit().add_verbatim_box(Circuit().h(0).add_verbatim_box(Circuit().x(0)).y(0))
+    )
+    adjacent_layout = PlotlyCircuitDiagram._compute_layout(
+        Circuit().add_verbatim_box(Circuit().h(0)).add_verbatim_box(Circuit().x(0))
+    )
+
+    assert PlotlyCircuitDiagram._find_verbatim_ranges(nested_layout) == [(0, 6)]
+    assert PlotlyCircuitDiagram._find_verbatim_ranges(adjacent_layout) == [(0, 2), (3, 5)]
+
+
+def test_nested_verbatim_expanded_state_renders_inner_gate_and_result_type():
+    circuit = (
+        Circuit()
+        .add_verbatim_box(Circuit().h(0).add_verbatim_box(Circuit().rx(0, 0.5)).cnot(0, 1))
+        .probability(target=[0])
+    )
+
+    fig = _fig(circuit)
+    expanded_annotations = fig.layout.updatemenus[0].buttons[1].args[1]["annotations"]
+    visible_expanded_annotations = [
+        annotation["text"] for annotation in expanded_annotations if annotation["visible"]
+    ]
+
+    assert any(text.startswith("Rx(") for text in visible_expanded_annotations)
+    assert "Probability" in visible_expanded_annotations
+    assert fig.to_json()
+
+
+def test_verbatim_expanded_state_preserves_device_metadata():
+    fig = PlotlyCircuitDiagram.build_diagram(
+        Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1)),
+        device_metadata={"CNot": "two-qubit native"},
+    )
+
+    expanded_hover_templates = [
+        trace.hovertemplate for trace in fig.data if trace.hovertemplate and trace.visible is False
+    ]
+
+    assert any(
+        "Gate: X<br>Qubit: q1<br>Parameters: None<br>Device metadata: two-qubit native" in template
+        for template in expanded_hover_templates
+    )
+
+
+def test_target_result_type_renders_as_result_type_column():
+    fig = _fig(Circuit().h(0).probability(target=[0]))
+    assert "Result Types" in _annotation_text(fig)
+    assert "Probability" in _annotation_text(fig)
+
+
+def test_anti_control_renders_open_control_hover():
+    fig = _fig(Circuit().x(0, control=[1], control_state=[0]))
+    assert any("Anti-control<br>Qubit: q1" in template for template in _hover_templates(fig))
+
+
+def test_large_circuit_smoke_serializes_to_json():
+    circuit = Circuit()
+    for qubit in range(20):
+        circuit.h(qubit)
+    for qubit in range(19):
+        circuit.cnot(qubit, qubit + 1)
+
+    fig = _fig(circuit)
+
+    assert fig.data
+    assert fig.layout.width >= 500
+    assert fig.layout.height >= 220
+    assert fig.to_json()

--- a/test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py
@@ -24,6 +24,7 @@ from braket.circuits import Circuit, FreeParameter, Observable
 from braket.circuits.graphical_diagram_builders.graphical_diagram_utils import (
     BarrierMarker,
     CircuitLayout,
+    Connection,
     GateBox,
 )
 from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (
@@ -49,8 +50,61 @@ def _visible_annotation_text(fig: go.Figure) -> list[str]:
     ]
 
 
-def _hover_templates(fig: go.Figure) -> list[str]:
-    return [trace.hovertemplate for trace in fig.data if trace.hovertemplate]
+def _trace_text(fig: go.Figure, *, visible: bool | None = None) -> list[str]:
+    text: list[str] = []
+    for trace in fig.data:
+        trace_visible = trace.visible if trace.visible is not None else True
+        if visible is not None and trace_visible is not visible:
+            continue
+        if trace.text is None:
+            continue
+        if isinstance(trace.text, str):
+            text.append(trace.text)
+        else:
+            text.extend(str(item) for item in trace.text)
+    return text
+
+
+def _figure_text(fig: go.Figure) -> list[str]:
+    return _annotation_text(fig) + _trace_text(fig)
+
+
+def _visible_figure_text(fig: go.Figure) -> list[str]:
+    return _visible_annotation_text(fig) + _trace_text(fig, visible=True)
+
+
+def _hover_templates(fig: go.Figure, *, visible: bool | None = None) -> list[str]:
+    text: list[str] = []
+    for trace in fig.data:
+        trace_visible = trace.visible if trace.visible is not None else True
+        if visible is not None and trace_visible is not visible:
+            continue
+        if not trace.hovertemplate:
+            continue
+        if trace.text is None:
+            text.append(trace.hovertemplate)
+        elif isinstance(trace.text, str):
+            text.append(trace.text)
+        else:
+            text.extend(str(item) for item in trace.text)
+    return text
+
+
+def _figure_text_after_button(fig: go.Figure, button) -> list[str]:
+    visible_by_trace = dict(zip(button.args[1], button.args[0]["visible"], strict=True))
+    text: list[str] = []
+    for index, trace in enumerate(fig.data):
+        trace_visible = visible_by_trace.get(
+            index,
+            trace.visible if trace.visible is not None else True,
+        )
+        if not trace_visible or trace.text is None:
+            continue
+        if isinstance(trace.text, str):
+            text.append(trace.text)
+        else:
+            text.extend(str(item) for item in trace.text)
+    return _visible_annotation_text(fig) + text
 
 
 def test_empty_circuit_returns_plotly_figure():
@@ -68,13 +122,13 @@ def test_only_gphase_circuit_returns_plotly_figure():
 def test_one_gate_one_qubit_renders_gate_annotation_and_hover():
     fig = _fig(Circuit().h(0))
     assert isinstance(fig, go.Figure)
-    assert "H" in _annotation_text(fig)
+    assert "H" in _figure_text(fig)
     assert any(
         "Gate: H<br>Qubit: q0<br>Parameters: None"
         "<br>Device metadata: N/A (not attached)" in template
         for template in _hover_templates(fig)
     )
-    assert any(shape.type == "rect" for shape in fig.layout.shapes)
+    assert any(trace.fill == "toself" for trace in fig.data)
 
 
 def test_multi_qubit_gate_renders_control_and_connection_hover():
@@ -88,8 +142,8 @@ def test_multi_qubit_gate_renders_control_and_connection_hover():
 def test_parameterized_gate_footer_lists_unassigned_parameter():
     theta = FreeParameter("theta")
     fig = _fig(Circuit().rx(angle=theta, target=0))
-    assert "Rx(theta)" in _annotation_text(fig)
-    assert "Unassigned parameters: theta" in _annotation_text(fig)
+    assert "Rx(theta)" in _figure_text(fig)
+    assert "Unassigned parameters: theta" in _figure_text(fig)
     assert any("Parameters: theta" in template for template in _hover_templates(fig))
     assert any(
         "Device metadata: N/A (not attached)" in template for template in _hover_templates(fig)
@@ -124,8 +178,15 @@ def test_device_metadata_mapping_populates_gate_hover_from_rendered_label():
 
 
 @pytest.mark.parametrize("alias", ["interactive", "plotly"])
-def test_circuit_show_forwards_device_metadata_to_plotly_alias(alias):
-    fig = (
+def test_circuit_show_forwards_device_metadata_to_plotly_alias(alias, monkeypatch):
+    shown = {}
+
+    def fake_show(self):
+        shown["figure"] = self
+
+    monkeypatch.setattr(go.Figure, "show", fake_show)
+
+    result = (
         Circuit()
         .cnot(0, 1)
         .show(
@@ -134,6 +195,8 @@ def test_circuit_show_forwards_device_metadata_to_plotly_alias(alias):
         )
     )
 
+    assert result is None
+    fig = shown["figure"]
     assert isinstance(fig, go.Figure)
     assert any(
         "Gate: X<br>Qubit: q1<br>Parameters: None"
@@ -173,7 +236,7 @@ def test_powered_gphase_after_gate_does_not_render_none_label():
     fig = _fig(Circuit().h(0).gphase(0.5, power=2))
 
     assert "Global phase: 1.0" in _annotation_text(fig)
-    assert "None^2" not in _annotation_text(fig)
+    assert "None^2" not in _figure_text(fig)
     assert not any("Gate: None^2" in template for template in _hover_templates(fig))
 
 
@@ -212,8 +275,8 @@ def test_barrier_renders_shape_and_hover():
     fig = _fig(Circuit().x(0).barrier(target=[0]).h(1))
     assert any("Barrier<br>Qubit: q0" in template for template in _hover_templates(fig))
     assert any(
-        shape.type == "rect" and shape.fillcolor == PlotlyCircuitDiagram.BARRIER_FILL_COLOR
-        for shape in fig.layout.shapes
+        trace.fill == "toself" and trace.fillcolor == PlotlyCircuitDiagram.BARRIER_FILL_COLOR
+        for trace in fig.data
     )
 
 
@@ -235,7 +298,7 @@ def test_controlled_swap_renders_controls_swaps_and_connection():
 def test_measure_renders_gate_hover():
     fig = _fig(Circuit().h(0).measure(0))
 
-    assert "M" in _annotation_text(fig)
+    assert "M" in _figure_text(fig)
     assert any(
         "Gate: M<br>Qubit: q0<br>Parameters: None" in template for template in _hover_templates(fig)
     )
@@ -244,7 +307,7 @@ def test_measure_renders_gate_hover():
 def test_unitary_renders_generic_gate_hover():
     fig = _fig(Circuit().unitary(matrix=np.array([[0, 1], [1, 0]]), targets=[0]))
 
-    assert "U" in _annotation_text(fig)
+    assert "U" in _figure_text(fig)
     assert any(
         "Gate: U<br>Qubit: q0<br>Parameters: None" in template for template in _hover_templates(fig)
     )
@@ -253,7 +316,7 @@ def test_unitary_renders_generic_gate_hover():
 def test_observable_result_type_hover_uses_observable_parameter_text():
     fig = _fig(Circuit().h(0).expectation(observable=Observable.X(), target=0))
 
-    assert "Expectation(X)" in _annotation_text(fig)
+    assert "Expectation(X)" in _figure_text(fig)
     assert any(
         "Gate: Expectation(X)<br>Qubit: q0<br>Parameters: X" in template
         for template in _hover_templates(fig)
@@ -277,17 +340,29 @@ def test_render_layout_ignores_unknown_element():
     )
     fig = PlotlyCircuitDiagram._render_layout(layout)
     assert isinstance(fig, go.Figure)
-    assert "H" in _annotation_text(fig)
+    assert "H" in _figure_text(fig)
 
 
-def test_circuit_show_accepts_plotly_alias():
-    fig = Circuit().h(0).show("plotly")
-    assert isinstance(fig, go.Figure)
+def test_circuit_show_accepts_plotly_alias(monkeypatch):
+    shown = {}
+
+    def fake_show(self):
+        shown["figure"] = self
+
+    monkeypatch.setattr(go.Figure, "show", fake_show)
+    assert Circuit().h(0).show("plotly") is None
+    assert isinstance(shown["figure"], go.Figure)
 
 
-def test_circuit_show_accepts_interactive_alias():
-    fig = Circuit().h(0).show("interactive")
-    assert isinstance(fig, go.Figure)
+def test_circuit_show_accepts_interactive_alias(monkeypatch):
+    shown = {}
+
+    def fake_show(self):
+        shown["figure"] = self
+
+    monkeypatch.setattr(go.Figure, "show", fake_show)
+    assert Circuit().h(0).show("interactive") is None
+    assert isinstance(shown["figure"], go.Figure)
 
 
 def test_circuit_show_rejects_unknown_diagram_alias():
@@ -330,21 +405,18 @@ def test_explicit_barrier_layout_element_renders():
 
 def test_verbatim_block_collapses_by_default_and_can_expand():
     fig = _fig(Circuit().h(0).add_verbatim_box(Circuit().h(0).cnot(0, 1)).x(1))
-    annotation_text = _visible_annotation_text(fig)
-    assert "Verbatim" in annotation_text
-    assert "StartVerbatim" not in annotation_text
-    assert "EndVerbatim" not in annotation_text
+    visible_text = _visible_figure_text(fig)
+    assert "Verbatim" in visible_text
+    assert "StartVerbatim" not in visible_text
+    assert "EndVerbatim" not in visible_text
     assert len(fig.layout.updatemenus) == 1
     assert [button.label for button in fig.layout.updatemenus[0].buttons] == [
-        "Collapse verbatim",
-        "Expand verbatim",
+        "Collapse verbatim 1",
+        "Expand verbatim 1",
     ]
-    expanded_annotations = fig.layout.updatemenus[0].buttons[1].args[1]["annotations"]
-    visible_expanded_annotations = [
-        annotation["text"] for annotation in expanded_annotations if annotation["visible"]
-    ]
-    assert "StartVerbatim" in visible_expanded_annotations
-    assert "EndVerbatim" in visible_expanded_annotations
+    expanded_text = _figure_text_after_button(fig, fig.layout.updatemenus[0].buttons[1])
+    assert "StartVerbatim" in expanded_text
+    assert "EndVerbatim" in expanded_text
 
 
 def test_verbatim_range_detection_deduplicates_multirow_boundaries():
@@ -374,13 +446,10 @@ def test_nested_verbatim_expanded_state_renders_inner_gate_and_result_type():
     )
 
     fig = _fig(circuit)
-    expanded_annotations = fig.layout.updatemenus[0].buttons[1].args[1]["annotations"]
-    visible_expanded_annotations = [
-        annotation["text"] for annotation in expanded_annotations if annotation["visible"]
-    ]
+    expanded_text = _figure_text_after_button(fig, fig.layout.updatemenus[0].buttons[1])
 
-    assert any(text.startswith("Rx(") for text in visible_expanded_annotations)
-    assert "Probability" in visible_expanded_annotations
+    assert any(text.startswith("Rx(") for text in expanded_text)
+    assert "Probability" in expanded_text
     assert fig.to_json()
 
 
@@ -390,20 +459,16 @@ def test_verbatim_expanded_state_preserves_device_metadata():
         device_metadata={"CNot": "two-qubit native"},
     )
 
-    expanded_hover_templates = [
-        trace.hovertemplate for trace in fig.data if trace.hovertemplate and trace.visible is False
-    ]
-
     assert any(
         "Gate: X<br>Qubit: q1<br>Parameters: None<br>Device metadata: two-qubit native" in template
-        for template in expanded_hover_templates
+        for template in _hover_templates(fig, visible=False)
     )
 
 
 def test_target_result_type_renders_as_result_type_column():
     fig = _fig(Circuit().h(0).probability(target=[0]))
-    assert "Result Types" in _annotation_text(fig)
-    assert "Probability" in _annotation_text(fig)
+    assert "Result Types" in _figure_text(fig)
+    assert "Probability" in _figure_text(fig)
 
 
 def test_anti_control_renders_open_control_hover():
@@ -424,3 +489,95 @@ def test_large_circuit_smoke_serializes_to_json():
     assert fig.layout.width >= 500
     assert fig.layout.height >= 220
     assert fig.to_json()
+
+
+def test_element_rows_returns_empty_for_unknown_element():
+    class UnknownElement:
+        col = 0
+        row = 0
+
+    assert PlotlyCircuitDiagram._element_rows(UnknownElement()) == set()
+
+
+def test_adjacent_verbatim_boxes_have_independent_trace_buttons():
+    fig = _fig(Circuit().add_verbatim_box(Circuit().h(0)).add_verbatim_box(Circuit().x(0)))
+
+    assert len(fig.layout.updatemenus) == 2
+    first_indices = set(fig.layout.updatemenus[0].buttons[1].args[1])
+    second_indices = set(fig.layout.updatemenus[1].buttons[1].args[1])
+    assert first_indices.isdisjoint(second_indices)
+    assert "H" in _figure_text_after_button(fig, fig.layout.updatemenus[0].buttons[1])
+    assert "X" in _figure_text_after_button(fig, fig.layout.updatemenus[1].buttons[1])
+
+
+def test_gate_hover_points_are_batched_into_one_trace():
+    fig = _fig(Circuit().h(0).x(1).y(2))
+
+    transparent_hover_traces = [
+        trace
+        for trace in fig.data
+        if trace.hovertemplate == "%{text}<extra></extra>"
+        and trace.marker
+        and trace.marker.color == "rgba(0,0,0,0)"
+    ]
+    assert len(transparent_hover_traces) == 1
+    assert {"Gate: H", "Gate: X", "Gate: Y"}.issubset({
+        text.split("<br>", maxsplit=1)[0] for text in transparent_hover_traces[0].text
+    })
+
+
+def test_non_verbatim_elements_remain_visible_when_verbatim_box_collapses():
+    # Controls, swaps, connections and a barrier live outside the verbatim box, so they
+    # must remain visible while only the verbatim box's own traces are toggled.
+    circuit = Circuit().cnot(0, 1).swap(0, 1).barrier().add_verbatim_box(Circuit().h(0).cnot(0, 1))
+    fig = _fig(circuit)
+    assert fig.to_json()
+
+
+def test_build_collapsed_verbatim_elements_empty_range_spans_all_qubits():
+    layout = CircuitLayout(
+        num_qubits=3,
+        num_moments=1,
+        qubit_labels=["q0", "q1", "q2"],
+        moment_labels=["0"],
+        elements=[],
+        global_phase=None,
+        additional_result_types=[],
+        unassigned_parameters=[],
+    )
+    elements = PlotlyCircuitDiagram._build_collapsed_verbatim_elements(layout, 0, 0, 0)
+    gate_rows = sorted(elem.row for elem in elements if isinstance(elem, GateBox))
+    assert gate_rows == [0, 1, 2]
+    assert all(elem.label == "Verbatim" for elem in elements if isinstance(elem, GateBox))
+    assert any(isinstance(elem, Connection) for elem in elements)
+
+
+def test_build_collapsed_verbatim_elements_single_row_omits_connection():
+    layout = CircuitLayout(
+        num_qubits=3,
+        num_moments=1,
+        qubit_labels=["q0", "q1", "q2"],
+        moment_labels=["0"],
+        elements=[GateBox(col=0, row=1, label="H")],
+        global_phase=None,
+        additional_result_types=[],
+        unassigned_parameters=[],
+    )
+    elements = PlotlyCircuitDiagram._build_collapsed_verbatim_elements(layout, 0, 0, 0)
+    assert elements == [GateBox(col=0, row=1, label="Verbatim")]
+    assert not any(isinstance(elem, Connection) for elem in elements)
+
+
+def test_device_metadata_none_value_renders_not_attached():
+    fig = PlotlyCircuitDiagram.build_diagram(Circuit().h(0), device_metadata={"H": None})
+    assert any(
+        "Device metadata: N/A (not attached)" in template for template in _hover_templates(fig)
+    )
+
+
+def test_format_device_metadata_none_renders_not_attached():
+    assert PlotlyCircuitDiagram._format_device_metadata(None) == "N/A (not attached)"
+
+
+def test_parameter_text_from_label_unclosed_parenthesis_returns_none():
+    assert PlotlyCircuitDiagram._parameter_text_from_label("Rx(0.5") is None

--- a/test/unit_tests/braket/circuits/test_unicode_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_unicode_circuit_diagram.py
@@ -99,6 +99,13 @@ def test_one_gate_with_global_phase(target):
     _assert_correct_diagram(circ, expected)
 
 
+def test_powered_global_phase_after_gate_does_not_draw_powered_gate():
+    diagram = UnicodeCircuitDiagram.build_diagram(Circuit().h(0).gphase(0.5, power=2))
+
+    assert "Global phase: 1.0" in diagram
+    assert "─^2" not in diagram
+
+
 def test_one_gate_with_zero_global_phase():
     circ = Circuit().gphase(-0.15).x(target=0).gphase(0.15)
     expected = (


### PR DESCRIPTION
## Summary

Closes #1250 
(edited - would github link issue now?)

This adds `PlotlyCircuitDiagram`, an optional interactive renderer for Braket circuits. It reuses the graphical circuit layout used by the Matplotlib renderer.
`Circuit.show("interactive")` and `Circuit.show("plotly")` display the interactive Plotly diagram as side-effect-only methods, matching the existing `Circuit.show()` behavior. Callers that need the `plotly.graph_objects.Figure` object for programmatic use can call `Circuit.to_plotly()`.

## What changed

- Added `PlotlyCircuitDiagram` under `graphical_diagram_builders`.
- Added `Circuit.show("interactive")` / `Circuit.show("plotly")` display aliases and `Circuit.to_plotly()` for returning a Plotly figure.
- Added hover text for gates, controls, swaps, barriers, result types, parameters, and optional caller-provided device metadata.
- Added collapsed-by-default verbatim rendering with expand/collapse buttons implemented with Plotly `updatemenus`.
- Added the `amazon-braket-sdk[interactive]` optional extra and lazy Plotly import handling.
- Added a short usage example in `examples/plotly_circuit_visualization.py`.
- Added unit coverage for rendering, hover text, verbatim toggling, result types, empty/global-phase circuits, and larger circuit serialization.

## Correctness note

While wiring the global-phase footer into the renderers, I found that powered `GPhase` instructions were not reflected in the public `Circuit.global_phase` value: the current value used only the raw angle and ignored the instruction power. This PR updates the public value and the text/graphical footers to use the effective phase `angle * power`, matching the unitary behavior. Powered `GPhase` instructions are also suppressed as standalone gate boxes so they appear only in the global-phase footer.

## Testing

After final formatting, I ran:

- `python -m pytest -p no:randomly test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py -q`
- `python -m pytest -p no:randomly test/unit_tests -q`
- `ruff format --check .`
- `ruff check src`

## AI assistance disclosure

I used AI assistants (Codex, Claude, and Hermes) to help draft and review parts of the renderer, tests, and PR text. I manually reviewed the implementation against #1250, refined the generated suggestions, and verified the final code locally with the tests and lint checks above.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
