### PR TITLE
  fix: support division in FreeParameterExpression string constructor

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -84,6 +84,7 @@ class FreeParameterExpression:
             ast.Add: self.__add__,
             ast.Sub: self.__sub__,
             ast.Mult: self.__mul__,
+            ast.Div: self.__truediv__,
             ast.Pow: self.__pow__,
             ast.USub: self.__neg__,
         }

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -104,9 +104,10 @@ def test_openqasm_arithmetic_str_and_repr_match():
     assert "alpha" in expr_str
 
 
-@pytest.mark.xfail(raises=ValueError)
-def test_unsupported_bin_op_str():
-    FreeParameterExpression("theta/1")
+def test_truediv_str():
+    truediv_expr = FreeParameterExpression("theta/1")
+    expected = FreeParameterExpression(FreeParameter("theta")) / FreeParameterExpression(1)
+    assert truediv_expr == expected
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
Fixes #1251

This PR adds support for division (`/`) in the `FreeParameterExpression` string constructor by adding `ast.Div: self.__truediv__` to the `_operations` dictionary.

Changes:
- Added `ast.Div: self.__truediv__` to `_operations` in `FreeParameterExpression.__init__`
- Replaced `test_unsupported_bin_op_str` with `test_truediv_str` to verify the fix

This allows `FreeParameterExpression("alpha/beta")` to work correctly, matching the behavior of `FreeParameter("alpha") / FreeParameter("beta")`.