### PR TITLE
feat: add canonical PauliStringSum container

### DIFF
--- a/src/braket/quantum_information/__init__.py
+++ b/src/braket/quantum_information/__init__.py
@@ -16,4 +16,4 @@ includes the PauliString class for representing and manipulating tensor products
 of Pauli operators.
 """
 
-from braket.quantum_information.pauli_string import PauliString  # noqa: F401
+from braket.quantum_information.pauli_string import PauliString, PauliStringSum  # noqa: F401

--- a/src/braket/quantum_information/pauli_string.py
+++ b/src/braket/quantum_information/pauli_string.py
@@ -14,9 +14,11 @@
 from __future__ import annotations
 
 import itertools
+import numbers
 
 from braket.circuits.circuit import Circuit
-from braket.circuits.observables import I, TensorProduct, X, Y, Z
+from braket.circuits.observable import Observable
+from braket.circuits.observables import I, Sum, TensorProduct, X, Y, Z
 
 _IDENTITY = "I"
 _PAULI_X = "X"
@@ -217,7 +219,7 @@ class PauliString:
             self._nontrivial = out_pauli_string._nontrivial
         return out_pauli_string
 
-    def __mul__(self, other: PauliString) -> PauliString:
+    def __mul__(self, other: PauliString | numbers.Real) -> PauliString | PauliStringSum:
         """Right multiplication operator overload using `dot()`.
 
         Returns the result of multiplying the current circuit by the argument on its right.
@@ -234,7 +236,30 @@ class PauliString:
         See Also:
             `braket.quantum_information.PauliString.dot()`
         """
-        return self.dot(other)
+        if isinstance(other, PauliString):
+            return self.dot(other)
+        if isinstance(other, numbers.Real):
+            return PauliStringSum([(other, self)])
+        return NotImplemented
+
+    def __rmul__(self, other: numbers.Real) -> PauliStringSum:
+        if isinstance(other, numbers.Real):
+            return PauliStringSum([(other, self)])
+        return NotImplemented
+
+    def __add__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        if isinstance(other, PauliString):
+            return PauliStringSum([(1, self), (1, other)])
+        if isinstance(other, PauliStringSum):
+            return PauliStringSum([(1, self)]) + other
+        return NotImplemented
+
+    def __sub__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        if isinstance(other, PauliString):
+            return PauliStringSum([(1, self), (-1, other)])
+        if isinstance(other, PauliStringSum):
+            return PauliStringSum([(1, self)]) - other
+        return NotImplemented
 
     def __imul__(self, other: PauliString) -> PauliString:
         """Operator overload for right-multiplication assignment (`*=`) using `dot()`.
@@ -408,3 +433,193 @@ class PauliString:
             elif state == -2:
                 circ.h(qubit).si(qubit)
         return circ
+
+
+class PauliStringSum:
+    """Canonical weighted sum of Pauli strings.
+
+    Duplicate Pauli strings are merged into a deterministic canonical representation. Terms whose
+    coefficient becomes zero are removed, making conversions and equality checks algebraic rather
+    than dependent on insertion order.
+    """
+
+    def __init__(
+        self,
+        terms: PauliStringSum | PauliString | list[tuple[numbers.Real, str | PauliString]] | None,
+    ):
+        self._terms = {}
+        if terms is None:
+            return
+        if isinstance(terms, PauliStringSum):
+            self._terms = dict(terms._terms)
+            return
+        if isinstance(terms, PauliString):
+            self._add_term(1, terms)
+            return
+        for coefficient, pauli_string in terms:
+            self._add_term(coefficient, pauli_string)
+
+    @classmethod
+    def from_list(cls, terms: list[tuple[numbers.Real, str | PauliString]]) -> PauliStringSum:
+        return cls(terms)
+
+    @classmethod
+    def from_sum(cls, observable_sum: Sum) -> PauliStringSum:
+        if not isinstance(observable_sum, Sum):
+            raise TypeError("observable_sum must be an Observable.Sum instance")
+        terms = []
+        for observable in observable_sum.summands:
+            coefficient, pauli_string = PauliStringSum._observable_to_term(observable)
+            terms.append((coefficient, pauli_string))
+        return cls(terms)
+
+    @property
+    def terms(self) -> tuple[tuple[float, PauliString], ...]:
+        return tuple((coefficient, PauliString(word)) for word, coefficient in self._sorted_terms())
+
+    def to_list(self) -> list[tuple[float, str]]:
+        return [(coefficient, word) for word, coefficient in self._sorted_terms()]
+
+    def to_sum(self) -> Sum:
+        if not self._terms:
+            raise ValueError("Cannot convert an empty PauliStringSum to Observable.Sum")
+        return Sum([
+            coefficient * PauliString(word).to_unsigned_observable(include_trivial=True)
+            for word, coefficient in self._sorted_terms()
+        ])
+
+    def commutes_with(self, other: PauliString | PauliStringSum) -> bool:
+        if isinstance(other, PauliString):
+            return all(
+                PauliStringSum._strings_commute(PauliString(word), other) for word in self._terms
+            )
+        if isinstance(other, PauliStringSum):
+            return all(
+                PauliStringSum._strings_commute(PauliString(left), PauliString(right))
+                for left in self._terms
+                for right in other._terms
+            )
+        raise TypeError("Can only check commutation with PauliString or PauliStringSum")
+
+    def is_self_commuting(self) -> bool:
+        words = list(self._terms)
+        return all(
+            PauliStringSum._strings_commute(PauliString(left), PauliString(right))
+            for i, left in enumerate(words)
+            for right in words[i + 1 :]
+        )
+
+    def __add__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        if isinstance(other, PauliString):
+            return PauliStringSum([*self.terms, (1, other)])
+        if isinstance(other, PauliStringSum):
+            return PauliStringSum([*self.terms, *other.terms])
+        return NotImplemented
+
+    def __radd__(self, other: PauliString) -> PauliStringSum:
+        if isinstance(other, PauliString):
+            return self + other
+        return NotImplemented
+
+    def __sub__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        if isinstance(other, PauliString):
+            return PauliStringSum([*self.terms, (-1, other)])
+        if isinstance(other, PauliStringSum):
+            return PauliStringSum([
+                *self.terms,
+                *((-coefficient, word) for coefficient, word in other.terms),
+            ])
+        return NotImplemented
+
+    def __rsub__(self, other: PauliString) -> PauliStringSum:
+        if isinstance(other, PauliString):
+            return PauliStringSum([(1, other)]) - self
+        return NotImplemented
+
+    def __mul__(self, other: numbers.Real | PauliString | PauliStringSum) -> PauliStringSum:
+        if isinstance(other, numbers.Real):
+            return PauliStringSum([(coefficient * other, word) for coefficient, word in self.terms])
+        if isinstance(other, PauliString):
+            return PauliStringSum([
+                (coefficient, PauliString(word) * other) for coefficient, word in self.terms
+            ])
+        if isinstance(other, PauliStringSum):
+            return PauliStringSum([
+                (left_coefficient * right_coefficient, left_word * right_word)
+                for left_coefficient, left_word in self.terms
+                for right_coefficient, right_word in other.terms
+            ])
+        return NotImplemented
+
+    def __rmul__(self, other: numbers.Real | PauliString) -> PauliStringSum:
+        if isinstance(other, numbers.Real):
+            return self * other
+        if isinstance(other, PauliString):
+            return PauliStringSum([(coefficient, other * word) for coefficient, word in self.terms])
+        return NotImplemented
+
+    def __contains__(self, item: str | PauliString) -> bool:
+        word, _ = self._canonical_word_and_phase(item)
+        return word in self._terms
+
+    def __getitem__(self, item: int) -> tuple[float, PauliString]:
+        coefficient, word = self.terms[item]
+        return coefficient, word
+
+    def __iter__(self):
+        return iter(self.terms)
+
+    def __len__(self):
+        return len(self._terms)
+
+    def __eq__(self, other: PauliStringSum) -> bool:
+        if isinstance(other, PauliStringSum):
+            return self._terms == other._terms
+        return False
+
+    def __repr__(self):
+        return f"PauliStringSum({self.to_list()})"
+
+    def _add_term(self, coefficient: numbers.Real, pauli_string: str | PauliString) -> None:
+        if not isinstance(coefficient, numbers.Real):
+            raise TypeError("PauliStringSum coefficients must be real numbers")
+        word, phase = self._canonical_word_and_phase(pauli_string)
+        updated = self._terms.get(word, 0) + coefficient * phase
+        if updated == 0:
+            self._terms.pop(word, None)
+        else:
+            self._terms[word] = updated
+
+    def _sorted_terms(self) -> tuple[tuple[str, float], ...]:
+        return tuple(sorted(self._terms.items()))
+
+    @staticmethod
+    def _canonical_word_and_phase(pauli_string: str | PauliString) -> tuple[str, int]:
+        signed_word = repr(PauliString(pauli_string))
+        phase = -1 if signed_word[0] == "-" else 1
+        return signed_word[1:], phase
+
+    @staticmethod
+    def _observable_to_term(observable: Observable) -> tuple[float, str]:
+        coefficient = observable.coefficient
+        if isinstance(observable, TensorProduct):
+            return coefficient, "".join(
+                PauliStringSum._factor_to_word(factor) for factor in observable.factors
+            )
+        return coefficient, PauliStringSum._factor_to_word(observable)
+
+    @staticmethod
+    def _factor_to_word(observable: Observable) -> str:
+        name = observable._unscaled().ascii_symbols[0]
+        if name not in _PAULI_INDICES:
+            raise ValueError(f"Observable {observable} is not a Pauli observable")
+        return name
+
+    @staticmethod
+    def _strings_commute(left: PauliString, right: PauliString) -> bool:
+        if left.qubit_count != right.qubit_count:
+            raise ValueError("Pauli strings must have the same length")
+        anti_commuting_positions = sum(
+            left[i] != 0 and right[i] != 0 and left[i] != right[i] for i in range(left.qubit_count)
+        )
+        return anti_commuting_positions % 2 == 0

--- a/test/unit_tests/braket/quantum_information/test_pauli_string_sum.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string_sum.py
@@ -1,0 +1,184 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# ruff: noqa: ANN201, PLC2801, S101
+
+import pytest
+
+from braket.circuits.observables import H, Sum, X
+from braket.quantum_information import PauliString, PauliStringSum
+
+
+def test_canonicalizes_duplicate_and_signed_terms():
+    pauli_sum = PauliStringSum.from_list([
+        (0.25, "XX"),
+        (0.75, "+XX"),
+        (2, "-YY"),
+        (-2, "YY"),
+        (0, "ZZ"),
+    ])
+
+    assert pauli_sum.to_list() == [(1.0, "XX"), (-4, "YY")]
+    assert PauliString("XX") in pauli_sum
+    assert PauliString("-YY") in pauli_sum
+    assert "ZZ" not in pauli_sum
+
+
+def test_round_trip_through_weighted_tuple_list_preserves_algebraic_meaning():
+    original = PauliStringSum.from_list([(1, "ZX"), (-0.5, "IZ"), (0.5, "-IZ")])
+
+    assert PauliStringSum.from_list(original.to_list()) == original
+    assert original.to_list() == [(-1.0, "IZ"), (1, "ZX")]
+
+
+def test_addition_subtraction_and_scalar_multiplication_are_canonical():
+    pauli_sum = PauliString("XX") + PauliString("YY") - PauliString("-YY")
+
+    assert pauli_sum == PauliStringSum.from_list([(1, "XX"), (2, "YY")])
+    assert (0.5 * pauli_sum).to_list() == [(0.5, "XX"), (1.0, "YY")]
+    assert (pauli_sum * 0).to_list() == []
+
+
+def test_pauli_string_multiplication_distributes_over_sum():
+    pauli_sum = PauliStringSum.from_list([(2, "XI"), (3, "IX")])
+
+    assert (pauli_sum * PauliString("XX")).to_list() == [(2, "IX"), (3, "XI")]
+    assert (PauliString("XX") * pauli_sum).to_list() == [(2, "IX"), (3, "XI")]
+
+
+def test_sum_multiplication_distributes_and_merges_terms():
+    left = PauliStringSum.from_list([(1, "XI"), (1, "IX")])
+    right = PauliStringSum.from_list([(1, "XX")])
+
+    assert (left * right).to_list() == [(1, "IX"), (1, "XI")]
+
+
+def test_conversion_to_and_from_observable_sum_preserves_terms():
+    pauli_sum = PauliStringSum.from_list([(2, "IX"), (-3, "ZY")])
+    observable_sum = pauli_sum.to_sum()
+
+    assert isinstance(observable_sum, Sum)
+    assert PauliStringSum.from_sum(observable_sum) == pauli_sum
+
+
+def test_from_observable_sum_with_manual_weighted_terms():
+    observable_sum = Sum([2 * (X() @ X()), -3 * (X() @ X()), 0.5 * X()])
+
+    assert PauliStringSum.from_sum(observable_sum).to_list() == [(0.5, "X"), (-1, "XX")]
+
+
+def test_empty_sum_has_no_observable_sum_representation():
+    with pytest.raises(ValueError, match="Cannot convert an empty PauliStringSum"):
+        PauliStringSum.from_list([(1, "XX"), (-1, "XX")]).to_sum()
+
+
+def test_from_sum_rejects_non_pauli_observables():
+    with pytest.raises(ValueError, match="is not a Pauli observable"):
+        PauliStringSum.from_sum(Sum([X(), H()]))
+
+
+def test_commutation_checks():
+    commuting = PauliStringSum.from_list([(1, "XX"), (2, "YY"), (3, "ZZ")])
+    non_commuting = PauliStringSum.from_list([(1, "XI"), (1, "ZI")])
+
+    assert commuting.is_self_commuting()
+    assert commuting.commutes_with(PauliString("ZZ"))
+    assert not non_commuting.is_self_commuting()
+    assert not non_commuting.commutes_with(PauliString("XI"))
+
+
+def test_length_mismatch_commutation_fails_explicitly():
+    with pytest.raises(ValueError, match="same length"):
+        PauliStringSum.from_list([(1, "XX")]).commutes_with(PauliString("X"))
+
+
+def test_invalid_coefficient_fails_explicitly():
+    with pytest.raises(TypeError, match="coefficients must be real numbers"):
+        PauliStringSum.from_list([("bad", "XX")])
+    with pytest.raises(TypeError, match="coefficients must be real numbers"):
+        PauliStringSum.from_list([(1j, "XX")])
+
+
+def test_indexing_and_iteration_are_deterministic():
+    pauli_sum = PauliStringSum.from_list([(2, "ZZ"), (1, "XX")])
+
+    assert pauli_sum[0] == (1, PauliString("XX"))
+    assert list(pauli_sum) == [(1, PauliString("XX")), (2, PauliString("ZZ"))]
+
+
+def test_constructor_variants_are_canonical():
+    empty = PauliStringSum(None)
+    empty_from_list = PauliStringSum.from_list([])
+    single = PauliStringSum(PauliString("-XX"))
+    copied = PauliStringSum(single)
+
+    assert empty.to_list() == []
+    assert empty_from_list.to_list() == []
+    assert single.to_list() == [(-1, "XX")]
+    assert copied == single
+
+
+def test_pauli_string_dunder_methods_with_sums_and_scalars():
+    pauli_string = PauliString("XX")
+    pauli_sum = PauliStringSum.from_list([(2, "YY")])
+
+    assert (pauli_string * 3).to_list() == [(3, "XX")]
+    assert (3 * pauli_string).to_list() == [(3, "XX")]
+    assert (pauli_string - PauliString("YY")).to_list() == [(1, "XX"), (-1, "YY")]
+    assert (pauli_string + pauli_sum).to_list() == [(1, "XX"), (2, "YY")]
+    assert (pauli_string - pauli_sum).to_list() == [(1, "XX"), (-2, "YY")]
+    assert pauli_string.__mul__("bad") is NotImplemented
+    assert pauli_string.__rmul__("bad") is NotImplemented
+    assert pauli_string.__add__("bad") is NotImplemented
+    assert pauli_string.__sub__("bad") is NotImplemented
+
+
+def test_pauli_string_sum_dunder_fallbacks():
+    pauli_sum = PauliStringSum.from_list([(1, "XX")])
+
+    assert pauli_sum.__add__("bad") is NotImplemented
+    assert pauli_sum.__radd__("bad") is NotImplemented
+    assert PauliStringSum.__radd__(pauli_sum, PauliString("YY")).to_list() == [
+        (1, "XX"),
+        (1, "YY"),
+    ]
+    assert pauli_sum.__sub__("bad") is NotImplemented
+    assert PauliStringSum.__rsub__(pauli_sum, PauliString("YY")).to_list() == [
+        (-1, "XX"),
+        (1, "YY"),
+    ]
+    assert pauli_sum.__mul__("bad") is NotImplemented
+    assert pauli_sum.__rmul__("bad") is NotImplemented
+    assert pauli_sum.__mul__(1j) is NotImplemented
+    assert pauli_sum.__rmul__(1j) is NotImplemented
+    assert pauli_sum != "bad"
+    assert repr(pauli_sum) == "PauliStringSum([(1, 'XX')])"
+    with pytest.raises(TypeError):
+        1 - pauli_sum
+
+
+def test_sum_to_sum_commutation_and_invalid_from_sum_input():
+    left = PauliStringSum.from_list([(1, "XX"), (1, "YY")])
+    right = PauliStringSum.from_list([(1, "ZZ")])
+
+    assert left.commutes_with(right)
+    assert not left.commutes_with(PauliStringSum.from_list([(1, "XI")]))
+    with pytest.raises(TypeError, match=r"Observable\.Sum"):
+        PauliStringSum.from_sum(X())
+    with pytest.raises(TypeError, match="Can only check commutation"):
+        left.commutes_with("bad")
+
+
+def test_multiplication_length_mismatch_fails_explicitly():
+    with pytest.raises(ValueError, match="length"):
+        PauliStringSum.from_list([(1, "XX")]) * PauliString("X")


### PR DESCRIPTION
*Issue #, if available:*

Closes #1256

*Description of changes:*

This PR adds a canonical `PauliStringSum` container for weighted `PauliString` expressions.

The implementation focuses on predictable algebraic behavior and representation fidelity across conversions:
- duplicate Pauli strings are merged deterministically;
- zero-coefficient terms are removed from the canonical representation;
- term ordering is stable;
- coefficients are restricted to real numbers;
- weighted tuple round-trips preserve algebraic meaning;
- conversions to/from `Observable.Sum` avoid silent semantic changes;
- unsupported operations fail explicitly.

The goal is to make weighted `PauliString` sums predictable across algebraic operations and representation boundaries.

*Testing done:*

- `ruff check src/braket/quantum_information/pauli_string.py src/braket/quantum_information/__init__.py test/unit_tests/braket/quantum_information/test_pauli_string_sum.py`
- `ruff format --check src/braket/quantum_information/pauli_string.py src/braket/quantum_information/__init__.py test/unit_tests/braket/quantum_information/test_pauli_string_sum.py`
- targeted pytest: `68 passed, 31 xfailed`
- coverage for `pauli_string.py`: `100%`
- `git diff --check`

AI assistance disclosure: I used AI assistance for design review and wording, then implemented, reviewed, and validated the changes locally.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
