### PR TITLE
feat: add circuit instruction density summary

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -172,6 +172,41 @@ class Circuit:
         """Iterable[Instruction]: Get an `iterable` of instructions in the circuit."""
         return list(self._moments.values())
 
+    def instruction_density(self) -> dict[str, Any]:
+        """Returns a deterministic instruction count and density summary for the circuit.
+
+        The returned densities are normalized by the total number of instructions. Multi-qubit
+        instructions contribute once to each qubit they touch, including control qubits.
+
+        Returns:
+            dict[str, Any]: Summary containing total instruction count, counts by operator,
+            operator densities, counts per qubit, and per-qubit densities.
+        """
+        instructions = self.instructions
+        total = len(instructions)
+        by_operator = Counter(instruction.operator.name.lower() for instruction in instructions)
+        per_qubit: Counter[int] = Counter()
+
+        for instruction in instructions:
+            touched_qubits = instruction.target.union(instruction.control or QubitSet())
+            per_qubit.update(int(qubit) for qubit in touched_qubits)
+
+        return {
+            "total": total,
+            "by_operator": dict(sorted(by_operator.items())),
+            "operator_density": {
+                operator: count / total for operator, count in sorted(by_operator.items())
+            }
+            if total
+            else {},
+            "per_qubit": dict(sorted(per_qubit.items())),
+            "per_qubit_density": {
+                qubit: count / total for qubit, count in sorted(per_qubit.items())
+            }
+            if total
+            else {},
+        }
+
     @property
     def result_types(self) -> list[ResultType]:
         """list[ResultType]: Get a list of requested result types in the circuit."""

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -183,6 +183,45 @@ def gate_calibrations(pulse_sequence, pulse_sequence_2):
     })
 
 
+def test_instruction_density_empty_circuit():
+    assert Circuit().instruction_density() == {
+        "total": 0,
+        "by_operator": {},
+        "operator_density": {},
+        "per_qubit": {},
+        "per_qubit_density": {},
+    }
+
+
+def test_instruction_density_counts_operators_and_touched_qubits():
+    circuit = (
+        Circuit()
+        .add_instruction(Instruction(gates.H(), 0))
+        .add_instruction(Instruction(gates.CNot(), [0, 1]))
+        .add_instruction(Instruction(gates.Rz(0.125), 1))
+    )
+
+    summary = circuit.instruction_density()
+
+    assert summary["total"] == 3
+    assert summary["by_operator"] == {"cnot": 1, "h": 1, "rz": 1}
+    assert summary["operator_density"] == {"cnot": 1 / 3, "h": 1 / 3, "rz": 1 / 3}
+    assert summary["per_qubit"] == {0: 2, 1: 2}
+    assert summary["per_qubit_density"] == {0: 2 / 3, 1: 2 / 3}
+
+
+def test_instruction_density_includes_control_qubits():
+    circuit = Circuit().add_instruction(Instruction(gates.H(), 2, control=[0, 1]))
+
+    summary = circuit.instruction_density()
+
+    assert summary["total"] == 1
+    assert summary["by_operator"] == {"h": 1}
+    assert summary["operator_density"] == {"h": 1.0}
+    assert summary["per_qubit"] == {0: 1, 1: 1, 2: 1}
+    assert summary["per_qubit_density"] == {0: 1.0, 1: 1.0, 2: 1.0}
+
+
 def test_repr_instructions(h):
     expected = f"Circuit('instructions': {h.instructions})"
     assert repr(h) == expected


### PR DESCRIPTION
*Issue #, if available:*

Addresses part of #1235

*Description of changes:*

This PR adds `Circuit.instruction_density()` as a deterministic instruction density summary for circuits.

It complements raw instruction counting by reporting both counts and normalized densities:

- total instruction count
- counts by operator name
- operator density normalized by total instructions
- per-qubit instruction counts
- per-qubit density normalized by total instructions

Multi-qubit instructions contribute once to each qubit they touch, including control qubits. The output is deterministic, with sorted operator and qubit summaries, making it useful for benchmarking, sanity checks, and comparing generated or transformed circuits.

This implements the operator density stretch goal from #1235 without duplicating the raw instruction count API.

*Testing done:*

- `ruff format --check src/braket/circuits/circuit.py test/unit_tests/braket/circuits/test_circuit.py`
- `ruff check src/braket/circuits/circuit.py`
- `pytest -o addopts='' test/unit_tests/braket/circuits/test_circuit.py -q`
  - `338 passed, 2 xfailed`
- `git diff --check`

AI assistance disclosure: I used AI assistance for design review and wording, then implemented, reviewed, and validated the changes locally.
