### PR TITLE
feature: add Circuit instruction counting

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -172,6 +172,30 @@ class Circuit:
         """Iterable[Instruction]: Get an `iterable` of instructions in the circuit."""
         return list(self._moments.values())
 
+    def count(self, instruction_name: str | None = None) -> int:
+        """Count instructions in the circuit.
+
+        Args:
+            instruction_name (str | None): The instruction name to count. Matching is
+                case-insensitive. If `None`, returns the total number of instructions.
+                Default = `None`.
+
+        Returns:
+            int: The number of matching instructions.
+
+        Examples:
+            >>> circ = Circuit().h(0).cnot(0, 1).cnot(1, 2)
+            >>> circ.count()
+            3
+            >>> circ.count("cnot")
+            2
+        """
+        if instruction_name is None:
+            return len(self.instructions)
+        return Counter(instr.operator.name.lower() for instr in self.instructions)[
+            instruction_name.lower()
+        ]
+
     @property
     def result_types(self) -> list[ResultType]:
         """list[ResultType]: Get a list of requested result types in the circuit."""

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -202,6 +202,29 @@ def test_str(h):
     assert str(h) == expected
 
 
+def test_count_empty_circuit():
+    circ = Circuit()
+    assert circ.count() == 0
+    assert circ.count("h") == 0
+
+
+def test_count_instructions_by_name():
+    circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).rx(0, 0.5)
+    assert circ.count() == 4
+    assert circ.count("cnot") == 2
+    assert circ.count("CNOT") == 2
+    assert circ.count("h") == 1
+    assert circ.count("rx") == 1
+    assert circ.count("x") == 0
+
+
+def test_count_noise_and_measure_instructions():
+    circ = Circuit().x(0).bit_flip(0, probability=0.1).measure(0)
+    assert circ.count() == 3
+    assert circ.count("bitflip") == 1
+    assert circ.count("measure") == 1
+
+
 def test_equality():
     circ_1 = Circuit().h(0).probability([0, 1])
     circ_2 = Circuit().h(0).probability([0, 1])


### PR DESCRIPTION
*Issue #, if available:* Fixes #1235

*Description of changes:*
Adds `Circuit.count(instruction_name: str | None = None)` so callers can count all instructions in a circuit or count instructions matching an operator name case-insensitively.

*Testing done:*
- `.venv/bin/python -m pytest test/unit_tests/braket/circuits/test_circuit.py -k 'count'` (10 passed)
- `.venv/bin/python -m pytest test/unit_tests/braket/circuits/test_circuit.py` (338 passed, 2 xfailed)
- `.venv/bin/python -m ruff format --check src/braket/circuits/circuit.py test/unit_tests/braket/circuits/test_circuit.py`
- `.venv/bin/python -m ruff check src/braket/circuits/circuit.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General
- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.