### PR TITLE
feat: add Circuit instruction counting

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -172,6 +172,30 @@ class Circuit:
         """Iterable[Instruction]: Get an `iterable` of instructions in the circuit."""
         return list(self._moments.values())
 
+    def count(self, instruction_name: str | None = None) -> Counter[str] | int:
+        """Count instructions in the circuit by operator name.
+
+        Args:
+            instruction_name (str | None): Optional operator name to count. Matching is
+                case-insensitive. If omitted, return counts for all instruction names.
+
+        Returns:
+            Counter[str] | int: A counter keyed by lowercase operator name when
+            `instruction_name` is omitted, or the count for `instruction_name` otherwise.
+
+        Examples:
+            >>> Circuit().h(0).cnot(0, 1).count("cnot")
+            1
+            >>> Circuit().h(0).cnot(0, 1).count()
+            Counter({'h': 1, 'cnot': 1})
+        """
+        instruction_counts = Counter(
+            instruction.operator.name.lower() for instruction in self.instructions
+        )
+        if instruction_name is None:
+            return instruction_counts
+        return instruction_counts[instruction_name.lower()]
+
     @property
     def result_types(self) -> list[ResultType]:
         """list[ResultType]: Get a list of requested result types in the circuit."""

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -223,6 +223,16 @@ def test_call():
     assert new_circ == expected and not new_circ.parameters
 
 
+def test_count_instructions():
+    circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).rx(0, 0).probability([0, 1])
+
+    assert dict(circ.count()) == {"h": 1, "cnot": 2, "rx": 1}
+    assert circ.count("cnot") == 2
+    assert circ.count("CNOT") == 2
+    assert circ.count("x") == 0
+    assert dict(Circuit().count()) == {}
+
+
 def test_call_with_result_type(prob):
     alpha = FreeParameter("alpha")
     theta = FreeParameter("theta")


### PR DESCRIPTION
## Summary
- add `Circuit.count()` to count instructions by lowercase operator name
- support `Circuit.count("cnot")` for a single instruction type and `Circuit.count()` for all instruction counts
- add regression coverage for case-insensitive lookup, missing instructions, empty circuits, and ignoring result types

Closes #1235.

## Validation
- `.venv/bin/python -m pytest test/unit_tests/braket/circuits/test_circuit.py -q`
- `.venv/bin/python -m ruff check src/braket/circuits/circuit.py`
- `.venv/bin/python -m ruff format --check src/braket/circuits/circuit.py test/unit_tests/braket/circuits/test_circuit.py`
- `git diff --check`

Note: running `ruff check` on the full existing `test_circuit.py` with the latest local ruff surfaces many pre-existing findings unrelated to this PR, so I scoped lint to the changed source file and used format checking for both touched files.

## AI use
I used an AI coding assistant to inspect the existing circuit API, implement the small method and tests, and run validation. I reviewed the final diff before submission.