### PR TITLE
feat: Add interactive Plotly circuit diagram renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+interactive = [
+    "plotly>=5.0.0",
+]
 test = [
     "botocore",
     "jsonschema==3.2.0",
+    "plotly>=5.0.0",
     "pytest",
     "pytest-cov",
     # https://github.com/pytest-dev/pytest-rerunfailures/issues/302

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1656,8 +1656,45 @@ class Circuit:
             return calculate_unitary_big_endian(self.instructions, qubits)
         return np.zeros(0, dtype=complex)
 
-    def show(self, circuit_diagram_class: type = MatplotlibCircuitDiagram) -> None:
-        circuit_diagram_class.build_diagram(self)
+    def show(self, mode: str = "static", circuit_diagram_class: type | None = None) -> object:
+        """Visualize the circuit as a graphical diagram.
+
+        Args:
+            mode: Rendering mode. ``"static"`` (default) uses matplotlib;
+                ``"interactive"`` uses Plotly with hover tooltips and
+                expandable/collapsible verbatim blocks.
+            circuit_diagram_class: Optional explicit diagram class override.
+                When provided, *mode* is ignored and this class is used
+                directly.
+
+        Returns:
+            A ``matplotlib.figure.Figure`` (static mode) or
+            ``plotly.graph_objects.Figure`` (interactive mode).
+
+        Raises:
+            ImportError: If ``mode="interactive"`` and plotly is not installed.
+            ValueError: If *mode* is not ``"static"`` or ``"interactive"``.
+
+        Examples:
+            >>> circuit.show()                    # Matplotlib (default)
+            >>> circuit.show("interactive")       # Plotly interactive
+        """
+        if circuit_diagram_class is not None:
+            return circuit_diagram_class.build_diagram(self)
+        if mode == "interactive":
+            try:
+                from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (
+                    PlotlyCircuitDiagram,
+                )
+            except ImportError as e:
+                raise ImportError(
+                    "Plotly is required for interactive visualization.  "
+                    "Install it with: pip install amazon-braket-sdk[interactive]"
+                ) from e
+            return PlotlyCircuitDiagram.build_diagram(self)
+        if mode == "static":
+            return MatplotlibCircuitDiagram.build_diagram(self)
+        raise ValueError(f"Unknown mode {mode!r}; expected 'static' or 'interactive'.")
 
     @property
     def qubits_frozen(self) -> bool:

--- a/src/braket/circuits/graphical_diagram_builders/__init__.py
+++ b/src/braket/circuits/graphical_diagram_builders/__init__.py
@@ -16,3 +16,12 @@ from braket.circuits.graphical_diagram_builders.matplotlib_circuit_diagram impor
 )
 
 __all__ = ["MatplotlibCircuitDiagram"]
+
+try:
+    from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (
+        PlotlyCircuitDiagram,
+    )
+
+    __all__.append("PlotlyCircuitDiagram")
+except ImportError:
+    pass

--- a/src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py
+++ b/src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py
@@ -1,0 +1,908 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Interactive circuit diagram renderer powered by Plotly.
+
+This module provides :class:`PlotlyCircuitDiagram`, a sibling to
+:class:`MatplotlibCircuitDiagram` that renders quantum circuits as
+interactive Plotly figures.  Key features include:
+
+* **Hover tooltips** – hovering over a gate displays the gate name,
+  target qubit(s), parameters (if any), and a placeholder for
+  device-specific metadata such as fidelity or error rates.
+* **Expandable/collapsible verbatim blocks** – verbatim boxes are
+  rendered as a single collapsed block by default.  A toggle button
+  lets the user expand them to reveal inner gates, or collapse them
+  back.  The mechanism is written with extensibility in mind so it
+  can later be reused for ``box``, ``scope``, and nested-subroutine
+  structures once the BDK exposes them.
+* **Zoom & pan** – provided out-of-the-box by Plotly's toolbar.
+* **Jupyter rendering** – the returned ``plotly.graph_objects.Figure``
+  renders inline in Jupyter notebooks without extra configuration.
+
+Usage
+-----
+::
+
+    from braket.circuits import Circuit
+
+    circuit = Circuit().h(0).cnot(0, 1)
+
+    # Via the Circuit convenience method:
+    fig = circuit.show("interactive")   # returns a plotly Figure
+    fig.show()                          # opens in browser / renders in notebook
+
+    # Directly:
+    from braket.circuits.graphical_diagram_builders import PlotlyCircuitDiagram
+    fig = PlotlyCircuitDiagram.build_diagram(circuit)
+
+Extensibility – sub-structure expand/collapse
+---------------------------------------------
+The toggle implementation identifies *collapsible regions* by scanning
+the instruction stream for matched compiler-directive pairs (currently
+``StartVerbatimBox`` / ``EndVerbatimBox``).  To support a new pair
+(e.g. a future ``StartScope`` / ``EndScope``), add an entry to
+``_COLLAPSIBLE_PAIRS`` and the rest of the pipeline handles it
+automatically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import braket.circuits.circuit as cir
+from braket.circuits.compiler_directive import CompilerDirective
+from braket.circuits.gate import Gate
+from braket.circuits.graphical_diagram_builders.graphical_circuit_diagram import (
+    GraphicalCircuitDiagram,
+)
+from braket.circuits.graphical_diagram_builders.graphical_diagram_utils import (
+    BarrierMarker,
+    CircuitLayout,
+    Connection,
+    ControlDot,
+    GateBox,
+    SwapMarker,
+)
+from braket.circuits.instruction import Instruction
+from braket.circuits.moments import MomentType
+
+# ---------------------------------------------------------------------------
+# Collapsible region registry – extend this to support new sub-structures.
+# Each entry maps a *start* compiler-directive name to the corresponding
+# *end* name and the label shown in the collapsed view.
+# ---------------------------------------------------------------------------
+_COLLAPSIBLE_PAIRS: dict[str, dict[str, str]] = {
+    "StartVerbatimBox": {"end": "EndVerbatimBox", "label": "Verbatim"},
+    # Future example:
+    # "StartScope": {"end": "EndScope", "label": "Scope"},
+}
+
+# Build a reverse look-up set for quick membership tests.
+_COLLAPSIBLE_END_NAMES: set[str] = {v["end"] for v in _COLLAPSIBLE_PAIRS.values()}
+
+
+@dataclass
+class _CollapsibleRegion:
+    """Describes one collapsible block in the circuit (e.g. a verbatim box).
+
+    Attributes:
+        label: Human-readable label shown in the collapsed view.
+        start_col: Column index of the start directive.
+        end_col: Column index of the end directive.
+        inner_cols: Column indices of the gates enclosed by the block
+                    (excluding the start/end directive columns).
+        row_min: Minimum qubit row spanned by the block.
+        row_max: Maximum qubit row spanned by the block.
+    """
+
+    label: str
+    start_col: int
+    end_col: int
+    inner_cols: list[int] = field(default_factory=list)
+    row_min: int = 0
+    row_max: int = 0
+
+
+def _ensure_plotly():
+    """Import plotly or raise a helpful error."""
+    try:
+        import plotly.graph_objects as go  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "Plotly is required for interactive circuit visualization.  "
+            "Install it with:\n\n"
+            "    pip install amazon-braket-sdk[interactive]\n"
+        ) from exc
+
+
+class PlotlyCircuitDiagram(GraphicalCircuitDiagram):
+    """Renders circuit diagrams as interactive Plotly figures.
+
+    The visual layout mirrors the Matplotlib renderer but adds:
+
+    * Hover tooltips on every gate element.
+    * Toggle buttons for verbatim-box expand/collapse.
+    * Built-in zoom/pan via the Plotly toolbar.
+
+    Examples:
+        >>> from braket.circuits import Circuit
+        >>> circ = Circuit().h(0).cnot(0, 1).rx(0, 0.5)
+        >>> fig = PlotlyCircuitDiagram.build_diagram(circ)
+        >>> fig.show()  # renders in browser or Jupyter
+    """
+
+    # ── Layout constants (match Matplotlib renderer) ──────────────────
+    COL_WIDTH = 1.4
+    COL_GAP = 0.2
+    ROW_HEIGHT = 0.8
+    WIRE_EXTEND = 0.5
+
+    GATE_BOX_HEIGHT = 0.5
+    GATE_BOX_MIN_WIDTH = 0.6
+    GATE_BOX_PADDING = 0.3
+    GATE_FONT_SIZE = 12
+
+    # Colours
+    GATE_FILL_COLOR = "#D4E6F1"
+    GATE_EDGE_COLOR = "black"
+    GATE_TEXT_COLOR = "black"
+    WIRE_COLOR = "#333333"
+    WIRE_LW = 1.0
+    CONTROL_DOT_RADIUS = 0.08
+    CONTROL_DOT_COLOR = "black"
+    CONNECTION_LW = 1.5
+    CONNECTION_COLOR = "black"
+    BARRIER_COLOR = "#888888"
+    BARRIER_FILL_COLOR = "#DDDDDD"
+    BARRIER_WIDTH = 0.25
+    BARRIER_HEIGHT_FRAC = 0.6
+    SWAP_MARKER_SIZE = 10
+
+    # Verbatim collapsed block colours
+    VERBATIM_FILL = "rgba(255,235,205,0.7)"
+    VERBATIM_EDGE = "#CC8800"
+
+    # ── Public entry point ────────────────────────────────────────────
+
+    @staticmethod
+    def build_diagram(circuit: cir.Circuit) -> object:
+        """Build an interactive Plotly figure for *circuit*.
+
+        Args:
+            circuit: The circuit to visualise.
+
+        Returns:
+            A ``plotly.graph_objects.Figure``.
+
+        Raises:
+            ImportError: If plotly is not installed.
+
+        Examples:
+            >>> fig = PlotlyCircuitDiagram.build_diagram(Circuit().h(0))
+            >>> fig.show()
+        """
+        _ensure_plotly()
+        import plotly.graph_objects as go
+
+        if not circuit.instructions:
+            fig = go.Figure()
+            fig.add_annotation(
+                x=0.5, y=0.5, text="(empty circuit)",
+                showarrow=False, font=dict(size=14),
+                xref="paper", yref="paper",
+            )
+            fig.update_layout(
+                xaxis=dict(visible=False), yaxis=dict(visible=False),
+                width=300, height=150,
+                margin=dict(l=10, r=10, t=10, b=10),
+            )
+            return fig
+
+        if all(m.moment_type == MomentType.GLOBAL_PHASE for m in circuit._moments):
+            fig = go.Figure()
+            fig.add_annotation(
+                x=0.5, y=0.5,
+                text=f"Global phase: {circuit.global_phase}",
+                showarrow=False, font=dict(size=14),
+                xref="paper", yref="paper",
+            )
+            fig.update_layout(
+                xaxis=dict(visible=False), yaxis=dict(visible=False),
+                width=400, height=150,
+                margin=dict(l=10, r=10, t=10, b=10),
+            )
+            return fig
+
+        layout = PlotlyCircuitDiagram._compute_layout(circuit)
+
+        # Detect collapsible regions in the layout.
+        regions = PlotlyCircuitDiagram._find_collapsible_regions(layout)
+
+        return PlotlyCircuitDiagram._render_layout(layout, regions=regions)
+
+    # ── Rendering ─────────────────────────────────────────────────────
+
+    @classmethod
+    def _render_layout(cls, layout: CircuitLayout, *, regions: list[_CollapsibleRegion] | None = None) -> object:  # noqa: E501
+        """Convert a ``CircuitLayout`` into a Plotly figure.
+
+        Args:
+            layout: Pre-computed circuit layout.
+            regions: Collapsible regions (verbatim boxes etc.).
+
+        Returns:
+            A ``plotly.graph_objects.Figure``.
+        """
+        _ensure_plotly()
+        import plotly.graph_objects as go
+
+        if regions is None:
+            regions = []
+
+        n_rows = max(layout.num_qubits, 1)
+        col_x, col_w = cls._compute_column_x(layout)
+        total_width = sum(col_w)
+
+        left_wire = col_x[0] - col_w[0] / 2 - cls.WIRE_EXTEND
+        right_wire = total_width + cls.WIRE_EXTEND
+
+        fig = go.Figure()
+
+        # ── qubit wires ──────────────────────────────────────────────
+        cls._draw_qubit_wires(fig, layout, left_wire, right_wire)
+
+        # ── determine which columns are inside collapsible regions ───
+        inner_col_set: set[int] = set()
+        start_end_col_set: set[int] = set()
+        for region in regions:
+            inner_col_set.update(region.inner_cols)
+            start_end_col_set.add(region.start_col)
+            start_end_col_set.add(region.end_col)
+
+        # ── elements (expanded view, always present) ─────────────────
+        expanded_shapes: list[dict] = []
+        expanded_annotations: list[dict] = []
+        expanded_traces: list[go.Scatter] = []
+
+        # ── elements that are NOT inside any collapsible region ──────
+        static_shapes: list[dict] = []
+        static_annotations: list[dict] = []
+
+        for elem in layout.elements:
+            col = elem.col
+            in_region = col in inner_col_set or col in start_end_col_set
+
+            shapes_out, annots_out, traces_out = cls._render_element(
+                elem, col_x, layout
+            )
+
+            if in_region:
+                for s in shapes_out:
+                    s["visible"] = True
+                expanded_shapes.extend(shapes_out)
+                for a in annots_out:
+                    a["visible"] = True
+                expanded_annotations.extend(annots_out)
+                expanded_traces.extend(traces_out)
+            else:
+                static_shapes.extend(shapes_out)
+                static_annotations.extend(annots_out)
+                for t in traces_out:
+                    fig.add_trace(t)
+
+        # ── collapsed verbatim blocks ────────────────────────────────
+        collapsed_shapes: list[dict] = []
+        collapsed_annotations: list[dict] = []
+
+        for region in regions:
+            s, a = cls._render_collapsed_region(region, col_x)
+            for shape in s:
+                shape["visible"] = False
+            collapsed_shapes.extend(s)
+            for annot in a:
+                annot["visible"] = False
+            collapsed_annotations.extend(a)
+
+        # ── add expanded traces (hidden by default if regions exist) ──
+        expanded_trace_start = len(fig.data)
+        for t in expanded_traces:
+            t.visible = True if not regions else True
+            fig.add_trace(t)
+        expanded_trace_end = len(fig.data)
+
+        # ── moment labels ────────────────────────────────────────────
+        label_y_top = cls.ROW_HEIGHT * 0.8
+        label_y_bottom = -(n_rows - 1) * cls.ROW_HEIGHT - cls.ROW_HEIGHT * 0.8
+        moment_annots = cls._moment_label_annotations(layout, col_x, label_y_top, label_y_bottom)
+
+        # ── footer ───────────────────────────────────────────────────
+        footer_annots = cls._footer_annotations(layout, left_wire, label_y_bottom)
+
+        # ── assemble all shapes and annotations ──────────────────────
+        all_shapes = static_shapes + expanded_shapes + collapsed_shapes
+        all_annotations = (
+            static_annotations + expanded_annotations
+            + collapsed_annotations + moment_annots + footer_annots
+        )
+
+        # ── update-menus for toggling ────────────────────────────────
+        updatemenus = []
+        if regions:
+            # Build visibility toggling.
+            # expanded state: expanded shapes/annots visible, collapsed hidden
+            # collapsed state: collapsed shapes/annots visible, expanded hidden
+
+            def _make_vis(show_expanded: bool):
+                """Return shapes + annotations lists with correct visibility."""
+                shapes_copy = []
+                for s in all_shapes:
+                    sc = dict(s)
+                    if s in expanded_shapes:
+                        sc["visible"] = show_expanded
+                    elif s in collapsed_shapes:
+                        sc["visible"] = not show_expanded
+                    shapes_copy.append(sc)
+
+                annots_copy = []
+                for a in all_annotations:
+                    ac = dict(a)
+                    if a in expanded_annotations:
+                        ac["visible"] = show_expanded
+                    elif a in collapsed_annotations:
+                        ac["visible"] = not show_expanded
+                    annots_copy.append(ac)
+
+                # Trace visibility
+                trace_vis = list(fig.data)  # noqa: B023
+                vis_list = []
+                for i in range(len(trace_vis)):
+                    if expanded_trace_start <= i < expanded_trace_end:
+                        vis_list.append(show_expanded)
+                    else:
+                        vis_list.append(True)
+
+                return shapes_copy, annots_copy, vis_list
+
+            exp_shapes, exp_annots, exp_trace_vis = _make_vis(True)
+            col_shapes, col_annots, col_trace_vis = _make_vis(False)
+
+            updatemenus.append(
+                dict(
+                    type="buttons",
+                    direction="left",
+                    x=0.0,
+                    xanchor="left",
+                    y=1.15,
+                    yanchor="top",
+                    buttons=[
+                        dict(
+                            label="▶ Expand Verbatim",
+                            method="update",
+                            args=[
+                                {"visible": exp_trace_vis},
+                                {
+                                    "shapes": exp_shapes,
+                                    "annotations": exp_annots,
+                                },
+                            ],
+                        ),
+                        dict(
+                            label="▼ Collapse Verbatim",
+                            method="update",
+                            args=[
+                                {"visible": col_trace_vis},
+                                {
+                                    "shapes": col_shapes,
+                                    "annotations": col_annots,
+                                },
+                            ],
+                        ),
+                    ],
+                )
+            )
+
+        # ── final layout ─────────────────────────────────────────────
+        fig_width = max(500, (cls.WIRE_EXTEND * 2 + total_width + 1.5) * 90)
+        fig_height = max(250, (n_rows * cls.ROW_HEIGHT + 1.5) * 90)
+
+        y_bottom = label_y_bottom - 0.4
+        if footer_annots:
+            y_bottom -= len(footer_annots) * cls.ROW_HEIGHT * 0.5
+
+        fig.update_layout(
+            shapes=all_shapes,
+            annotations=all_annotations,
+            updatemenus=updatemenus if updatemenus else [],
+            xaxis=dict(
+                range=[left_wire - 1.5, right_wire + 0.5],
+                showgrid=False,
+                zeroline=False,
+                visible=False,
+            ),
+            yaxis=dict(
+                range=[y_bottom, label_y_top + 0.4],
+                showgrid=False,
+                zeroline=False,
+                visible=False,
+                scaleanchor="x",
+                scaleratio=1,
+            ),
+            width=fig_width,
+            height=fig_height,
+            plot_bgcolor="white",
+            paper_bgcolor="white",
+            margin=dict(l=10, r=10, t=50, b=10),
+            showlegend=False,
+            hovermode="closest",
+        )
+
+        return fig
+
+    # ── Per-element rendering helpers ─────────────────────────────────
+
+    @classmethod
+    def _render_element(cls, elem, col_x, layout):
+        """Render a single layout element into Plotly shapes/annotations/traces.
+
+        Returns:
+            Tuple of (shapes, annotations, traces).
+        """
+        import plotly.graph_objects as go
+
+        shapes: list[dict] = []
+        annotations: list[dict] = []
+        traces: list[go.Scatter] = []
+
+        if isinstance(elem, GateBox):
+            s, a, t = cls._render_gate_box(elem, col_x[elem.col], layout)
+            shapes.extend(s)
+            annotations.extend(a)
+            traces.extend(t)
+        elif isinstance(elem, ControlDot):
+            s, t = cls._render_control_dot(elem, col_x[elem.col], layout)
+            shapes.extend(s)
+            traces.extend(t)
+        elif isinstance(elem, SwapMarker):
+            t = cls._render_swap_marker(elem, col_x[elem.col], layout)
+            traces.extend(t)
+        elif isinstance(elem, Connection):
+            t = cls._render_connection(elem, col_x[elem.col])
+            traces.extend(t)
+        elif isinstance(elem, BarrierMarker):
+            s = cls._render_barrier(elem, col_x[elem.col])
+            shapes.extend(s)
+
+        return shapes, annotations, traces
+
+    @classmethod
+    def _render_gate_box(cls, elem: GateBox, x: float, layout: CircuitLayout):
+        """Render a gate as a filled rectangle with label and hover trace."""
+        import plotly.graph_objects as go
+
+        y = -elem.row * cls.ROW_HEIGHT
+        box_w = cls._gate_box_width(elem.label)
+        half_w = box_w / 2
+        half_h = cls.GATE_BOX_HEIGHT / 2
+
+        shape = dict(
+            type="rect",
+            x0=x - half_w, y0=y - half_h,
+            x1=x + half_w, y1=y + half_h,
+            fillcolor=cls.GATE_FILL_COLOR,
+            line=dict(color=cls.GATE_EDGE_COLOR, width=1.2),
+            layer="above",
+        )
+
+        annotation = dict(
+            x=x, y=y,
+            text=elem.label,
+            showarrow=False,
+            font=dict(size=cls.GATE_FONT_SIZE, family="monospace", color=cls.GATE_TEXT_COLOR),
+        )
+
+        # Hover tooltip
+        qubit_label = layout.qubit_labels[elem.row] if elem.row < len(layout.qubit_labels) else f"q{elem.row}"
+        hover_text = cls._build_hover_text(
+            gate_name=elem.label,
+            qubit_label=qubit_label,
+            row=elem.row,
+            col=elem.col,
+        )
+
+        hover_trace = go.Scatter(
+            x=[x], y=[y],
+            mode="markers",
+            marker=dict(size=max(box_w, cls.GATE_BOX_HEIGHT) * 30, opacity=0),
+            hoverinfo="text",
+            hovertext=hover_text,
+            showlegend=False,
+        )
+
+        return [shape], [annotation], [hover_trace]
+
+    @classmethod
+    def _render_control_dot(cls, elem: ControlDot, x: float, layout: CircuitLayout):
+        """Render a control/anti-control dot with hover."""
+        import plotly.graph_objects as go
+
+        y = -elem.row * cls.ROW_HEIGHT
+        r = cls.CONTROL_DOT_RADIUS
+
+        if elem.filled:
+            shape = dict(
+                type="circle",
+                x0=x - r, y0=y - r,
+                x1=x + r, y1=y + r,
+                fillcolor=cls.CONTROL_DOT_COLOR,
+                line=dict(color=cls.CONTROL_DOT_COLOR, width=1),
+                layer="above",
+            )
+        else:
+            shape = dict(
+                type="circle",
+                x0=x - r, y0=y - r,
+                x1=x + r, y1=y + r,
+                fillcolor="white",
+                line=dict(color=cls.CONTROL_DOT_COLOR, width=1.5),
+                layer="above",
+            )
+
+        qubit_label = layout.qubit_labels[elem.row] if elem.row < len(layout.qubit_labels) else f"q{elem.row}"
+        control_type = "Control" if elem.filled else "Anti-control"
+        hover_text = (
+            f"<b>{control_type}</b><br>"
+            f"Qubit: {qubit_label}<br>"
+            f"<i>Device metadata: N/A</i>"
+        )
+
+        hover_trace = go.Scatter(
+            x=[x], y=[y],
+            mode="markers",
+            marker=dict(size=12, opacity=0),
+            hoverinfo="text",
+            hovertext=hover_text,
+            showlegend=False,
+        )
+
+        return [shape], [hover_trace]
+
+    @classmethod
+    def _render_swap_marker(cls, elem: SwapMarker, x: float, layout: CircuitLayout):
+        """Render a SWAP × marker with hover."""
+        import plotly.graph_objects as go
+
+        y = -elem.row * cls.ROW_HEIGHT
+        qubit_label = layout.qubit_labels[elem.row] if elem.row < len(layout.qubit_labels) else f"q{elem.row}"
+        hover_text = (
+            f"<b>SWAP</b><br>"
+            f"Qubit: {qubit_label}<br>"
+            f"<i>Device metadata: N/A</i>"
+        )
+
+        trace = go.Scatter(
+            x=[x], y=[y],
+            mode="markers",
+            marker=dict(
+                symbol="x",
+                size=cls.SWAP_MARKER_SIZE,
+                color=cls.CONNECTION_COLOR,
+                line=dict(width=2, color=cls.CONNECTION_COLOR),
+            ),
+            hoverinfo="text",
+            hovertext=hover_text,
+            showlegend=False,
+        )
+        return [trace]
+
+    @classmethod
+    def _render_connection(cls, elem: Connection, x: float):
+        """Render a vertical connection line between qubit rows."""
+        import plotly.graph_objects as go
+
+        y_start = -elem.row_start * cls.ROW_HEIGHT
+        y_end = -elem.row_end * cls.ROW_HEIGHT
+
+        trace = go.Scatter(
+            x=[x, x], y=[y_start, y_end],
+            mode="lines",
+            line=dict(color=cls.CONNECTION_COLOR, width=cls.CONNECTION_LW),
+            hoverinfo="skip",
+            showlegend=False,
+        )
+        return [trace]
+
+    @classmethod
+    def _render_barrier(cls, elem: BarrierMarker, x: float):
+        """Render a barrier marker as a hatched rectangle."""
+        y = -elem.row * cls.ROW_HEIGHT
+        half_h = cls.ROW_HEIGHT * cls.BARRIER_HEIGHT_FRAC / 2
+        half_w = cls.BARRIER_WIDTH / 2
+
+        shape = dict(
+            type="rect",
+            x0=x - half_w, y0=y - half_h,
+            x1=x + half_w, y1=y + half_h,
+            fillcolor=cls.BARRIER_FILL_COLOR,
+            line=dict(color=cls.BARRIER_COLOR, width=1, dash="dot"),
+            layer="above",
+        )
+        return [shape]
+
+    # ── Collapsed region rendering ────────────────────────────────────
+
+    @classmethod
+    def _render_collapsed_region(cls, region: _CollapsibleRegion, col_x: list[float]):
+        """Render a collapsed verbatim block as a single labelled rectangle."""
+        x_start = col_x[region.start_col]
+        x_end = col_x[region.end_col]
+
+        cx = (x_start + x_end) / 2
+        y_top = -region.row_min * cls.ROW_HEIGHT + cls.GATE_BOX_HEIGHT / 2 + 0.1
+        y_bot = -region.row_max * cls.ROW_HEIGHT - cls.GATE_BOX_HEIGHT / 2 - 0.1
+
+        shape = dict(
+            type="rect",
+            x0=x_start - cls.COL_WIDTH / 2,
+            y0=y_bot,
+            x1=x_end + cls.COL_WIDTH / 2,
+            y1=y_top,
+            fillcolor=cls.VERBATIM_FILL,
+            line=dict(color=cls.VERBATIM_EDGE, width=2, dash="dash"),
+            layer="above",
+        )
+
+        annotation = dict(
+            x=cx,
+            y=(y_top + y_bot) / 2,
+            text=f"<b>{region.label}</b>",
+            showarrow=False,
+            font=dict(size=14, family="monospace", color=cls.VERBATIM_EDGE),
+        )
+
+        return [shape], [annotation]
+
+    # ── Collapsible region detection ──────────────────────────────────
+
+    @classmethod
+    def _find_collapsible_regions(cls, layout: CircuitLayout) -> list[_CollapsibleRegion]:
+        """Scan layout elements for matched start/end directive pairs.
+
+        Returns a list of :class:`_CollapsibleRegion` objects describing
+        each block that can be collapsed.
+        """
+        # Map label text to the directive type.
+        start_labels = {}
+        for start_name, info in _COLLAPSIBLE_PAIRS.items():
+            # The ascii_symbols for StartVerbatimBox is "StartVerbatim"
+            start_labels["StartVerbatim"] = info
+        end_labels = {"EndVerbatim": "StartVerbatim"}
+
+        # Find start/end GateBox elements by label, uniqueing by column index
+        # to avoid duplicates for multi-qubit compiler directives.
+        start_by_col: dict[int, dict] = {}
+        end_by_col: dict[int, None] = {}
+
+        for elem in layout.elements:
+            if isinstance(elem, GateBox):
+                if elem.label in start_labels:
+                    if elem.col not in start_by_col:
+                        start_by_col[elem.col] = start_labels[elem.label]
+                elif elem.label in end_labels:
+                    if elem.col not in end_by_col:
+                        end_by_col[elem.col] = None
+
+        # Build sorted list of events
+        events: list[tuple[int, str, dict | None]] = []
+        for col, info in start_by_col.items():
+            events.append((col, "start", info))
+        for col in end_by_col:
+            events.append((col, "end", None))
+        events.sort(key=lambda x: x[0])
+
+        # Match pairs using a stack
+        regions: list[_CollapsibleRegion] = []
+        stack: list[tuple[int, dict]] = []
+
+        for col, event_type, info in events:
+            if event_type == "start":
+                stack.append((col, info))
+            elif event_type == "end":
+                if stack:
+                    start_col, start_info = stack.pop()
+                    # Determine inner columns
+                    inner_cols = [
+                        c for c in range(start_col + 1, col)
+                        if c < layout.num_moments
+                    ]
+
+                    # Determine row span
+                    all_rows = set()
+                    for e in layout.elements:
+                        if hasattr(e, "col") and hasattr(e, "row"):
+                            if start_col <= e.col <= col:
+                                all_rows.add(e.row)
+                        elif isinstance(e, Connection):
+                            if e.col >= start_col and e.col <= col:
+                                all_rows.update(range(e.row_start, e.row_end + 1))
+
+                    row_min = min(all_rows) if all_rows else 0
+                    row_max = max(all_rows) if all_rows else 0
+
+                    regions.append(_CollapsibleRegion(
+                        label=start_info["label"],
+                        start_col=start_col,
+                        end_col=col,
+                        inner_cols=inner_cols,
+                        row_min=row_min,
+                        row_max=row_max,
+                    ))
+
+        return regions
+
+    # ── Hover text builder ────────────────────────────────────────────
+
+    @classmethod
+    def _build_hover_text(
+        cls,
+        gate_name: str,
+        qubit_label: str,
+        row: int,
+        col: int,
+        metadata: dict | None = None,
+    ) -> str:
+        """Build HTML hover text for a gate element.
+
+        Args:
+            gate_name: Display name of the gate (e.g. "H", "Rx(0.5)").
+            qubit_label: Label of the qubit row (e.g. "q0").
+            row: Row index.
+            col: Column (moment) index.
+            metadata: Optional dict of device-specific metadata
+                      (e.g. fidelity, error_rate).  When ``None``, a
+                      placeholder is shown.
+
+        Returns:
+            An HTML string for Plotly's ``hovertext``.
+        """
+        # Extract parameters from the label if present
+        params_str = ""
+        if "(" in gate_name and gate_name.endswith(")"):
+            name_part = gate_name[:gate_name.index("(")]
+            params_part = gate_name[gate_name.index("(") + 1:-1]
+            params_str = f"Parameters: {params_part}<br>"
+            display_name = name_part
+        else:
+            display_name = gate_name
+
+        meta_lines = ""
+        if metadata:
+            for key, val in metadata.items():
+                meta_lines += f"{key}: {val}<br>"
+        else:
+            meta_lines = "<i>Device metadata: N/A</i>"
+
+        return (
+            f"<b>{display_name}</b><br>"
+            f"Qubit: {qubit_label}<br>"
+            f"{params_str}"
+            f"Moment: {col}<br>"
+            f"{meta_lines}"
+        )
+
+    # ── Wire & label helpers ──────────────────────────────────────────
+
+    @classmethod
+    def _draw_qubit_wires(cls, fig, layout: CircuitLayout, left_wire: float, right_wire: float):
+        """Draw horizontal qubit wires and labels."""
+        import plotly.graph_objects as go
+
+        for row_idx, label in enumerate(layout.qubit_labels):
+            y = -row_idx * cls.ROW_HEIGHT
+            fig.add_trace(go.Scatter(
+                x=[left_wire, right_wire],
+                y=[y, y],
+                mode="lines",
+                line=dict(color=cls.WIRE_COLOR, width=cls.WIRE_LW),
+                hoverinfo="skip",
+                showlegend=False,
+            ))
+            fig.add_annotation(
+                x=left_wire - 0.15,
+                y=y,
+                text=f"{label} :",
+                showarrow=False,
+                font=dict(size=11, family="monospace"),
+                xanchor="right",
+            )
+
+    @classmethod
+    def _moment_label_annotations(
+        cls, layout: CircuitLayout, col_x: list[float],
+        label_y_top: float, label_y_bottom: float,
+    ) -> list[dict]:
+        """Generate moment label annotations (top and bottom)."""
+        annotations = []
+        moment_col_ranges: list[tuple[str, int, int]] = []
+        for col_idx, label in enumerate(layout.moment_labels):
+            if moment_col_ranges and moment_col_ranges[-1][0] == label:
+                moment_col_ranges[-1] = (label, moment_col_ranges[-1][1], col_idx)
+            else:
+                moment_col_ranges.append((label, col_idx, col_idx))
+
+        for label, col_start, col_end in moment_col_ranges:
+            cx = (col_x[col_start] + col_x[col_end]) / 2
+            for y_pos in (label_y_top, label_y_bottom):
+                annotations.append(dict(
+                    x=cx, y=y_pos,
+                    text=label,
+                    showarrow=False,
+                    font=dict(size=9, family="monospace", color="#555555"),
+                ))
+        return annotations
+
+    @classmethod
+    def _footer_annotations(
+        cls, layout: CircuitLayout, left_wire: float, label_y_bottom: float,
+    ) -> list[dict]:
+        """Generate footer annotations for global phase, result types, params."""
+        annotations = []
+        footer_lines: list[str] = []
+        if layout.global_phase:
+            footer_lines.append(f"Global phase: {layout.global_phase}")
+        if layout.additional_result_types:
+            footer_lines.append(
+                f"Additional result types: {', '.join(layout.additional_result_types)}"
+            )
+        if layout.unassigned_parameters:
+            footer_lines.append(
+                f"Unassigned parameters: {', '.join(layout.unassigned_parameters)}"
+            )
+
+        footer_y = label_y_bottom - cls.ROW_HEIGHT * 0.7
+        for i, line in enumerate(footer_lines):
+            annotations.append(dict(
+                x=left_wire, y=footer_y - i * cls.ROW_HEIGHT * 0.5,
+                text=line,
+                showarrow=False,
+                font=dict(size=9, family="monospace", color="#333333"),
+                xanchor="left",
+                yanchor="top",
+            ))
+        return annotations
+
+    # ── Shared geometry helpers ────────────────────────────────────────
+
+    @classmethod
+    def _gate_box_width(cls, label: str) -> float:
+        """Return the width of a gate box for *label*."""
+        char_width = cls.GATE_FONT_SIZE * 0.012
+        text_width = len(label) * char_width
+        return max(cls.GATE_BOX_MIN_WIDTH, text_width + cls.GATE_BOX_PADDING)
+
+    @classmethod
+    def _compute_column_x(cls, layout: CircuitLayout) -> tuple[list[float], list[float]]:
+        """Compute column centers and widths (same algorithm as Matplotlib)."""
+        n_cols = max(layout.num_moments, 1)
+        widths = [cls.COL_WIDTH] * n_cols
+        for elem in layout.elements:
+            if isinstance(elem, GateBox):
+                widths[elem.col] = max(
+                    widths[elem.col], cls._gate_box_width(elem.label) + cls.COL_GAP
+                )
+        centers: list[float] = []
+        cursor = 0.0
+        for w in widths:
+            centers.append(cursor + w / 2)
+            cursor += w
+        return centers, widths

--- a/test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py
@@ -1,0 +1,980 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests for PlotlyCircuitDiagram.
+
+Each test mirrors a corresponding test in test_matplotlib_circuit_diagram.py.
+Since graphical output cannot be compared as strings we verify:
+  - build_diagram() returns a plotly Figure
+  - _compute_layout() produces the correct layout primitives
+  - Hover text contains correct gate information
+  - Verbatim expand/collapse toggle data is correct
+"""
+
+import numpy as np
+import pytest
+
+from braket.circuits import Circuit, FreeParameter, Gate, Instruction, Noise, Observable, Operator
+from braket.circuits.compiler_directives import Barrier
+from braket.circuits.graphical_diagram_builders.graphical_circuit_diagram import (
+    GraphicalCircuitDiagram,
+)
+from braket.circuits.graphical_diagram_builders.graphical_diagram_utils import (
+    BarrierMarker,
+    CircuitLayout,
+    Connection,
+    ControlDot,
+    GateBox,
+    SwapMarker,
+)
+from braket.circuits.graphical_diagram_builders.plotly_circuit_diagram import (
+    PlotlyCircuitDiagram,
+    _CollapsibleRegion,
+)
+from braket.pulse import Frame, Port, PulseSequence
+
+plotly = pytest.importorskip("plotly")
+go = plotly.graph_objects
+
+
+def _layout(circ: Circuit) -> CircuitLayout:
+    return PlotlyCircuitDiagram._compute_layout(circ)
+
+
+def _fig(circ: Circuit) -> go.Figure:
+    return PlotlyCircuitDiagram.build_diagram(circ)
+
+
+def _elements_of_type(layout: CircuitLayout, cls):
+    return [e for e in layout.elements if isinstance(e, cls)]
+
+
+def _gate_labels(layout: CircuitLayout) -> list[str]:
+    return [e.label for e in layout.elements if isinstance(e, GateBox)]
+
+
+# ── Basic rendering ──────────────────────────────────────────────────
+
+
+def test_empty_circuit():
+    fig = _fig(Circuit())
+    assert isinstance(fig, go.Figure)
+
+
+def test_only_gphase_circuit():
+    fig = _fig(Circuit().gphase(0.1))
+    assert isinstance(fig, go.Figure)
+
+
+def test_one_gate_one_qubit():
+    layout = _layout(Circuit().h(0))
+    assert layout.qubit_labels == ["q0"]
+    assert layout.num_moments == 1
+    gates = _elements_of_type(layout, GateBox)
+    assert len(gates) == 1
+    assert gates[0] == GateBox(col=0, row=0, label="H")
+    assert isinstance(_fig(Circuit().h(0)), go.Figure)
+
+
+def test_one_gate_one_qubit_rotation():
+    layout = _layout(Circuit().rx(angle=3.14, target=0))
+    gates = _elements_of_type(layout, GateBox)
+    assert len(gates) == 1
+    assert gates[0].label == "Rx(3.14)"
+
+
+def test_one_gate_one_qubit_rotation_with_parameter():
+    theta = FreeParameter("theta")
+    layout = _layout(Circuit().rx(angle=theta, target=0))
+    gates = _elements_of_type(layout, GateBox)
+    assert len(gates) == 1
+    assert gates[0].label == "Rx(theta)"
+    assert layout.unassigned_parameters == ["theta"]
+
+
+@pytest.mark.parametrize("target", [0, 1])
+def test_one_gate_with_global_phase(target):
+    layout = _layout(Circuit().x(target=target).gphase(0.15))
+    assert layout.global_phase == 0.15
+    gates = _elements_of_type(layout, GateBox)
+    assert any(g.label == "X" for g in gates)
+
+
+def test_one_gate_with_zero_global_phase():
+    layout = _layout(Circuit().gphase(-0.15).x(target=0).gphase(0.15))
+    assert layout.global_phase == pytest.approx(0.0)
+
+
+def test_one_gate_one_qubit_rotation_with_unicode():
+    theta = FreeParameter("\u03b8")
+    layout = _layout(Circuit().rx(angle=theta, target=0))
+    gates = _elements_of_type(layout, GateBox)
+    assert gates[0].label == "Rx(θ)"
+    assert layout.unassigned_parameters == ["θ"]
+
+
+def test_one_gate_with_parametric_expression_global_phase():
+    theta = FreeParameter("\u03b8")
+    circ = Circuit().x(target=0).gphase(2 * theta).x(0).gphase(1)
+    layout = _layout(circ)
+    assert layout.global_phase is not None
+    assert layout.unassigned_parameters == ["θ"]
+
+
+def test_one_gate_one_qubit_rotation_with_parameter_assigned():
+    theta = FreeParameter("theta")
+    circ = Circuit().rx(angle=theta, target=0)
+    new_circ = circ.make_bound_circuit({"theta": np.pi})
+    layout = _layout(new_circ)
+    gates = _elements_of_type(layout, GateBox)
+    assert gates[0].label == "Rx(3.14)"
+    assert layout.unassigned_parameters == []
+
+
+# ── Multi-qubit gates ────────────────────────────────────────────────
+
+
+def test_qubit_width():
+    layout = _layout(Circuit().h(0).h(100))
+    assert layout.qubit_labels == ["q0", "q100"]
+    assert layout.num_qubits == 2
+    gates = _elements_of_type(layout, GateBox)
+    assert len(gates) == 2
+    assert all(g.label == "H" for g in gates)
+
+
+def test_different_size_boxes():
+    layout = _layout(Circuit().cnot(0, 1).rx(2, 0.3))
+    gates = _elements_of_type(layout, GateBox)
+    gate_labels = [g.label for g in gates]
+    assert "X" in gate_labels
+    assert "Rx(0.30)" in gate_labels
+    controls = _elements_of_type(layout, ControlDot)
+    assert len(controls) == 1
+    assert controls[0].filled is True
+
+
+def test_swap():
+    layout = _layout(Circuit().swap(0, 2).x(1))
+    swaps = _elements_of_type(layout, SwapMarker)
+    assert len(swaps) == 2
+    assert {s.row for s in swaps} == {0, 2}
+    gates = _elements_of_type(layout, GateBox)
+    assert any(g.label == "X" for g in gates)
+
+
+def test_gate_width():
+    class Foo(Gate):
+        def __init__(self):
+            super().__init__(qubit_count=1, ascii_symbols=["FOO"])
+
+        def to_ir(self, target):
+            return "foo"
+
+    circ = Circuit().h(0).h(1).add_instruction(Instruction(Foo(), 0))
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "FOO" in gate_labels_list
+    assert gate_labels_list.count("H") == 2
+
+
+def test_time_width():
+    circ = Circuit()
+    num_qubits = 8
+    for qubit in range(num_qubits - 1):
+        circ.cnot(qubit, qubit + 1)
+    layout = _layout(circ)
+    assert layout.num_qubits == 8
+    assert layout.num_moments == 7
+    gates = _elements_of_type(layout, GateBox)
+    assert all(g.label == "X" for g in gates)
+    controls = _elements_of_type(layout, ControlDot)
+    assert len(controls) == 7
+    connections = _elements_of_type(layout, Connection)
+    assert len(connections) == 7
+
+
+def test_connector_across_two_qubits():
+    layout = _layout(Circuit().cnot(4, 3).h(range(2, 6)))
+    connections = _elements_of_type(layout, Connection)
+    assert any(c.row_start == 1 and c.row_end == 2 for c in connections)
+
+
+def test_neg_control_qubits():
+    layout = _layout(Circuit().x(1, control=[0, 2], control_state=[0, 1]))
+    controls = _elements_of_type(layout, ControlDot)
+    filled_states = {c.row: c.filled for c in controls}
+    assert filled_states[0] is False
+    assert filled_states[2] is True
+
+
+def test_only_neg_control_qubits():
+    layout = _layout(Circuit().x(2, control=[0, 1], control_state=0))
+    controls = _elements_of_type(layout, ControlDot)
+    assert len(controls) == 2
+    assert all(c.filled is False for c in controls)
+
+
+def test_connector_across_three_qubits():
+    layout = _layout(Circuit().x(control=(3, 4), target=5).h(range(2, 6)))
+    controls = _elements_of_type(layout, ControlDot)
+    assert len(controls) == 2
+
+
+def test_overlapping_qubits():
+    circ = Circuit().cnot(0, 2).x(control=1, target=3).h(0)
+    layout = _layout(circ)
+    assert layout.num_moments >= 3
+    gates = _elements_of_type(layout, GateBox)
+    assert any(g.label == "H" for g in gates)
+
+
+def test_overlapping_qubits_angled_gates():
+    circ = Circuit().zz(0, 2, 0.15).x(control=1, target=3).h(0)
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "ZZ(0.15)" in gate_labels_list
+    assert "H" in gate_labels_list
+
+
+def test_connector_across_gt_two_qubits():
+    layout = _layout(Circuit().h(4).x(control=3, target=5).h(4).h(2))
+    connections = _elements_of_type(layout, Connection)
+    assert any(
+        conn.row_start <= 2 <= conn.row_end for conn in connections
+    )
+
+
+def test_connector_across_non_used_qubits():
+    layout = _layout(Circuit().h(4).cnot(3, 100).h(4).h(101))
+    assert layout.num_qubits == 4  # q3, q4, q100, q101
+
+
+# ── Verbatim blocks ──────────────────────────────────────────────────
+
+
+def test_verbatim_1q_no_preceding():
+    layout = _layout(Circuit().add_verbatim_box(Circuit().h(0)))
+    gate_labels_list = _gate_labels(layout)
+    assert "StartVerbatim" in gate_labels_list
+    assert "EndVerbatim" in gate_labels_list
+    assert "H" in gate_labels_list
+
+
+def test_verbatim_1q_preceding():
+    layout = _layout(Circuit().h(0).add_verbatim_box(Circuit().h(0)))
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("H") == 2
+    assert "StartVerbatim" in gate_labels_list
+    assert "EndVerbatim" in gate_labels_list
+
+
+def test_verbatim_1q_following():
+    layout = _layout(Circuit().add_verbatim_box(Circuit().h(0)).h(0))
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("H") == 2
+    assert "StartVerbatim" in gate_labels_list
+    assert "EndVerbatim" in gate_labels_list
+
+
+def test_verbatim_2q_no_preceding():
+    layout = _layout(Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1)))
+    gate_labels_list = _gate_labels(layout)
+    assert "StartVerbatim" in gate_labels_list
+    assert "EndVerbatim" in gate_labels_list
+    assert "H" in gate_labels_list
+    assert "X" in gate_labels_list
+
+
+def test_verbatim_2q_preceding():
+    layout = _layout(Circuit().h(0).add_verbatim_box(Circuit().h(0).cnot(0, 1)))
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("H") == 2
+
+
+def test_verbatim_2q_following():
+    layout = _layout(Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1)).h(0))
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("H") == 2
+
+
+def test_verbatim_3q_no_preceding():
+    layout = _layout(Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1).cnot(1, 2)))
+    gate_labels_list = _gate_labels(layout)
+    assert "StartVerbatim" in gate_labels_list
+    assert "EndVerbatim" in gate_labels_list
+
+
+def test_verbatim_3q_preceding():
+    layout = _layout(Circuit().h(0).add_verbatim_box(Circuit().h(0).cnot(0, 1).cnot(1, 2)))
+    assert isinstance(
+        _fig(Circuit().h(0).add_verbatim_box(Circuit().h(0).cnot(0, 1).cnot(1, 2))), go.Figure
+    )
+
+
+def test_verbatim_3q_following():
+    layout = _layout(Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1).cnot(1, 2)).h(0))
+    assert isinstance(
+        _fig(Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1).cnot(1, 2)).h(0)), go.Figure
+    )
+
+
+def test_verbatim_different_qubits():
+    circ = Circuit().h(1).add_verbatim_box(Circuit().h(0)).cnot(3, 4)
+    layout = _layout(circ)
+    assert layout.num_qubits == 4  # q0, q1, q3, q4
+
+
+def test_verbatim_qubset_qubits():
+    circ = Circuit().h(1).cnot(0, 1).cnot(1, 2).add_verbatim_box(Circuit().h(1)).cnot(2, 3)
+    layout = _layout(circ)
+    assert layout.num_qubits == 4
+
+
+# ── Verbatim expand/collapse ─────────────────────────────────────────
+
+
+def test_verbatim_collapse_regions_detected():
+    """Collapsed regions should be found for verbatim boxes."""
+    circ = Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1))
+    layout = _layout(circ)
+    regions = PlotlyCircuitDiagram._find_collapsible_regions(layout)
+    assert len(regions) == 1
+    assert regions[0].label == "Verbatim"
+    assert regions[0].start_col < regions[0].end_col
+
+
+def test_verbatim_collapse_region_inner_cols():
+    """Inner columns should exclude start/end directive columns."""
+    circ = Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1))
+    layout = _layout(circ)
+    regions = PlotlyCircuitDiagram._find_collapsible_regions(layout)
+    region = regions[0]
+    # Inner cols should be between start and end, not including them
+    assert all(region.start_col < c < region.end_col for c in region.inner_cols)
+
+
+def test_verbatim_collapse_toggle_buttons_present():
+    """Figure for circuit with verbatim box should have toggle buttons."""
+    circ = Circuit().add_verbatim_box(Circuit().h(0).cnot(0, 1))
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+    assert len(fig.layout.updatemenus) > 0
+    button_labels = [
+        b.label for menu in fig.layout.updatemenus for b in menu.buttons
+    ]
+    assert any("Expand" in label for label in button_labels)
+    assert any("Collapse" in label for label in button_labels)
+
+
+def test_no_toggle_buttons_without_verbatim():
+    """Circuits without verbatim boxes should have no toggle buttons."""
+    circ = Circuit().h(0).cnot(0, 1)
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+    assert len(fig.layout.updatemenus) == 0
+
+
+def test_verbatim_collapsed_region_rendering():
+    """Collapsed region should render with appropriate shapes."""
+    circ = Circuit().add_verbatim_box(Circuit().h(0))
+    layout = _layout(circ)
+    regions = PlotlyCircuitDiagram._find_collapsible_regions(layout)
+    col_x, _ = PlotlyCircuitDiagram._compute_column_x(layout)
+    shapes, annots = PlotlyCircuitDiagram._render_collapsed_region(regions[0], col_x)
+    assert len(shapes) >= 1
+    assert len(annots) >= 1
+    assert "Verbatim" in annots[0]["text"]
+
+
+# ── Ignore non-gate operators ────────────────────────────────────────
+
+
+def test_ignore_non_gates():
+    class Foo(Operator):
+        @property
+        def name(self) -> str:
+            return "foo"
+
+        def to_ir(self, target):
+            return "foo"
+
+    circ = Circuit().h(0).h(1).cnot(1, 2).add_instruction(Instruction(Foo(), 0))
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "foo" not in gate_labels_list
+    assert "H" in gate_labels_list
+
+
+# ── Result types ─────────────────────────────────────────────────────
+
+
+def test_single_qubit_result_types_target_none():
+    layout = _layout(Circuit().h(0).probability())
+    gate_labels_list = _gate_labels(layout)
+    assert "Probability" in gate_labels_list
+
+
+def test_result_types_target_none():
+    layout = _layout(Circuit().h(0).h(100).probability())
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("Probability") == 2
+
+
+def test_result_types_target_some():
+    circ = (
+        Circuit()
+        .h(0)
+        .h(1)
+        .h(100)
+        .expectation(observable=Observable.Y() @ Observable.Z(), target=[0, 100])
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert any("Expectation" in g for g in gate_labels_list)
+
+
+def test_additional_result_types():
+    circ = Circuit().h(0).h(1).h(100).state_vector().amplitude(["110", "001"])
+    layout = _layout(circ)
+    assert "StateVector" in layout.additional_result_types
+    assert "Amplitude(110,001)" in layout.additional_result_types
+
+
+def test_multiple_result_types():
+    circ = (
+        Circuit()
+        .cnot(0, 2)
+        .cnot(1, 3)
+        .h(0)
+        .variance(observable=Observable.Y(), target=0)
+        .expectation(observable=Observable.Y(), target=2)
+        .sample(observable=Observable.Y())
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert any("Variance" in g for g in gate_labels_list)
+    assert any("Expectation" in g for g in gate_labels_list)
+    assert any("Sample" in g for g in gate_labels_list)
+
+
+def test_multiple_result_types_with_state_vector_amplitude():
+    circ = (
+        Circuit()
+        .cnot(0, 2)
+        .cnot(1, 3)
+        .h(0)
+        .variance(observable=Observable.Y(), target=0)
+        .expectation(observable=Observable.Y(), target=3)
+        .expectation(
+            observable=Observable.Hermitian(np.array([[1.0, 0.0], [0.0, 1.0]])),
+            target=1,
+        )
+        .amplitude(["0001"])
+        .state_vector()
+    )
+    layout = _layout(circ)
+    assert "Amplitude(0001)" in layout.additional_result_types
+    assert "StateVector" in layout.additional_result_types
+
+
+def test_multiple_result_types_with_custom_hermitian_ascii_symbol():
+    herm_matrix = (Observable.Y() @ Observable.Z()).to_matrix()
+    circ = (
+        Circuit()
+        .cnot(0, 2)
+        .cnot(1, 3)
+        .h(0)
+        .variance(observable=Observable.Y(), target=0)
+        .expectation(observable=Observable.Y(), target=3)
+        .expectation(
+            observable=Observable.Hermitian(
+                matrix=herm_matrix,
+                display_name="MyHerm",
+            ),
+            target=[1, 2],
+        )
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert any("MyHerm" in g for g in gate_labels_list)
+
+
+# ── Noise ─────────────────────────────────────────────────────────────
+
+
+def test_noise_1qubit():
+    layout = _layout(Circuit().h(0).x(1).bit_flip(1, 0.1))
+    gate_labels_list = _gate_labels(layout)
+    assert "BF(0.1)" in gate_labels_list
+
+
+def test_noise_2qubit():
+    layout = _layout(Circuit().h(1).kraus((0, 2), [np.eye(4)]))
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("KR") == 2
+
+
+def test_noise_multi_probabilities():
+    layout = _layout(Circuit().h(0).x(1).pauli_channel(1, 0.1, 0.2, 0.3))
+    gate_labels_list = _gate_labels(layout)
+    assert "PC(0.1,0.2,0.3)" in gate_labels_list
+
+
+def test_noise_multi_probabilities_with_parameter():
+    a = FreeParameter("a")
+    c = FreeParameter("c")
+    d = FreeParameter("d")
+    layout = _layout(Circuit().h(0).x(1).pauli_channel(1, a, c, d))
+    gate_labels_list = _gate_labels(layout)
+    assert "PC(a,c,d)" in gate_labels_list
+    assert sorted(layout.unassigned_parameters) == ["a", "c", "d"]
+
+
+# ── Pulse gates ───────────────────────────────────────────────────────
+
+
+def test_pulse_gate_1_qubit_circuit():
+    circ = (
+        Circuit()
+        .h(0)
+        .pulse_gate(0, PulseSequence().set_phase(Frame("x", Port("px", 1e-9), 1e9, 0), 0))
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "PG" in gate_labels_list
+
+
+def test_pulse_gate_multi_qubit_circuit():
+    circ = (
+        Circuit()
+        .h(0)
+        .pulse_gate([0, 1], PulseSequence().set_phase(Frame("x", Port("px", 1e-9), 1e9, 0), 0))
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("PG") == 2
+
+
+# ── Nested targets ────────────────────────────────────────────────────
+
+
+def test_circuit_with_nested_target_list():
+    circ = (
+        Circuit()
+        .h(0)
+        .h(1)
+        .expectation(
+            observable=(2 * Observable.Y()) @ (-3 * Observable.I())
+            - 0.75 * Observable.Y() @ Observable.Z(),
+            target=[[0, 1], [0, 1]],
+        )
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert any("Hamiltonian" in g for g in gate_labels_list)
+
+
+def test_hamiltonian():
+    circ = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .rx(0, FreeParameter("theta"))
+        .adjoint_gradient(
+            4 * (2e-5 * Observable.Z() + 2 * (3 * Observable.X() @ (2 * Observable.Y()))),
+            [[0], [1, 2]],
+        )
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert any("AdjointGradient" in g for g in gate_labels_list)
+    assert layout.unassigned_parameters == ["theta"]
+
+
+# ── Power ─────────────────────────────────────────────────────────────
+
+
+def test_power():
+    class Foo(Gate):
+        def __init__(self):
+            super().__init__(qubit_count=1, ascii_symbols=["FOO"])
+
+    class CFoo(Gate):
+        def __init__(self):
+            super().__init__(qubit_count=2, ascii_symbols=["C", "FOO"])
+
+    class FooFoo(Gate):
+        def __init__(self):
+            super().__init__(qubit_count=2, ascii_symbols=["FOO", "FOO"])
+
+    circ = Circuit().h(0, power=1).h(1, power=0).h(2, power=-3.14)
+    circ.add_instruction(Instruction(Foo(), 0, power=-1))
+    circ.add_instruction(Instruction(CFoo(), (0, 1), power=2))
+    circ.add_instruction(Instruction(CFoo(), (1, 2), control=0, power=3))
+    circ.add_instruction(Instruction(FooFoo(), (1, 3), control=[0, 2], power=4))
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "H" in gate_labels_list
+    assert "H^0" in gate_labels_list
+    assert "H^-3.14" in gate_labels_list
+    assert "FOO^-1" in gate_labels_list
+    assert "FOO^2" in gate_labels_list
+    assert "FOO^3" in gate_labels_list
+    assert "FOO^4" in gate_labels_list
+
+
+def test_unbalanced_ascii_symbols():
+    class FooFoo(Gate):
+        def __init__(self):
+            super().__init__(qubit_count=2, ascii_symbols=["FOOO", "FOO"])
+
+    circ = Circuit().add_instruction(Instruction(FooFoo(), (1, 3), control=[0, 2], power=4))
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "FOOO^4" in gate_labels_list
+    assert "FOO^4" in gate_labels_list
+
+
+# ── Measure ───────────────────────────────────────────────────────────
+
+
+def test_measure():
+    circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).cnot(2, 3).measure([0, 2, 3])
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("M") == 3
+
+
+def test_measure_with_multiple_measures():
+    circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).cnot(2, 3).measure([0, 2]).measure(3).measure(1)
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("M") == 4
+
+
+def test_measure_multiple_instructions_after():
+    circ = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .cnot(1, 2)
+        .cnot(2, 3)
+        .measure(0)
+        .measure(1)
+        .h(3)
+        .cnot(3, 4)
+        .measure([2, 3])
+    )
+    layout = _layout(circ)
+    assert layout.num_qubits == 5
+    gate_labels_list = _gate_labels(layout)
+    assert gate_labels_list.count("M") == 4
+
+
+def test_measure_with_readout_noise():
+    circ = (
+        Circuit()
+        .h(0)
+        .cnot(0, 1)
+        .apply_readout_noise(Noise.BitFlip(probability=0.1), target_qubits=1)
+        .measure([0, 1])
+    )
+    layout = _layout(circ)
+    gate_labels_list = _gate_labels(layout)
+    assert "BF(0.1)" in gate_labels_list
+    assert gate_labels_list.count("M") == 2
+
+
+# ── Barrier ───────────────────────────────────────────────────────────
+
+
+def test_barrier_circuit_visualization_without_other_gates():
+    layout = _layout(Circuit().barrier(target=[0, 100]))
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert sorted(b.row for b in barriers) == [0, 1]
+
+
+def test_barrier_circuit_visualization_with_other_gates():
+    layout = _layout(Circuit().x(0).barrier(target=[0, 100]).h(3))
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert sorted(b.row for b in barriers) == [0, 2]
+    gate_labels_list = _gate_labels(layout)
+    assert "X" in gate_labels_list
+    assert "H" in gate_labels_list
+
+
+def test_barrier_single_qubit():
+    layout = _layout(Circuit().x(0).x(1).barrier(target=[0]).h(2))
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert len(barriers) == 1
+    assert barriers[0].row == 0
+
+
+def test_barrier_multiple_qubits_with_gates():
+    layout = _layout(Circuit().x(0).x(1).barrier(target=[0, 1]).h(0).h(2))
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert sorted(b.row for b in barriers) == [0, 1]
+    gate_labels_list = _gate_labels(layout)
+    assert "X" in gate_labels_list
+    assert "H" in gate_labels_list
+
+
+def test_barrier_global_marks_all_qubits():
+    circ = Circuit().x(0).x(1)
+    circ.add_instruction(Instruction(Barrier([]), []))
+    circ.h(2)
+    layout = _layout(circ)
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert sorted(b.row for b in barriers) == [0, 1, 2]
+
+
+def test_barrier_non_contiguous_target_marks_only_targeted_rows():
+    circ = Circuit().h(0).h(1).h(2).barrier([0, 2]).cnot(0, 1).cnot(1, 2)
+    layout = _layout(circ)
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert sorted(b.row for b in barriers) == [0, 2]
+
+
+def test_barrier_contiguous_target_marks_each_targeted_row():
+    circ = Circuit().h(0).h(1).h(2).barrier([0, 1]).cnot(0, 1)
+    layout = _layout(circ)
+    barriers = _elements_of_type(layout, BarrierMarker)
+    assert sorted(b.row for b in barriers) == [0, 1]
+
+
+def test_barrier_target_not_mutated_by_diagram():
+    circ = Circuit()
+    circ.h(0)
+    circ.h(1)
+    circ.h(2)
+    circ.barrier([0, 1])
+    circ.rx(2, 0.5)
+    circ.cnot(0, 1)
+
+    barrier_instr = circ.instructions[3]
+    original_target = list(barrier_instr.target)
+    assert len(original_target) == 2
+    assert 0 in original_target
+    assert 1 in original_target
+    assert 2 not in original_target
+
+    _fig(circ)
+
+    assert len(barrier_instr.target) == 2
+    assert 0 in barrier_instr.target
+    assert 1 in barrier_instr.target
+    assert 2 not in barrier_instr.target
+
+
+# ── Hover tooltip content ─────────────────────────────────────────────
+
+
+def test_hover_text_gate_name():
+    """Hover text should include the gate name."""
+    text = PlotlyCircuitDiagram._build_hover_text(
+        gate_name="H", qubit_label="q0", row=0, col=0
+    )
+    assert "<b>H</b>" in text
+
+
+def test_hover_text_qubit_label():
+    """Hover text should include the qubit label."""
+    text = PlotlyCircuitDiagram._build_hover_text(
+        gate_name="H", qubit_label="q5", row=5, col=0
+    )
+    assert "q5" in text
+
+
+def test_hover_text_parameters():
+    """Hover text should include gate parameters when present."""
+    text = PlotlyCircuitDiagram._build_hover_text(
+        gate_name="Rx(3.14)", qubit_label="q0", row=0, col=0
+    )
+    assert "Parameters: 3.14" in text
+    assert "<b>Rx</b>" in text
+
+
+def test_hover_text_device_metadata_placeholder():
+    """Hover text should include device metadata placeholder."""
+    text = PlotlyCircuitDiagram._build_hover_text(
+        gate_name="H", qubit_label="q0", row=0, col=0
+    )
+    assert "Device metadata" in text
+
+
+def test_hover_text_with_metadata():
+    """Hover text should include supplied device metadata."""
+    text = PlotlyCircuitDiagram._build_hover_text(
+        gate_name="H", qubit_label="q0", row=0, col=0,
+        metadata={"fidelity": 0.998, "error_rate": 0.002},
+    )
+    assert "fidelity" in text
+    assert "0.998" in text
+    assert "error_rate" in text
+
+
+def test_hover_text_moment_index():
+    """Hover text should include the moment/column index."""
+    text = PlotlyCircuitDiagram._build_hover_text(
+        gate_name="H", qubit_label="q0", row=0, col=3
+    )
+    assert "Moment: 3" in text
+
+
+def test_hover_traces_present_in_figure():
+    """Build diagram should include hover-enabled traces for gates."""
+    circ = Circuit().h(0).cnot(0, 1)
+    fig = _fig(circ)
+    # Find traces with hovertext
+    hover_traces = [
+        t for t in fig.data
+        if hasattr(t, "hovertext") and t.hovertext is not None
+    ]
+    assert len(hover_traces) > 0
+
+
+# ── Build diagram returns Figure ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "circ",
+    [
+        Circuit().h(0),
+        Circuit().cnot(0, 1),
+        Circuit().h(0).cnot(0, 1).cnot(1, 2),
+        Circuit().swap(0, 2).x(1),
+        Circuit().x(1, control=[0, 2], control_state=[0, 1]),
+        Circuit().h(0).h(1).h(100).state_vector(),
+        Circuit().h(0).cnot(0, 1).measure([0, 1]),
+    ],
+    ids=[
+        "single_h",
+        "cnot",
+        "chain",
+        "swap_and_x",
+        "neg_control",
+        "state_vector",
+        "measure",
+    ],
+)
+def test_build_diagram_returns_figure(circ):
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+
+
+def test_build_diagram_with_global_phase_footer():
+    circ = Circuit().h(0).gphase(0.25)
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+
+
+def test_build_diagram_with_unassigned_parameters_footer():
+    circ = Circuit().rx(angle=FreeParameter("theta"), target=0)
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+
+
+def test_build_diagram_with_barrier_and_following_gate():
+    circ = Circuit().x(0).barrier(target=[0, 1]).h(0)
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+
+
+def test_draw_elements_ignores_unknown_element():
+    class UnknownElement:
+        col = 0
+        row = 0
+
+    layout = CircuitLayout(
+        num_qubits=1,
+        num_moments=1,
+        qubit_labels=["q0"],
+        moment_labels=["0"],
+        elements=[GateBox(col=0, row=0, label="H"), UnknownElement()],
+        global_phase=None,
+        additional_result_types=[],
+        unassigned_parameters=[],
+    )
+    fig = PlotlyCircuitDiagram._render_layout(layout)
+    assert isinstance(fig, go.Figure)
+
+
+# ── Circuit.show() integration ────────────────────────────────────────
+
+
+def test_circuit_show_interactive():
+    """circuit.show('interactive') should return a plotly Figure."""
+    circ = Circuit().h(0).cnot(0, 1)
+    fig = circ.show("interactive")
+    assert isinstance(fig, go.Figure)
+
+
+def test_circuit_show_static():
+    """circuit.show() should still return a matplotlib Figure."""
+    from matplotlib.figure import Figure as MplFigure
+
+    circ = Circuit().h(0).cnot(0, 1)
+    fig = circ.show("static")
+    assert isinstance(fig, MplFigure)
+
+
+def test_circuit_show_default_is_static():
+    """circuit.show() with no args should default to matplotlib."""
+    from matplotlib.figure import Figure as MplFigure
+
+    circ = Circuit().h(0)
+    fig = circ.show()
+    assert isinstance(fig, MplFigure)
+
+
+def test_circuit_show_invalid_mode():
+    """circuit.show with an invalid mode should raise ValueError."""
+    with pytest.raises(ValueError, match="Unknown mode"):
+        Circuit().h(0).show("invalid")
+
+
+def test_circuit_show_with_explicit_class():
+    """circuit.show with circuit_diagram_class should use that class."""
+    circ = Circuit().h(0)
+    fig = circ.show(circuit_diagram_class=PlotlyCircuitDiagram)
+    assert isinstance(fig, go.Figure)
+
+
+# ── Large circuit ─────────────────────────────────────────────────────
+
+
+def test_large_circuit():
+    """A large circuit should render without error."""
+    circ = Circuit()
+    for i in range(20):
+        circ.h(i)
+    for i in range(19):
+        circ.cnot(i, i + 1)
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)
+
+
+# ── Deeply nested verbatim blocks ─────────────────────────────────────
+
+
+def test_circuit_with_multiple_verbatim_blocks():
+    """Multiple verbatim boxes should each get their own region."""
+    inner1 = Circuit().h(0)
+    inner2 = Circuit().x(1)
+    circ = Circuit().add_verbatim_box(inner1).add_verbatim_box(inner2)
+    layout = _layout(circ)
+    regions = PlotlyCircuitDiagram._find_collapsible_regions(layout)
+    assert len(regions) == 2
+    fig = _fig(circ)
+    assert isinstance(fig, go.Figure)


### PR DESCRIPTION
This PR implements the interactive circuit diagram renderer powered by Plotly, as a sibling to the existing Matplotlib renderer. Both are subclasses of GraphicalCircuitDiagram.

Closes #1250

### Proposed Changes
- Added `PlotlyCircuitDiagram` as a subclass of `GraphicalCircuitDiagram` in `src/braket/circuits/graphical_diagram_builders/plotly_circuit_diagram.py`.
- Features support for zoom/pan, hover tooltips displaying gate details/parameters/metadata, and a visibility toggle (via Plotly `updatemenus`) for expanding and collapsing verbatim blocks.
- Fixed duplicate collapsible region detection by sorting by column index, uniqueing directive markers, and implementing a stack-based matcher.
- Integrated interactive mode into `Circuit.show(mode="interactive")` in `src/braket/circuits/circuit.py` with backward compatibility for static matplotlib-based rendering.
- Added package configuration optional dependencies for interactive mode in `pyproject.toml`.
- Added a comprehensive test suite in `test/unit_tests/braket/circuits/test_plotly_circuit_diagram.py` ensuring full test coverage and no regressions.
