### PR TITLE
fix: task cancellation from non-main thread

### DIFF
--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -316,10 +316,9 @@ class AwsQuantumTask(QuantumTask):
         return self._arn
 
     def _cancel_future(self) -> None:
-        """Cancel the future if it exists. Else, create a cancelled future."""
-        if not hasattr(self, "_future"):
-            self._future = asyncio.Future()
-        self._future.cancel()
+        """Cancel the future if it exists."""
+        if hasattr(self, "_future"):
+            self._future.cancel()
 
     def cancel(self) -> None:
         """Cancel the quantum task. This cancels the future and the quantum task in Amazon

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -349,7 +349,23 @@ def test_cancel_without_fetching_result(quantum_task):
     quantum_task.cancel()
 
     assert quantum_task.result() is None
-    assert quantum_task._future.cancelled()
+    quantum_task._aws_session.cancel_quantum_task.assert_called_with(quantum_task.id)
+
+
+def test_cancel_without_event_loop(quantum_task):
+    errors = []
+
+    def run():
+        try:
+            quantum_task.cancel()
+        except BaseException as e:
+            errors.append(e)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join()
+
+    assert not errors
     quantum_task._aws_session.cancel_quantum_task.assert_called_with(quantum_task.id)
 
 


### PR DESCRIPTION
*Issue #, if available:*
fixes #1305

*Description of changes:*
When cancelling a quantum task, there is no reason to create a future just to cancel it; and in fact this doesn't work on non-main threads (or even on main threads in Python 3.14 - although this is not officially supported yet) where there is no event loop. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
