### PR TITLE
feat: Add `properties` to `Device` and `Emulator`

### DIFF
--- a/src/braket/devices/device.py
+++ b/src/braket/devices/device.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from braket.device_schema import DeviceActionType
+from braket.device_schema import DeviceActionType, DeviceCapabilities
 
 from braket.circuits.noise_model import NoiseModel
 from braket.circuits.translations import SUPPORTED_NOISE_PRAGMA_TO_NOISE
@@ -109,6 +109,11 @@ class Device(ABC):
             str: The status of this Device
         """
         return self._status
+
+    @property
+    def properties(self) -> DeviceCapabilities:
+        """DeviceCapabilities: Return the device properties."""
+        raise NotImplementedError("Device properties are not implemented for this device.")
 
     def _validate_device_noise_model_support(self, noise_model: NoiseModel) -> None:
         supported_noises = {

--- a/src/braket/emulation/emulator.py
+++ b/src/braket/emulation/emulator.py
@@ -17,6 +17,8 @@ import warnings
 from collections.abc import Iterable
 from typing import Any
 
+from braket.device_schema import DeviceCapabilities
+
 from braket.circuits.noise_model import NoiseModel
 from braket.devices import Device
 from braket.emulation.pass_manager import PassManager
@@ -42,6 +44,8 @@ class Emulator(Device):
             Defaults to None.
         passes (Iterable[ValidationPass] | None): A list of validation passes to apply to the
             emulated circuits. Defaults to None.
+        device_capabilities (DeviceCapabilities | None): The capabilities of the device being
+            emulated. Defaults to None.
     """
 
     def __init__(
@@ -49,12 +53,15 @@ class Emulator(Device):
         backend: Device,
         noise_model: NoiseModel | None = None,
         passes: Iterable[ValidationPass] | None = None,
+        *,
+        device_capabilities: DeviceCapabilities | None = None,
         **kwargs,
     ):
         Device.__init__(self, name=kwargs.get("name", "DeviceEmulator"), status="AVAILABLE")
         self._pass_manager = PassManager(passes)
         self._noise_model = noise_model
         self._backend = backend
+        self._device_capabilities = device_capabilities
 
     def run(
         self,
@@ -114,6 +121,11 @@ class Emulator(Device):
             NoiseModel: This emulator's noise model.
         """
         return self._noise_model
+
+    @property
+    def properties(self) -> DeviceCapabilities:
+        """DeviceCapabilities: The capabilities of the emulated device."""
+        return self._device_capabilities or super().properties
 
     def transform(
         self,

--- a/src/braket/emulation/local_emulator.py
+++ b/src/braket/emulation/local_emulator.py
@@ -75,6 +75,7 @@ class LocalEmulator(Emulator):
             device_em_properties = DeviceEmulatorProperties.from_device_properties(
                 device_properties
             )
+            kwargs["device_capabilities"] = device_properties
         else:
             raise TypeError(
                 f"device_properties must be an instance of either DeviceCapabilities or "

--- a/test/unit_tests/braket/emulation/test_emulator.py
+++ b/test/unit_tests/braket/emulation/test_emulator.py
@@ -121,3 +121,10 @@ def test_backend_noise_model_warning(local_dm_simulator):
         emulator = Emulator(local_dm_simulator)
         circuit = Circuit().h(0)
         emulator.run(circuit, shots=1)
+
+
+def test_emulator_properties(local_dm_simulator):
+    device_capabilities = local_dm_simulator.properties
+    emulator = Emulator(local_dm_simulator, device_capabilities=device_capabilities)
+
+    assert emulator.properties is device_capabilities

--- a/test/unit_tests/braket/emulation/test_local_emulator.py
+++ b/test/unit_tests/braket/emulation/test_local_emulator.py
@@ -46,6 +46,7 @@ def test_from_device_properties(reduced_standardized_json):
     device_properties = IqmDeviceCapabilities.parse_raw(reduced_standardized_json)
     emulator = LocalEmulator.from_device_properties(device_properties)
     assert isinstance(emulator, LocalEmulator)
+    assert emulator.properties is device_properties
 
 
 def test_from_device_properties_non_fully_connected(reduced_standardized_json_2):


### PR DESCRIPTION
Both of the main implementations of `Device`, namely `AwsDevice` and `LocalSimulator`, have a `properties` property that doesn't, but should exist in the parent class. This change codifies this property, and gives emulators the capabilities of the emulated device.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
