### PR TITLE
fix: parse function calls in FreeParameterExpression

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import ast
 import operator
+from collections.abc import Callable
 from functools import reduce
 from numbers import Number
 from typing import Any, ClassVar
@@ -97,6 +98,21 @@ class FreeParameterExpression:
         else:
             raise NotImplementedError
 
+    _STRING_FUNCTIONS: ClassVar[dict[str, Callable[..., Any]]] = {
+        "sin": sympy.sin,
+        "cos": sympy.cos,
+        "tan": sympy.tan,
+        "arcsin": sympy.asin,
+        "arccos": sympy.acos,
+        "arctan": sympy.atan,
+        "exp": sympy.exp,
+        "log": sympy.log,
+        "sqrt": sympy.sqrt,
+        "mod": sympy.Mod,
+        "ceiling": sympy.ceiling,
+        "floor": sympy.floor,
+    }
+
     @property
     def expression(self) -> Number | sympy.Expr:
         """Gets the expression.
@@ -144,6 +160,15 @@ class FreeParameterExpression:
             return FreeParameterExpression(node.value)
         if isinstance(node, ast.Name):
             return FreeParameterExpression(sympy.Symbol(node.id))
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name) or node.keywords:
+                raise ValueError(f"Unsupported string detected: {node}")
+            function = self._STRING_FUNCTIONS.get(node.func.id)
+            if function is None:
+                raise ValueError(f"Unsupported string function: {node.func.id}")
+            return FreeParameterExpression(
+                function(*(self._eval_operation(arg).expression for arg in node.args))
+            )
         if isinstance(node, ast.BinOp):
             if type(node.op) not in self._operations:
                 raise ValueError(f"Unsupported binary operation: {type(node.op)}")

--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -18,31 +18,33 @@ import operator
 from collections.abc import Callable
 from functools import reduce
 from numbers import Number
-from typing import Any, ClassVar
+from typing import Any
 
 import sympy
 from oqpy.base import OQPyExpression
 from oqpy.classical_types import FloatVar
 from sympy.printing.str import StrPrinter
 
+_STRING_FUNCTIONS: dict[str, Callable[..., Any]] = {
+    "sin": sympy.sin,
+    "cos": sympy.cos,
+    "tan": sympy.tan,
+    "arcsin": sympy.asin,
+    "arccos": sympy.acos,
+    "arctan": sympy.atan,
+    "exp": sympy.exp,
+    "log": sympy.log,
+    "sqrt": sympy.sqrt,
+    "mod": sympy.Mod,
+    "ceiling": sympy.ceiling,
+    "floor": sympy.floor,
+}
+_FN_MAP = {function: name for name, function in _STRING_FUNCTIONS.items()}
+
 
 class _OpenQASMExpressionPrinter(StrPrinter):
-    _FN_MAP: ClassVar[dict[type, str]] = {
-        sympy.sin: "sin",
-        sympy.cos: "cos",
-        sympy.tan: "tan",
-        sympy.asin: "arcsin",
-        sympy.acos: "arccos",
-        sympy.atan: "arctan",
-        sympy.exp: "exp",
-        sympy.log: "log",
-        sympy.Mod: "mod",
-        sympy.ceiling: "ceiling",
-        sympy.floor: "floor",
-    }
-
     def _print_Function(self, expr: sympy.Function) -> str:
-        function_name = self._FN_MAP.get(expr.func)
+        function_name = _FN_MAP.get(expr.func)
         if function_name is None:
             raise ValueError(f"No OpenQASM 3 equivalent for {expr.func.__name__}")
         args = ", ".join(self._print(arg) for arg in expr.args)
@@ -98,21 +100,6 @@ class FreeParameterExpression:
         else:
             raise NotImplementedError
 
-    _STRING_FUNCTIONS: ClassVar[dict[str, Callable[..., Any]]] = {
-        "sin": sympy.sin,
-        "cos": sympy.cos,
-        "tan": sympy.tan,
-        "arcsin": sympy.asin,
-        "arccos": sympy.acos,
-        "arctan": sympy.atan,
-        "exp": sympy.exp,
-        "log": sympy.log,
-        "sqrt": sympy.sqrt,
-        "mod": sympy.Mod,
-        "ceiling": sympy.ceiling,
-        "floor": sympy.floor,
-    }
-
     @property
     def expression(self) -> Number | sympy.Expr:
         """Gets the expression.
@@ -161,11 +148,22 @@ class FreeParameterExpression:
         if isinstance(node, ast.Name):
             return FreeParameterExpression(sympy.Symbol(node.id))
         if isinstance(node, ast.Call):
-            if not isinstance(node.func, ast.Name) or node.keywords:
-                raise ValueError(f"Unsupported string detected: {node}")
-            function = self._STRING_FUNCTIONS.get(node.func.id)
+            if not isinstance(node.func, ast.Name):
+                raise ValueError(
+                    "Unsupported function call target "
+                    f"'{type(node.func).__name__}'; expected a direct function name"
+                )
+            if node.keywords:
+                raise ValueError(
+                    f"Keyword arguments are not supported for string function '{node.func.id}'"
+                )
+            function = _STRING_FUNCTIONS.get(node.func.id)
             if function is None:
-                raise ValueError(f"Unsupported string function: {node.func.id}")
+                supported_functions = ", ".join(_STRING_FUNCTIONS)
+                raise ValueError(
+                    f"Unsupported string function '{node.func.id}'; "
+                    f"supported functions are: {supported_functions}"
+                )
             return FreeParameterExpression(
                 function(*(self._eval_operation(arg).expression for arg in node.args))
             )

--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -148,25 +148,7 @@ class FreeParameterExpression:
         if isinstance(node, ast.Name):
             return FreeParameterExpression(sympy.Symbol(node.id))
         if isinstance(node, ast.Call):
-            if not isinstance(node.func, ast.Name):
-                raise ValueError(
-                    "Unsupported function call target "
-                    f"'{type(node.func).__name__}'; expected a direct function name"
-                )
-            if node.keywords:
-                raise ValueError(
-                    f"Keyword arguments are not supported for string function '{node.func.id}'"
-                )
-            function = _STRING_FUNCTIONS.get(node.func.id)
-            if function is None:
-                supported_functions = ", ".join(_STRING_FUNCTIONS)
-                raise ValueError(
-                    f"Unsupported string function '{node.func.id}'; "
-                    f"supported functions are: {supported_functions}"
-                )
-            return FreeParameterExpression(
-                function(*(self._eval_operation(arg).expression for arg in node.args))
-            )
+            return self._eval_function_call(node)
         if isinstance(node, ast.BinOp):
             if type(node.op) not in self._operations:
                 raise ValueError(f"Unsupported binary operation: {type(node.op)}")
@@ -178,6 +160,27 @@ class FreeParameterExpression:
                 raise ValueError(f"Unsupported unary operation: {type(node.op)}", type(node.op))
             return self._eval_operation(node.operand)._operations[type(node.op)]()
         raise ValueError(f"Unsupported string detected: {node}")
+
+    def _eval_function_call(self, node: ast.Call) -> FreeParameterExpression:
+        if not isinstance(node.func, ast.Name):
+            raise TypeError(
+                "Unsupported function call target "
+                f"'{type(node.func).__name__}'; expected a direct function name"
+            )
+        if node.keywords:
+            raise ValueError(
+                f"Keyword arguments are not supported for string function '{node.func.id}'"
+            )
+        function = _STRING_FUNCTIONS.get(node.func.id)
+        if function is None:
+            supported_functions = ", ".join(_STRING_FUNCTIONS)
+            raise ValueError(
+                f"Unsupported string function '{node.func.id}'; "
+                f"supported functions are: {supported_functions}"
+            )
+        return FreeParameterExpression(
+            function(*(self._eval_operation(arg).expression for arg in node.args))
+        )
 
     def __add__(self, other: FreeParameterExpression):
         if issubclass(type(other), FreeParameterExpression):

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -54,6 +54,26 @@ def test_equality_str():
 
 
 @pytest.mark.parametrize(
+    ("string_expression", "expected_expression"),
+    [
+        ("exp(alpha)", sympy.exp(sympy.Symbol("alpha"))),
+        ("log(alpha)", sympy.log(sympy.Symbol("alpha"))),
+        ("sqrt(alpha)", sympy.sqrt(sympy.Symbol("alpha"))),
+        ("mod(alpha, 2)", sympy.Mod(sympy.Symbol("alpha"), 2)),
+    ],
+)
+def test_string_function_expression_matches_sympy(string_expression, expected_expression):
+    assert FreeParameterExpression(string_expression) == FreeParameterExpression(
+        expected_expression
+    )
+
+
+def test_unsupported_string_function_raises_value_error():
+    with pytest.raises(ValueError, match="Unsupported string function: custom"):
+        FreeParameterExpression("custom(alpha)")
+
+
+@pytest.mark.parametrize(
     ("function", "extra_args", "expected"),
     [
         (sympy.sin, (), "sin(alpha)"),

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -84,9 +84,9 @@ def test_string_function_keyword_arguments_raise_value_error():
         FreeParameterExpression("sin(alpha, beta=1)")
 
 
-def test_unsupported_string_callable_raises_value_error():
+def test_unsupported_string_callable_raises_type_error():
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Unsupported function call target 'Attribute'; expected a direct function name",
     ):
         FreeParameterExpression("math.sin(alpha)")

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -73,6 +73,12 @@ def test_unsupported_string_function_raises_value_error():
         FreeParameterExpression("custom(alpha)")
 
 
+@pytest.mark.parametrize("string_expression", ["sin(alpha, beta=1)", "math.sin(alpha)"])
+def test_unsupported_string_call_raises_value_error(string_expression):
+    with pytest.raises(ValueError, match="Unsupported string detected"):
+        FreeParameterExpression(string_expression)
+
+
 @pytest.mark.parametrize(
     ("function", "extra_args", "expected"),
     [

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -69,14 +69,27 @@ def test_string_function_expression_matches_sympy(string_expression, expected_ex
 
 
 def test_unsupported_string_function_raises_value_error():
-    with pytest.raises(ValueError, match="Unsupported string function: custom"):
+    with pytest.raises(
+        ValueError,
+        match="Unsupported string function 'custom'; supported functions are:",
+    ):
         FreeParameterExpression("custom(alpha)")
 
 
-@pytest.mark.parametrize("string_expression", ["sin(alpha, beta=1)", "math.sin(alpha)"])
-def test_unsupported_string_call_raises_value_error(string_expression):
-    with pytest.raises(ValueError, match="Unsupported string detected"):
-        FreeParameterExpression(string_expression)
+def test_string_function_keyword_arguments_raise_value_error():
+    with pytest.raises(
+        ValueError,
+        match="Keyword arguments are not supported for string function 'sin'",
+    ):
+        FreeParameterExpression("sin(alpha, beta=1)")
+
+
+def test_unsupported_string_callable_raises_value_error():
+    with pytest.raises(
+        ValueError,
+        match="Unsupported function call target 'Attribute'; expected a direct function name",
+    ):
+        FreeParameterExpression("math.sin(alpha)")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fix parsing of OpenQASM-compatible function calls in `FreeParameterExpression`.

## Changes

- Map the existing OpenQASM math helper names to their SymPy functions.
- Recursively evaluate positional call arguments while rejecting unknown functions and keyword calls.
- Add regression coverage for `exp`, `log`, `sqrt`, `mod`, and the unsupported-function boundary.

## Testing/Verification

- `PYTHONPATH=src .venv/Scripts/python.exe -m pytest -o addopts='' test/unit_tests/braket/parametric/test_free_parameter_expression.py -q` (58 passed, 4 xfailed)
- `ruff format --check` on modified files (pass)
- `ruff check src/braket/parametric/free_parameter_expression.py` (pass)
- `python -m compileall -q` on modified files (pass)
- `git diff --check` (pass)
- The full unit suite was attempted but collection is blocked in this isolated environment by missing generated/runtime packages (`braket.ir`, `braket.task_result`) after the editable test install hit Windows long-path limits; no full-suite failure is attributed to this patch.

Related issue: #1322
