### PR TITLE
fix: remove redundant sign

### DIFF
--- a/src/braket/quantum_information/pauli_sum.py
+++ b/src/braket/quantum_information/pauli_sum.py
@@ -182,7 +182,7 @@ class PauliSum:
         factors = ["I"] * pauli_string.qubit_count
         for qubit in range(pauli_string.qubit_count):
             factors[qubit] = "IXYZ"[pauli_string[qubit]]
-        return coefficient * pauli_string.phase, f"+{''.join(factors)}"
+        return coefficient * pauli_string.phase, "".join(factors)
 
     @staticmethod
     def _coerce(other: PauliSum | PauliString | str) -> PauliSum:
@@ -221,7 +221,7 @@ class PauliSum:
             factors = PauliSum._factors_from_tensor_product(unscaled)
         else:
             raise TypeError(f"Unsupported observable type {type(observable).__name__}")
-        return coefficient, f"+{''.join(factors)}"
+        return coefficient, "".join(factors)
 
     @staticmethod
     def _factors_from_standard(observable: StandardObservable) -> list[str]:

--- a/test/unit_tests/braket/quantum_information/test_pauli_string_sum.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string_sum.py
@@ -20,35 +20,35 @@ from braket.quantum_information import PauliString, PauliStringSum, PauliSum
 def test_initializes_from_weighted_list_and_combines_terms():
     pauli_sum = PauliStringSum.from_list([(1.5, "XZ"), (2.0, "-XZ"), (3.0, "YY")])
 
-    assert pauli_sum.to_list() == [(-0.5, "+XZ"), (3.0, "+YY")]
+    assert pauli_sum.to_list() == [(-0.5, "XZ"), (3.0, "YY")]
 
 
 def test_addition_subtraction_and_scalar_multiplication():
     first = PauliStringSum([(1.0, "XI")])
     second = PauliStringSum([(2.0, "IZ")])
 
-    assert (first + second - PauliString("XI")).to_list() == [(2.0, "+IZ")]
-    assert (0.5 * second).to_list() == [(1.0, "+IZ")]
-    assert (-second).to_list() == [(-2.0, "+IZ")]
+    assert (first + second - PauliString("XI")).to_list() == [(2.0, "IZ")]
+    assert (0.5 * second).to_list() == [(1.0, "IZ")]
+    assert (-second).to_list() == [(-2.0, "IZ")]
 
 
 def test_multiplication_by_pauli_string():
     pauli_sum = PauliStringSum([(2.0, "XY"), (3.0, "ZZ")])
 
-    assert (pauli_sum * PauliString("YZ")).to_list() == [(-2.0, "+ZX"), (-3.0, "+XI")]
+    assert (pauli_sum * PauliString("YZ")).to_list() == [(-2.0, "ZX"), (-3.0, "XI")]
 
 
 def test_multiplication_by_pauli_string_pads_mixed_width_terms():
     pauli_sum = PauliStringSum([(1.0, "X"), (2.0, "IZ")])
 
-    assert (pauli_sum * PauliString("ZZ")).to_list() == [(-1.0, "+YZ"), (2.0, "+ZI")]
+    assert (pauli_sum * PauliString("ZZ")).to_list() == [(-1.0, "YZ"), (2.0, "ZI")]
 
 
 def test_left_multiplication_by_pauli_string_preserves_order():
     pauli_sum = PauliStringSum([(2.0, "X")])
 
-    assert (pauli_sum * PauliString("Z")).to_list() == [(-2.0, "+Y")]
-    assert (PauliString("Z") * pauli_sum).to_list() == [(2.0, "+Y")]
+    assert (pauli_sum * PauliString("Z")).to_list() == [(-2.0, "Y")]
+    assert (PauliString("Z") * pauli_sum).to_list() == [(2.0, "Y")]
 
 
 def test_indexing_and_membership():
@@ -78,15 +78,15 @@ def test_equality_is_independent_of_term_insertion_order():
 def test_reverse_subtraction():
     pauli_sum = PauliStringSum([(2.0, "XI")])
 
-    assert (PauliString("IZ") - pauli_sum).to_list() == [(1, "+IZ"), (-2.0, "+XI")]
+    assert (PauliString("IZ") - pauli_sum).to_list() == [(1, "IZ"), (-2.0, "XI")]
 
 
 def test_from_sum_with_targeted_observables():
     observable_sum = 2.0 * (X(0) @ Y(2)) - 3.0 * Z(1)
 
     assert PauliStringSum.from_sum(observable_sum).to_list() == [
-        (2.0, "+XIY"),
-        (-3.0, "+IZ"),
+        (2.0, "XIY"),
+        (-3.0, "IZ"),
     ]
 
 
@@ -102,7 +102,7 @@ def test_from_sum_with_targetless_tensor_product():
 
     observable = Sum([1.0 * (X() @ Y())])
 
-    assert PauliStringSum.from_sum(observable).to_list() == [(1.0, "+XY")]
+    assert PauliStringSum.from_sum(observable).to_list() == [(1.0, "XY")]
 
 
 def test_commutation_checks():
@@ -146,13 +146,13 @@ def test_empty_sum_has_zero_qubit_count_and_repr():
 def test_zero_coefficient_terms_cancel_to_empty_sum():
     pauli_sum = PauliStringSum([(1.0, "X"), (-1.0, "X"), (2.0, "Y")])
 
-    assert pauli_sum.to_list() == [(2.0, "+Y")]
+    assert pauli_sum.to_list() == [(2.0, "Y")]
 
 
 def test_zero_coefficient_term_is_ignored():
     pauli_sum = PauliStringSum([(0.0, "X"), (2.0, "Y")])
 
-    assert pauli_sum.to_list() == [(2.0, "+Y")]
+    assert pauli_sum.to_list() == [(2.0, "Y")]
 
 
 def test_radd_and_non_matching_eq_type():
@@ -172,7 +172,7 @@ def test_from_sum_uses_default_target_for_standard_observables_and_rejects_unmap
     from braket.circuits.observables import Sum
 
     from_sum_with_no_targets = PauliStringSum.from_sum(Sum([1.0 * X()]))
-    assert from_sum_with_no_targets.to_list() == [(1.0, "+X")]
+    assert from_sum_with_no_targets.to_list() == [(1.0, "X")]
 
     class NonStandardObservable:
         coefficient = 1.0


### PR DESCRIPTION
*Issue #, if available:*

Closes #1309. Notably, the phase is treated in the PauliSum, so can be safely discarded when cast to a string in PauliSum.to_list(). 

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
